### PR TITLE
Add confidence calibration for stored learnings (Item A)

### DIFF
--- a/scripts/core/confidence_calibrator.py
+++ b/scripts/core/confidence_calibrator.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python3
+"""Confidence calibration for stored learnings.
+
+Analyzes learning content to assign calibrated confidence scores based on
+specificity, actionability, evidence, and scope. Replaces the naive
+"always high" default with a heuristic-based assessment.
+
+Scoring dimensions (each 0.0-1.0):
+  - Specificity: Does the learning reference concrete files, functions, errors?
+  - Actionability: Does it describe what to do (not just what happened)?
+  - Evidence: Does it cite commits, test results, or verified behavior?
+  - Scope: Is it narrowly applicable (high) or vague/universal (low)?
+
+Final confidence = weighted average mapped to high/medium/low.
+
+Usage:
+    # Calibrate learnings from a specific session
+    uv run python scripts/core/confidence_calibrator.py --session-id abc123
+
+    # Backfill: recalibrate all learnings missing calibration
+    uv run python scripts/core/confidence_calibrator.py --backfill
+
+    # Dry-run: show what would change without writing
+    uv run python scripts/core/confidence_calibrator.py --backfill --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import re
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+logger = logging.getLogger(__name__)
+
+# Load env
+global_env = Path.home() / ".claude" / ".env"
+if global_env.exists():
+    load_dotenv(global_env)
+load_dotenv()
+
+project_dir = os.environ.get(
+    "CLAUDE_PROJECT_DIR", str(Path(__file__).parent.parent.parent)
+)
+sys.path.insert(0, project_dir)
+
+# ---------------------------------------------------------------------------
+# Scoring patterns
+# ---------------------------------------------------------------------------
+
+# Specificity indicators: concrete references in content
+_SPECIFICITY_PATTERNS = [
+    (r"\b[\w/]+\.\w{1,4}(?::\d+)?\b", 0.15),       # file paths (foo.py:42)
+    (r"\b(?:def|class|function|method)\s+\w+", 0.15), # function/class names
+    (r"\b[0-9a-f]{7,40}\b", 0.10),                    # git hashes
+    (r"`[^`]+`", 0.10),                                # inline code
+    (r"\b(?:error|exception|traceback|TypeError|ValueError|KeyError)\b", 0.10),
+    (r"\b(?:line \d+|column \d+)\b", 0.05),           # line references
+    (r"(?:https?://|localhost:\d+)", 0.05),            # URLs
+]
+
+# Actionability indicators: prescriptive language
+_ACTIONABILITY_PATTERNS = [
+    (r"\b(?:use|always|never|must|should|prefer|avoid|ensure)\b", 0.20),
+    (r"\b(?:instead of|rather than|don't|do not)\b", 0.15),
+    (r"\b(?:works? (?:by|because|when)|the (?:fix|solution|approach) is)\b", 0.15),
+    (r"\b(?:step \d|first|then|next|finally)\b", 0.10),
+    (r"\b(?:pattern|technique|approach|strategy|workflow)\b", 0.10),
+]
+
+# Evidence indicators: verified/tested claims
+_EVIDENCE_PATTERNS = [
+    (r"\b(?:commit|merged|PR|pull request)\s*[#:]?\s*\w+", 0.20),
+    (r"\b(?:tested|verified|confirmed|validated|proved)\b", 0.20),
+    (r"\b(?:tests? pass|build succeed|works correctly)\b", 0.15),
+    (r"\b\d+%|\b\d+/\d+\b", 0.10),                     # percentages/ratios
+    (r"\b(?:benchmark|measured|profiled|timed)\b", 0.10),
+]
+
+# Vagueness indicators (reduce scope score)
+_VAGUENESS_PATTERNS = [
+    (r"\b(?:sometimes|perhaps|possibly)\b", 0.12),
+    (r"\b(?:maybe|might)\b", 0.12),
+    (r"\b(?:could|may)\b", 0.08),
+    (r"\b(?:generally|usually|often|tends to)\b", 0.10),
+    (r"\b(?:seems? to|appears? to|looks? like)\b", 0.10),
+    (r"\b(?:in general|overall|broadly)\b", 0.10),
+    (r"\b(?:etc|and so on|and more)\b", 0.05),
+]
+
+
+def _score_dimension(
+    content: str, patterns: list[tuple[str, float]], cap: float = 1.0
+) -> float:
+    """Score content against a list of (regex, weight) patterns."""
+    total = 0.0
+    content_lower = content.lower()
+    for pattern, weight in patterns:
+        if re.search(pattern, content_lower, re.IGNORECASE):
+            total += weight
+    return min(total, cap)
+
+
+def score_specificity(content: str) -> float:
+    """How specific/concrete is the learning? (0.0-1.0)"""
+    return _score_dimension(content, _SPECIFICITY_PATTERNS)
+
+
+def score_actionability(content: str) -> float:
+    """How actionable/prescriptive is the learning? (0.0-1.0)"""
+    return _score_dimension(content, _ACTIONABILITY_PATTERNS)
+
+
+def score_evidence(content: str) -> float:
+    """How well-evidenced is the learning? (0.0-1.0)"""
+    return _score_dimension(content, _EVIDENCE_PATTERNS)
+
+
+def score_scope(content: str) -> float:
+    """How focused is the learning scope? (0.0-1.0, higher = more focused)"""
+    # Start at 0.7 (decent baseline), reduce for vagueness
+    base = 0.7
+    vagueness = _score_dimension(content, _VAGUENESS_PATTERNS)
+    # Shorter learnings tend to be more focused
+    word_count = len(content.split())
+    length_bonus = 0.1 if word_count < 50 else (-0.1 if word_count > 200 else 0.0)
+    return max(0.0, min(1.0, base - vagueness + length_bonus))
+
+
+# Dimension weights for final score
+WEIGHTS = {
+    "specificity": 0.30,
+    "actionability": 0.25,
+    "evidence": 0.25,
+    "scope": 0.20,
+}
+
+
+def calibrate_confidence(content: str) -> dict:
+    """Compute calibrated confidence for a learning.
+
+    Returns:
+        dict with keys: confidence (str), score (float),
+        dimensions (dict of dimension scores)
+    """
+    if not content or not content.strip():
+        return {
+            "confidence": "low",
+            "score": 0.0,
+            "dimensions": {
+                "specificity": 0.0,
+                "actionability": 0.0,
+                "evidence": 0.0,
+                "scope": 0.0,
+            },
+        }
+
+    dimensions = {
+        "specificity": score_specificity(content),
+        "actionability": score_actionability(content),
+        "evidence": score_evidence(content),
+        "scope": score_scope(content),
+    }
+
+    score = sum(WEIGHTS[k] * dimensions[k] for k in WEIGHTS)
+
+    # Map to categorical confidence
+    if score >= 0.30:
+        confidence = "high"
+    elif score >= 0.20:
+        confidence = "medium"
+    else:
+        confidence = "low"
+
+    return {
+        "confidence": confidence,
+        "score": round(score, 3),
+        "dimensions": {k: round(v, 3) for k, v in dimensions.items()},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Database operations
+# ---------------------------------------------------------------------------
+
+
+def _pg_connect():
+    """Get a PostgreSQL connection."""
+    import psycopg2
+    db_url = os.environ.get("CONTINUOUS_CLAUDE_DB_URL") or os.environ.get("DATABASE_URL")
+    if not db_url:
+        raise RuntimeError("No DATABASE_URL configured")
+    return psycopg2.connect(db_url)
+
+
+def _ensure_calibration_column():
+    """Add confidence_calibrated_at column if missing."""
+    conn = _pg_connect()
+    cur = conn.cursor()
+    cur.execute("""
+        ALTER TABLE archival_memory
+        ADD COLUMN IF NOT EXISTS confidence_calibrated_at TIMESTAMPTZ
+    """)
+    conn.commit()
+    conn.close()
+
+
+async def calibrate_session(session_id: str, dry_run: bool = False) -> dict:
+    """Calibrate confidence for all learnings in a session.
+
+    Returns:
+        dict with counts: total, updated, unchanged, errors
+    """
+    conn = _pg_connect()
+    cur = conn.cursor()
+
+    cur.execute(
+        """
+        SELECT id, content, metadata
+        FROM archival_memory
+        WHERE session_id = %s AND superseded_by IS NULL
+        """,
+        (session_id,),
+    )
+    rows = cur.fetchall()
+
+    stats = {"total": len(rows), "updated": 0, "unchanged": 0, "errors": 0}
+    changes = []
+
+    for row in rows:
+        memory_id, content, metadata = row
+        if not content:
+            stats["errors"] += 1
+            continue
+
+        result = calibrate_confidence(content)
+        old_confidence = (metadata or {}).get("confidence")
+        new_confidence = result["confidence"]
+
+        if old_confidence == new_confidence:
+            stats["unchanged"] += 1
+            continue
+
+        stats["updated"] += 1
+        changes.append({
+            "id": str(memory_id),
+            "old": old_confidence,
+            "new": new_confidence,
+            "score": result["score"],
+            "dimensions": result["dimensions"],
+        })
+
+        if not dry_run:
+            updated_metadata = dict(metadata or {})
+            updated_metadata["confidence"] = new_confidence
+            updated_metadata["confidence_score"] = result["score"]
+            updated_metadata["confidence_dimensions"] = result["dimensions"]
+            cur.execute(
+                """
+                UPDATE archival_memory
+                SET metadata = %s,
+                    confidence_calibrated_at = NOW()
+                WHERE id = %s
+                """,
+                (json.dumps(updated_metadata), memory_id),
+            )
+
+    if not dry_run:
+        conn.commit()
+    conn.close()
+
+    return {"stats": stats, "changes": changes}
+
+
+async def backfill_calibration(
+    dry_run: bool = False, batch_size: int = 100
+) -> dict:
+    """Recalibrate all learnings that haven't been calibrated yet.
+
+    Returns:
+        dict with total stats across all batches
+    """
+    _ensure_calibration_column()
+
+    conn = _pg_connect()
+    cur = conn.cursor()
+
+    cur.execute(
+        """
+        SELECT id, content, metadata
+        FROM archival_memory
+        WHERE superseded_by IS NULL
+          AND confidence_calibrated_at IS NULL
+        ORDER BY created_at DESC
+        """
+    )
+    rows = cur.fetchall()
+    conn.close()
+
+    total_stats = {"total": len(rows), "updated": 0, "unchanged": 0, "errors": 0}
+    all_changes = []
+
+    # Process in batches
+    for i in range(0, len(rows), batch_size):
+        batch = rows[i : i + batch_size]
+        conn = _pg_connect()
+        cur = conn.cursor()
+
+        for row in batch:
+            memory_id, content, metadata = row
+            if not content:
+                total_stats["errors"] += 1
+                continue
+
+            result = calibrate_confidence(content)
+            old_confidence = (metadata or {}).get("confidence")
+            new_confidence = result["confidence"]
+
+            if old_confidence == new_confidence:
+                total_stats["unchanged"] += 1
+                if not dry_run:
+                    # Still mark as calibrated even if unchanged
+                    cur.execute(
+                        """
+                        UPDATE archival_memory
+                        SET confidence_calibrated_at = NOW()
+                        WHERE id = %s
+                        """,
+                        (memory_id,),
+                    )
+                continue
+
+            total_stats["updated"] += 1
+            all_changes.append({
+                "id": str(memory_id),
+                "old": old_confidence,
+                "new": new_confidence,
+                "score": result["score"],
+            })
+
+            if not dry_run:
+                updated_metadata = dict(metadata or {})
+                updated_metadata["confidence"] = new_confidence
+                updated_metadata["confidence_score"] = result["score"]
+                updated_metadata["confidence_dimensions"] = result["dimensions"]
+                cur.execute(
+                    """
+                    UPDATE archival_memory
+                    SET metadata = %s,
+                        confidence_calibrated_at = NOW()
+                    WHERE id = %s
+                    """,
+                    (json.dumps(updated_metadata), memory_id),
+                )
+
+        if not dry_run:
+            conn.commit()
+        conn.close()
+
+    return {"stats": total_stats, "changes": all_changes}
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+async def main():
+    parser = argparse.ArgumentParser(
+        description="Calibrate learning confidence scores",
+    )
+    parser.add_argument(
+        "--session-id", help="Calibrate learnings for a specific session",
+    )
+    parser.add_argument(
+        "--backfill", action="store_true",
+        help="Recalibrate all uncalibrated learnings",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Show changes without writing")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+
+    args = parser.parse_args()
+
+    if not args.session_id and not args.backfill:
+        parser.error("Must specify --session-id or --backfill")
+
+    if args.session_id:
+        result = await calibrate_session(args.session_id, dry_run=args.dry_run)
+    else:
+        result = await backfill_calibration(dry_run=args.dry_run)
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        stats = result["stats"]
+        prefix = "[DRY RUN] " if args.dry_run else ""
+        print(f"{prefix}Calibration complete:")
+        print(f"  Total:     {stats['total']}")
+        print(f"  Updated:   {stats['updated']}")
+        print(f"  Unchanged: {stats['unchanged']}")
+        print(f"  Errors:    {stats['errors']}")
+
+        if result["changes"]:
+            print(f"\n{'Proposed' if args.dry_run else 'Applied'} changes:")
+            for change in result["changes"][:20]:
+                cid = change["id"][:8]
+                old, new, sc = change["old"], change["new"], change["score"]
+                print(f"  {cid}: {old} -> {new} (score: {sc})")
+            if len(result["changes"]) > 20:
+                print(f"  ... and {len(result['changes']) - 20} more")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/core/memory_daemon.py
+++ b/scripts/core/memory_daemon.py
@@ -615,6 +615,25 @@ def archive_session_jsonl(session_id: str, jsonl_path: Path | None = None):
         log(f"Archive error for {session_id}: {e}")
 
 
+def _calibrate_session_confidence(session_id: str):
+    """Run confidence calibration on learnings from a completed extraction."""
+    try:
+        import asyncio
+
+        from scripts.core.confidence_calibrator import calibrate_session
+
+        result = asyncio.run(calibrate_session(session_id))
+        stats = result["stats"]
+        if stats["total"] > 0:
+            log(
+                f"Confidence calibration for {session_id}: "
+                f"{stats['updated']} updated, "
+                f"{stats['unchanged']} unchanged"
+            )
+    except Exception as e:
+        log(f"Confidence calibration failed for {session_id}: {e}")
+
+
 def _extract_and_store_workflows(
     session_id: str,
     jsonl_path: Path,
@@ -749,6 +768,7 @@ def reap_completed_extractions():
                 f"exit={exit_code}, elapsed={elapsed}s{learnings_info})")
             if exit_code == 0:
                 mark_extracted(session_id)
+                _calibrate_session_confidence(session_id)
                 _extract_and_store_workflows(session_id, jsonl_path, project)
                 _generate_mini_handoff(session_id, jsonl_path, project)
                 archive_session_jsonl(session_id, jsonl_path)

--- a/scripts/core/store_learning.py
+++ b/scripts/core/store_learning.py
@@ -222,6 +222,22 @@ async def store_learning_v2(
                     "Auto-classification error: %s", str(e)[:100]
                 )
 
+        # Auto-calibrate confidence if not explicitly provided
+        confidence_score_val = None
+        confidence_dimensions = None
+        if not confidence:
+            try:
+                from scripts.core.confidence_calibrator import (
+                    calibrate_confidence,
+                )
+
+                cal = calibrate_confidence(content)
+                confidence = cal["confidence"]
+                confidence_score_val = cal["score"]
+                confidence_dimensions = cal["dimensions"]
+            except Exception:
+                pass  # Non-fatal: fall through to no confidence
+
         # Build metadata
         metadata = {
             "type": "session_learning",
@@ -245,6 +261,10 @@ async def store_learning_v2(
             metadata["tags"] = tags
         if confidence:
             metadata["confidence"] = confidence
+        if confidence_score_val is not None:
+            metadata["confidence_score"] = confidence_score_val
+        if confidence_dimensions is not None:
+            metadata["confidence_dimensions"] = confidence_dimensions
         if project:
             metadata["project"] = project
 

--- a/scripts/migrations/add_confidence_calibration.sql
+++ b/scripts/migrations/add_confidence_calibration.sql
@@ -1,0 +1,10 @@
+-- Add confidence_calibrated_at column for tracking calibration state
+-- This column is NULL for uncalibrated learnings, set to NOW() after calibration.
+
+ALTER TABLE archival_memory
+ADD COLUMN IF NOT EXISTS confidence_calibrated_at TIMESTAMPTZ;
+
+-- Index for efficient backfill queries (find uncalibrated learnings)
+CREATE INDEX IF NOT EXISTS idx_archival_memory_uncalibrated
+ON archival_memory (created_at DESC)
+WHERE confidence_calibrated_at IS NULL AND superseded_by IS NULL;

--- a/tests/test_confidence_calibrator.py
+++ b/tests/test_confidence_calibrator.py
@@ -1,0 +1,203 @@
+"""Tests for confidence calibration.
+
+Validates that:
+1. Individual dimension scorers detect the right patterns
+2. calibrate_confidence() produces correct mappings
+3. Edge cases (empty content, missing fields) are handled
+4. Calibration thresholds produce reasonable distributions
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from scripts.core.confidence_calibrator import (  # noqa: E402
+    calibrate_confidence,
+    score_actionability,
+    score_evidence,
+    score_scope,
+    score_specificity,
+)
+
+
+# ---------------------------------------------------------------------------
+# Specificity scoring
+# ---------------------------------------------------------------------------
+
+class TestSpecificity:
+    def test_file_path_reference(self):
+        score = score_specificity("The fix is in scripts/core/store_learning.py:42")
+        assert score >= 0.15
+
+    def test_function_name(self):
+        score = score_specificity("def calibrate_confidence handles the mapping")
+        assert score >= 0.15
+
+    def test_git_hash(self):
+        score = score_specificity("Fixed in commit abc1234")
+        assert score >= 0.10
+
+    def test_inline_code(self):
+        score = score_specificity("Use `store_learning_v2` for new code")
+        assert score >= 0.10
+
+    def test_error_type(self):
+        score = score_specificity("Got a TypeError when passing None")
+        assert score >= 0.10
+
+    def test_vague_content(self):
+        score = score_specificity("Things work better now")
+        assert score < 0.15
+
+    def test_multiple_indicators(self):
+        content = "Fixed TypeError in `store_learning.py:86` by checking for None"
+        score = score_specificity(content)
+        assert score >= 0.35
+
+
+class TestActionability:
+    def test_prescriptive_language(self):
+        score = score_actionability("Always use store_learning_v2 instead of the legacy function")
+        assert score >= 0.35
+
+    def test_pattern_description(self):
+        score = score_actionability("The pattern for hooks is to check availability first")
+        assert score >= 0.10
+
+    def test_step_instructions(self):
+        score = score_actionability("First check the config, then validate, then store")
+        assert score >= 0.10
+
+    def test_descriptive_only(self):
+        score = score_actionability("The system processes data in batches")
+        assert score < 0.20
+
+
+class TestEvidence:
+    def test_commit_reference(self):
+        score = score_evidence("Tested and merged in PR #5, commit abc1234")
+        assert score >= 0.20
+
+    def test_verification_language(self):
+        score = score_evidence("Verified that the fix works with all test cases")
+        assert score >= 0.20
+
+    def test_test_results(self):
+        score = score_evidence("Tests pass with 95% coverage after the change")
+        assert score >= 0.25
+
+    def test_no_evidence(self):
+        score = score_evidence("This approach should work well")
+        assert score < 0.10
+
+
+class TestScope:
+    def test_focused_short(self):
+        score = score_scope("Use psycopg2.connect() not psycopg2.pool for single queries")
+        assert score >= 0.6
+
+    def test_vague_hedging(self):
+        score = score_scope("Sometimes this might work, maybe it could help generally")
+        assert score < 0.5
+
+    def test_long_content(self):
+        content = "word " * 250
+        score = score_scope(content)
+        assert score < score_scope("Short focused learning")
+
+
+# ---------------------------------------------------------------------------
+# End-to-end calibration
+# ---------------------------------------------------------------------------
+
+class TestCalibrateConfidence:
+    def test_high_confidence_learning(self):
+        content = (
+            "Fixed TypeError in `store_learning.py:86` by checking for None. "
+            "Always validate content before calling embed(). "
+            "Verified with tests, merged in commit abc1234."
+        )
+        result = calibrate_confidence(content)
+        assert result["confidence"] == "high"
+        assert result["score"] >= 0.30
+        assert "dimensions" in result
+        assert set(result["dimensions"].keys()) == {
+            "specificity", "actionability", "evidence", "scope"
+        }
+
+    def test_medium_confidence_learning(self):
+        content = (
+            "The hook system uses a pattern where you check availability first. "
+            "Use `checkService()` before proceeding with the workflow."
+        )
+        result = calibrate_confidence(content)
+        assert result["confidence"] in ("medium", "high")
+        assert result["score"] >= 0.20
+
+    def test_low_confidence_learning(self):
+        content = "Things seem to maybe work sometimes."
+        result = calibrate_confidence(content)
+        assert result["confidence"] == "low"
+        assert result["score"] < 0.15
+
+    def test_empty_content(self):
+        result = calibrate_confidence("")
+        assert result["confidence"] == "low"
+
+    def test_result_structure(self):
+        result = calibrate_confidence("test content")
+        assert "confidence" in result
+        assert "score" in result
+        assert "dimensions" in result
+        assert isinstance(result["score"], float)
+        assert 0.0 <= result["score"] <= 1.0
+
+    def test_score_is_weighted_average(self):
+        """Verify score equals weighted sum of dimensions."""
+        from scripts.core.confidence_calibrator import WEIGHTS
+        result = calibrate_confidence("Use `foo.py` always, verified with tests")
+        expected = sum(
+            WEIGHTS[k] * result["dimensions"][k] for k in WEIGHTS
+        )
+        assert abs(result["score"] - round(expected, 3)) < 0.01
+
+
+# ---------------------------------------------------------------------------
+# Distribution sanity check
+# ---------------------------------------------------------------------------
+
+class TestDistribution:
+    """Verify calibration produces reasonable distribution across sample learnings."""
+
+    SAMPLE_LEARNINGS = [
+        # Should be HIGH
+        "Fixed TypeError in `store_learning.py:86` by adding None check. Always validate before embed(). Commit abc1234.",
+        "Use `psycopg2.connect()` not pool for single queries. Tested: 3x faster for one-shot operations.",
+        # Should be MEDIUM
+        "The hook system works by checking availability first, then proceeding.",
+        "Parallel agent spawning works well for independent tasks.",
+        # Should be LOW
+        "Things might work better sometimes.",
+        "Generally the system seems fine overall.",
+    ]
+
+    def test_not_all_same_confidence(self):
+        results = [calibrate_confidence(s) for s in self.SAMPLE_LEARNINGS]
+        confidences = {r["confidence"] for r in results}
+        assert len(confidences) >= 2, (
+            f"All learnings got same confidence: {confidences}"
+        )
+
+    def test_high_samples_score_higher(self):
+        high_scores = [
+            calibrate_confidence(s)["score"]
+            for s in self.SAMPLE_LEARNINGS[:2]
+        ]
+        low_scores = [
+            calibrate_confidence(s)["score"]
+            for s in self.SAMPLE_LEARNINGS[-2:]
+        ]
+        assert min(high_scores) > max(low_scores)


### PR DESCRIPTION
## Summary
- Adds heuristic-based confidence calibration scoring learnings on 4 dimensions: specificity, actionability, evidence, and scope
- Replaces naive 'always high' default (92% of learnings were high) with calibrated distribution: 15% high / 67% medium / 18% low
- Auto-calibrates at store time in `store_learning_v2` when no explicit confidence provided
- Post-extraction calibration pass wired into `memory_daemon.py`
- Backfill CLI: `uv run python scripts/core/confidence_calibrator.py --backfill [--dry-run]`
- Migration adds `confidence_calibrated_at` column with partial index for efficient backfill

## Test plan
- [x] 26 unit tests covering all 4 scoring dimensions, threshold mappings, edge cases, and distribution sanity
- [x] Full test suite passes (210 tests)
- [x] Dry-run backfill verified against 2,243 real learnings
- [ ] Run actual backfill after merge: `uv run python scripts/core/confidence_calibrator.py --backfill`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Learning records now automatically receive confidence scores based on content analysis
  * Existing records can be bulk recalibrated to apply new scoring logic
  * System tracks when each record was last calibrated for transparency

* **Database Updates**
  * Added schema changes to support confidence calibration tracking and indexing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->