### PR TITLE
Fix daemon to pass project context through extraction paths

### DIFF
--- a/scripts/core/memory_daemon.py
+++ b/scripts/core/memory_daemon.py
@@ -74,8 +74,9 @@ def _normalize_project(path_str: str) -> str | None:
     parts = p.parts
     if ".worktrees" in parts:
         idx = parts.index(".worktrees")
-        return parts[idx - 1] if idx > 0 else p.name
-    return p.name
+        name = parts[idx - 1] if idx > 0 else p.name
+        return name or None
+    return p.name or None
 
 # Global config
 POLL_INTERVAL = 60  # seconds
@@ -511,7 +512,8 @@ Store each learning using store_learning.py with appropriate type and tags."""
 
         env = os.environ.copy()
         env["CLAUDE_MEMORY_EXTRACTION"] = "1"  # Prevent session-register from registering extraction sessions
-        env["CLAUDE_PROJECT_DIR"] = project_dir or ""
+        if project_dir:
+            env["CLAUDE_PROJECT_DIR"] = project_dir
 
         proc = subprocess.Popen(
             [


### PR DESCRIPTION
## Summary
- Set `CLAUDE_PROJECT_DIR` in subprocess env for LLM extraction so spawned Claude sessions have project context
- Pass `project=` kwarg to `store_learning_v2()` for workflow extraction
- Add `_normalize_project()` helper with worktree-aware path resolution (resolves worktree paths to parent project name)
- Bump `DAEMON_VERSION` to 0.7.1

## Problem
Neither extraction path passed project context, so all daemon-extracted learnings got `project = NULL`. This degraded the reranker's highest-weighted signal (`project_match`, weight 0.15).

## Test plan
- [x] All 184 existing tests pass
- [ ] Verify daemon-extracted learnings have non-NULL project values after deployment
- [ ] Verify worktree paths resolve to parent project name (e.g. `/foo/opc/.worktrees/feature-x` → `opc`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Version Update**
  * Updated to version 0.7.1

* **Improvements**
  * Enhanced project detection in multi-worktree setups
  * Improved project context handling in workflow learning

<!-- end of auto-generated comment: release notes by coderabbit.ai -->