### PR TITLE
TDD/FP refactor: db/memory_protocol.py (S3)

### DIFF
--- a/scripts/core/db/memory_protocol.py
+++ b/scripts/core/db/memory_protocol.py
@@ -9,17 +9,24 @@ Both SQLite and PostgreSQL implementations satisfy this protocol.
 import inspect
 from typing import Any, Protocol, runtime_checkable
 
+_VARIADIC_KINDS = frozenset({
+    inspect.Parameter.VAR_POSITIONAL,
+    inspect.Parameter.VAR_KEYWORD,
+})
+
 
 def _get_protocol_methods() -> dict[str, inspect.Signature]:
     """Extract method names and signatures from MemoryBackend Protocol.
 
+    Uses __protocol_attrs__ to enumerate only the declared protocol members,
+    avoiding inherited metaclass/ABC callables like register().
+
     Returns:
         Dict mapping method name to its inspect.Signature.
     """
+    attrs = getattr(MemoryBackend, "__protocol_attrs__", set())
     methods: dict[str, inspect.Signature] = {}
-    for name in dir(MemoryBackend):
-        if name.startswith("_"):
-            continue
+    for name in attrs:
         attr = getattr(MemoryBackend, name, None)
         if callable(attr):
             methods[name] = inspect.signature(attr)
@@ -33,8 +40,10 @@ def _check_signature_compatible(
 ) -> list[str]:
     """Check that actual_sig can accept calls shaped like expected_sig.
 
-    Verifies parameter count, and that positional parameters in the protocol
-    are also positional (not keyword-only) in the implementation.
+    Verifies:
+    - Required parameter count matches (excluding *args/**kwargs).
+    - Positional params in the protocol are positional in the implementation.
+    - Implementations using **kwargs satisfy any missing required params.
 
     Args:
         name: Method name (for error messages).
@@ -46,25 +55,37 @@ def _check_signature_compatible(
     """
     errors: list[str] = []
     expected_params = [
-        p for p in expected_sig.parameters.values() if p.name != "self"
+        p for p in expected_sig.parameters.values()
+        if p.name != "self" and p.kind not in _VARIADIC_KINDS
     ]
     actual_params = list(actual_sig.parameters.values())
+    has_var_positional = any(
+        p.kind == inspect.Parameter.VAR_POSITIONAL for p in actual_params
+    )
+    has_var_keyword = any(
+        p.kind == inspect.Parameter.VAR_KEYWORD for p in actual_params
+    )
+    actual_non_variadic = [
+        p for p in actual_params if p.kind not in _VARIADIC_KINDS
+    ]
 
     expected_required = [
         p for p in expected_params
         if p.default is inspect.Parameter.empty
     ]
     actual_required = [
-        p for p in actual_params
+        p for p in actual_non_variadic
         if p.default is inspect.Parameter.empty
     ]
 
-    if len(actual_required) != len(expected_required):
-        errors.append(
-            f"method {name} expects {len(expected_required)} required params, "
-            f"got {len(actual_required)}"
-        )
-        return errors
+    # If impl has *args or **kwargs, it can absorb extra params
+    if not (has_var_positional or has_var_keyword):
+        if len(actual_required) != len(expected_required):
+            errors.append(
+                f"method {name} expects {len(expected_required)} required params, "
+                f"got {len(actual_required)}"
+            )
+            return errors
 
     # Check that positional params in protocol are positional in impl
     for ep in expected_params:
@@ -72,9 +93,7 @@ def _check_signature_compatible(
             inspect.Parameter.POSITIONAL_ONLY,
             inspect.Parameter.POSITIONAL_OR_KEYWORD,
         ):
-            matching = [
-                ap for ap in actual_params if ap.name == ep.name
-            ]
+            matching = [ap for ap in actual_non_variadic if ap.name == ep.name]
             if matching and matching[0].kind == inspect.Parameter.KEYWORD_ONLY:
                 errors.append(
                     f"method {name} param '{ep.name}' is keyword-only "

--- a/tests/test_memory_protocol.py
+++ b/tests/test_memory_protocol.py
@@ -223,9 +223,9 @@ class TestMemoryBackendProtocol:
 
     def test_protocol_is_a_protocol(self) -> None:
         """MemoryBackend should be a typing.Protocol subclass."""
-        assert hasattr(MemoryBackend, "__protocol_attrs__") or issubclass(
-            MemoryBackend, object
-        )
+        from typing import is_protocol
+
+        assert is_protocol(MemoryBackend)
 
     def test_protocol_defines_expected_methods(self) -> None:
         """Protocol should define all expected async method stubs."""
@@ -275,17 +275,38 @@ class TestStructuralTyping:
 class TestNoSideEffects:
     """Protocol module should be free of import-time side effects."""
 
-    def test_no_faulthandler_in_module(self) -> None:
-        """The protocol module should not enable faulthandler at import time."""
-        import inspect
+    def test_no_faulthandler_in_source(self) -> None:
+        """Module source should not contain faulthandler.enable calls."""
+        import inspect as _inspect
         import sys
 
         module_name = "scripts.core.db.memory_protocol"
         if module_name in sys.modules:
-            source = inspect.getsource(sys.modules[module_name])
+            source = _inspect.getsource(sys.modules[module_name])
             assert "faulthandler.enable" not in source, (
                 "Protocol module should not have faulthandler side effects"
             )
+
+    def test_import_does_not_enable_faulthandler(self) -> None:
+        """Re-importing the module should not toggle faulthandler state."""
+        import faulthandler
+        import importlib
+        import sys
+
+        module_name = "scripts.core.db.memory_protocol"
+        # Remove cached module so import runs init code again
+        saved = sys.modules.pop(module_name, None)
+        try:
+            before = faulthandler.is_enabled()
+            importlib.import_module(module_name)
+            after = faulthandler.is_enabled()
+            assert before == after, (
+                f"faulthandler state changed on import: {before} -> {after}"
+            )
+        finally:
+            # Restore original module to avoid side effects on other tests
+            if saved is not None:
+                sys.modules[module_name] = saved
 
 
 # ---------------------------------------------------------------------------
@@ -357,3 +378,50 @@ class TestValidateBackend:
         assert not is_valid
         kw_errors = [e for e in errors if "keyword-only" in e]
         assert len(kw_errors) >= 5, f"Expected >=5 kw-only errors, got: {kw_errors}"
+
+    def test_kwargs_backend_passes_validation(self) -> None:
+        """Backend using **kwargs for forward-compatibility should pass.
+
+        Implementations may use **kwargs to accept future protocol params
+        without breaking. The validator should treat this as compatible.
+        """
+
+        class KwargsBackend:
+            async def set_core(self, key: str, value: str, **kw: Any) -> None:
+                pass
+
+            async def get_core(self, key: str, **kw: Any) -> str | None:
+                return None
+
+            async def list_core_keys(self, **kw: Any) -> list[str]:
+                return []
+
+            async def delete_core(self, key: str, **kw: Any) -> None:
+                pass
+
+            async def get_all_core(self, **kw: Any) -> dict[str, str]:
+                return {}
+
+            async def store(self, content: str, **kw: Any) -> str:
+                return "id"
+
+            async def search(self, query: str, limit: int = 10, **kw: Any) -> list[dict[str, Any]]:
+                return []
+
+            async def delete_archival(self, memory_id: str, **kw: Any) -> None:
+                pass
+
+            async def recall(self, query: str, **kw: Any) -> str:
+                return ""
+
+            async def to_context(self, **kw: Any) -> str:
+                return ""
+
+            async def connect(self, **kw: Any) -> None:
+                pass
+
+            async def close(self, **kw: Any) -> None:
+                pass
+
+        is_valid, errors = validate_backend(KwargsBackend())
+        assert is_valid, f"KwargsBackend should pass validation, got errors: {errors}"


### PR DESCRIPTION
## Summary

TDD/FP compliance refactor of `scripts/core/db/memory_protocol.py` (Stage S3 of the [refactor plan](../thoughts/shared/plans/tdd-fp-compliance-refactor.md)).

### Changes

- **Remove faulthandler side effect**: The module-level `faulthandler.enable(file=open(...))` was an I/O side effect in a pure Protocol definition. Removed per FP principles.
- **Add `@runtime_checkable`**: Enables `isinstance(obj, MemoryBackend)` checks for structural typing.
- **Add `validate_backend()` function**: Deep protocol validation that goes beyond `isinstance` name-only checks:
  - Verifies all 12 required methods exist
  - Verifies each method is `async def` (coroutine)
  - Verifies signature compatibility (parameter count + positional vs keyword-only)
- **14 new tests** covering protocol contract, structural typing, side-effect absence, and validator edge cases (sync stubs, wrong arity, keyword-only params)

### Adversarial Review Summary

3 rounds completed. Key findings addressed:
1. Round 1: Added `validate_backend` to catch sync backends that pass `isinstance`
2. Round 2: Upgraded from arity-only to full signature compatibility checking
3. Round 3: Added keyword-only parameter detection

Note: Factory wiring of `validate_backend` is deferred to S6 (`memory_factory.py`).

### Security Review

No HIGH or MEDIUM vulnerabilities. Zero attack surface (pure interface + pure functions).

## Test plan

- [x] `uv run pytest tests/test_memory_protocol.py -v` — 14 tests pass
- [x] `uv run pytest tests/ -x` — 442 passed, no regressions
- [x] `uv run ruff check scripts/core/db/memory_protocol.py` — clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime validation for backend implementations to detect configuration issues.

* **Tests**
  * Added comprehensive test suite validating backend protocol compliance and validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->