### PR TITLE
Wire pattern detection into recall/reranker (Item D Phase 5)

### DIFF
--- a/scripts/core/recall_learnings.py
+++ b/scripts/core/recall_learnings.py
@@ -108,7 +108,7 @@ async def enrich_with_pattern_strength(
             rows = await conn.fetch(
                 """
                 SELECT pm.memory_id,
-                       MAX(dp.confidence * (1.0 - pm.distance))
+                       MAX(dp.confidence * GREATEST(1.0 - COALESCE(pm.distance, 0), 0))
                            AS pattern_strength,
                        ARRAY_AGG(DISTINCT unnested_tag)
                            AS pattern_tags
@@ -139,9 +139,12 @@ async def enrich_with_pattern_strength(
                 result["pattern_strength"] = lookup[rid]["pattern_strength"]
                 result["pattern_tags"] = lookup[rid]["pattern_tags"]
 
-    except Exception:
-        # Graceful degradation: tables may not exist yet
-        logger.debug("Pattern enrichment unavailable", exc_info=True)
+    except (ImportError, OSError, ConnectionError) as e:
+        # Expected: tables don't exist, DB unreachable, pool import fails
+        logger.debug("Pattern enrichment unavailable: %s", e)
+    except Exception as e:
+        # Unexpected: surface for debugging but don't break recall
+        logger.warning("Pattern enrichment error: %s", e, exc_info=True)
 
     return results
 

--- a/scripts/core/reranker.py
+++ b/scripts/core/reranker.py
@@ -205,8 +205,11 @@ def pattern_score(result: dict, ctx: RecallContext) -> float:
     if not query_tags or not pattern_tags:
         return 0.0
 
-    overlap = len(set(query_tags) & set(pattern_tags))
-    ratio = overlap / len(query_tags)
+    unique_query = set(query_tags)
+    if not unique_query:
+        return 0.0
+    overlap = len(unique_query & set(pattern_tags))
+    ratio = overlap / len(unique_query)
     return strength * min(1.0, ratio)
 
 

--- a/tests/test_reranker.py
+++ b/tests/test_reranker.py
@@ -516,19 +516,21 @@ class TestPatternScore:
 
 class TestRerankWithPattern:
 
-    def test_pattern_signal_in_rerank_details(self):
-        results = [
-            _make_result(similarity=0.5),
-            _make_result(similarity=0.4),
-        ]
-        results[1]["pattern_strength"] = 0.9
-        results[1]["pattern_tags"] = ["test"]
+    def test_pattern_signal_boosts_ranking(self):
+        r1 = _make_result(similarity=0.5)
+        r1["id"] = "id1"
+        r2 = _make_result(similarity=0.4)
+        r2["id"] = "id2"
+        r2["pattern_strength"] = 0.9
+        r2["pattern_tags"] = ["test"]
         ctx = RecallContext(
             tags_hint=["test"],
             retrieval_mode="hybrid_rrf",
         )
-        ranked = rerank(results, ctx, k=2)
-        assert "pattern" in ranked[0]["rerank_details"]
+        ranked = rerank([r1, r2], ctx, k=2)
+        # Pattern-boosted result should rank higher
+        assert ranked[0]["id"] == "id2"
+        assert ranked[0]["rerank_details"]["pattern"] > 0
 
     def test_pattern_weight_in_config(self):
         config = RerankerConfig()


### PR DESCRIPTION
## Summary

- Adds `pattern_score()` signal to the reranker — query-aware boost that only activates when query tags overlap pattern tags (Gemini review mitigation: prevents generic clustered learnings from drowning novel ones)
- Adds `enrich_with_pattern_strength()` to recall pipeline — batch LEFT JOIN on `pattern_members` + `detected_patterns` to inject `pattern_strength` and `pattern_tags` into results before reranking
- Graceful degradation: if `detected_patterns` table doesn't exist yet, enrichment silently skips
- Only runs on PostgreSQL backend with reranking enabled

This completes all 6 phases of Item D (Cross-session Pattern Detection).

## Live validation

Ran against production database (2,221 learnings, 760 sessions):
- **143 patterns** detected in 6.2 seconds (142 cross-project, 1 anti-pattern)
- **2,480 pattern memberships** written
- Pattern enrichment confirmed working: zombie daemon learning received `pattern: 0.89` boost when queried with matching tags
- Migration applied: `detected_patterns` + `pattern_members` tables live

## Test plan

- [x] 7 unit tests for `pattern_score()` (zero strength, zero overlap, partial, full, missing data)
- [x] 2 integration tests for rerank with pattern signal (details key present, config weight)
- [x] Full suite: 184/184 passing, zero regressions
- [x] Dry-run on real data: 143 patterns from 2,221 learnings
- [x] Full run: migration applied, patterns + members written
- [x] End-to-end recall: pattern enrichment appears in `rerank_details` with correct boost values