### PR TITLE
Add config system, system health metrics, and duplicate density analysis

### DIFF
--- a/opc.toml
+++ b/opc.toml
@@ -1,0 +1,154 @@
+# OPC Configuration
+# ─────────────────
+# Opinionated Persistent Context — memory system for Claude Code.
+#
+# This file is loaded automatically from:
+#   1. Path in OPC_CONFIG env var (highest priority)
+#   2. ./opc.toml (project root)
+#   3. ~/.config/opc/config.toml (user global)
+#
+# Any value omitted here falls back to the built-in default.
+# Environment variables override config file values (see each section).
+
+
+[dedup]
+# Cosine similarity threshold for semantic deduplication.
+# Learnings above this similarity to an existing learning are rejected.
+# Range: 0.0–1.0. Based on density analysis: 0.85+ is same-fact rewording.
+threshold = 0.85
+
+
+[daemon]
+# How often the daemon checks for new sessions (seconds).
+poll_interval = 60
+
+# Sessions must be this old before extraction qualifies (seconds).
+stale_threshold = 900
+
+# Max simultaneous Claude extraction subprocesses.
+max_concurrent_extractions = 4
+
+# DB connection retry count.
+max_retries = 5
+
+# Kill extraction subprocess after this many seconds.
+extraction_timeout = 1800
+
+# Hours between pattern detection runs.
+# Env override: PATTERN_DETECTION_INTERVAL_HOURS
+pattern_detection_interval_hours = 6
+
+# Claude model used for extraction subprocesses.
+extraction_model = "sonnet"
+
+# Max turns per extraction subprocess.
+extraction_max_turns = 15
+
+
+[reranker]
+# Contextual signal weights (should sum to ~0.35).
+project_weight = 0.15
+recency_weight = 0.05
+confidence_weight = 0.05
+recall_weight = 0.05
+type_affinity_weight = 0.05
+tag_overlap_weight = 0.05
+pattern_weight = 0.05
+
+# Exponential decay half-life for recency scoring (days).
+recency_half_life_days = 45
+
+# Recall count normalizer: recall_count of 2^N scores as 1.0.
+recall_log2_normalizer = 4
+
+# Scale-up factor for hybrid_rrf raw scores in calibration.
+rrf_scale_factor = 60
+
+
+[patterns]
+# HDBSCAN clustering parameters.
+min_cluster_size = 5
+min_samples = 3
+
+# Minimum confidence for a detected pattern to be stored.
+min_confidence = 0.3
+
+# Bottom Nth percentile of tag IDF treated as noise.
+tag_noise_percentile = 10
+
+# Minimum IDF-weighted edge for tag co-occurrence graph.
+min_cooccurrence = 1.0
+
+# Minimum connected component size for tag clusters.
+min_component_size = 5
+
+# Jaccard overlap threshold for merging embedding + tag clusters.
+overlap_threshold = 0.3
+
+# Split tag clusters larger than this.
+max_cluster_size = 20
+
+# Classification heuristic thresholds.
+anti_pattern_threshold = 0.6
+problem_solution_threshold = 0.4
+expertise_threshold = 0.6
+tool_cluster_threshold = 0.7
+cross_project_days = 30
+cross_project_contexts = 4
+cross_project_sessions = 3
+
+
+[recall]
+# Default number of results returned.
+default_k = 5
+
+# RRF constant (higher = more weight to lower-ranked results).
+rrf_k = 60
+
+# Max IDF terms added during query expansion.
+max_expansion_terms = 5
+
+# Recall-count boost multiplier in hybrid RRF query.
+recall_boost_multiplier = 0.002
+
+# BM25 normalization divisor for SQLite scores.
+bm25_normalization_divisor = 25.0
+
+
+[embedding]
+# Default Ollama model for local embeddings.
+# Env override: OLLAMA_EMBED_MODEL
+ollama_model = "nomic-embed-text"
+
+# Default Ollama server URL.
+# Env override: OLLAMA_HOST
+ollama_host = "http://localhost:11434"
+
+# Batch size for re-embedding operations.
+re_embed_batch_size = 64
+
+
+[query_expansion]
+# Hours before the on-disk IDF cache is rebuilt.
+idf_max_age_hours = 24
+
+# If doc count drifts more than this fraction, force IDF rebuild.
+idf_drift_threshold = 0.10
+
+
+[archival]
+# Subprocess timeouts for backup operations (seconds).
+compress_timeout = 300
+upload_timeout = 300
+
+# Files modified within this many minutes are skipped from archival.
+skip_recent_minutes = 10
+
+
+[database]
+# Max asyncpg connection pool size.
+# Env override: AGENTICA_MAX_POOL_SIZE
+max_pool_size = 10
+
+# Max archival facts included when building LLM context string.
+max_archival_context = 10

--- a/scripts/core/backfill_archive.py
+++ b/scripts/core/backfill_archive.py
@@ -18,6 +18,15 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 
+# Add repository root to path
+_repo_root = str(Path(__file__).parent.parent.parent)
+if _repo_root not in sys.path:
+    sys.path.insert(0, _repo_root)
+
+from scripts.core.config import get_config as _get_config  # noqa: E402
+
+_archival_cfg = _get_config().archival
+
 faulthandler.enable(file=open(os.path.expanduser("~/.claude/logs/opc_crash.log"), "a"), all_threads=True)  # noqa: E501
 
 # Load env (same as daemon)
@@ -81,7 +90,7 @@ def archive_jsonl(jsonl_path: Path, bucket: str, dry_run: bool = False):
         # Compress
         result = subprocess.run(
             ["zstd", "-q", "--rm", str(jsonl_path)],
-            capture_output=True, timeout=300,
+            capture_output=True, timeout=_archival_cfg.compress_timeout,
         )
         if result.returncode != 0:
             print(f"  zstd failed: {result.stderr.decode()}")
@@ -90,14 +99,14 @@ def archive_jsonl(jsonl_path: Path, bucket: str, dry_run: bool = False):
         # Upload
         result = subprocess.run(
             ["aws", "s3", "cp", str(zst_path), s3_key, "--quiet"],
-            capture_output=True, timeout=120,
+            capture_output=True, timeout=_archival_cfg.upload_timeout,
         )
         if result.returncode != 0:
             print(f"  S3 upload failed: {result.stderr.decode()}")
             # Restore original
             subprocess.run(
                 ["zstd", "-d", "-q", "--rm", str(zst_path)],
-                capture_output=True, timeout=300,
+                capture_output=True, timeout=_archival_cfg.compress_timeout,
             )
             return False
 
@@ -115,7 +124,7 @@ def archive_jsonl(jsonl_path: Path, bucket: str, dry_run: bool = False):
         if zst_path.exists() and not jsonl_path.exists():
             subprocess.run(
                 ["zstd", "-d", "-q", "--rm", str(zst_path)],
-                capture_output=True, timeout=300,
+                capture_output=True, timeout=_archival_cfg.compress_timeout,
             )
         return False
     except Exception as e:
@@ -138,7 +147,7 @@ def main():
 
     from datetime import datetime, timedelta
 
-    cutoff = datetime.now() - timedelta(minutes=10)
+    cutoff = datetime.now() - timedelta(minutes=_archival_cfg.skip_recent_minutes)
     all_jsonls = sorted(jsonl_dir.glob("*/*.jsonl"), key=lambda x: x.stat().st_mtime)
     jsonls = [
         f for f in all_jsonls

--- a/scripts/core/config/__init__.py
+++ b/scripts/core/config/__init__.py
@@ -1,0 +1,13 @@
+"""OPC configuration package.
+
+Public API:
+    from scripts.core.config import get_config, reset_config
+
+    cfg = get_config()
+    cfg.dedup.threshold
+"""
+
+from scripts.core.config.handlers import get_config, reset_config
+from scripts.core.config.models import OPCConfig
+
+__all__ = ["get_config", "reset_config", "OPCConfig"]

--- a/scripts/core/config/core.py
+++ b/scripts/core/config/core.py
@@ -58,6 +58,7 @@ _RANGE_RULES: dict[tuple[str, str], tuple[float | None, float | None]] = {
     ("patterns", "min_cluster_size"): (2, None),
     ("patterns", "min_samples"): (1, None),
     ("patterns", "min_confidence"): (0.0, 1.0),
+    ("patterns", "tag_noise_percentile"): (0, 100),
     ("patterns", "overlap_threshold"): (0.0, 1.0),
     ("recall", "default_k"): (1, None),
     ("recall", "rrf_k"): (1, None),

--- a/scripts/core/config/core.py
+++ b/scripts/core/config/core.py
@@ -1,0 +1,67 @@
+"""Pure configuration construction — no I/O, no global state.
+
+All functions are pure: same input produces same output, no side effects.
+"""
+
+from __future__ import annotations
+
+from dataclasses import fields
+from typing import Any
+
+from scripts.core.config.models import (
+    ArchivalConfig,
+    DatabaseConfig,
+    DaemonConfig,
+    DedupConfig,
+    EmbeddingConfig,
+    OPCConfig,
+    PatternsConfig,
+    QueryExpansionConfig,
+    RerankerConfig,
+    RecallConfig,
+)
+
+
+_SECTION_MAP: dict[str, type] = {
+    "dedup": DedupConfig,
+    "daemon": DaemonConfig,
+    "reranker": RerankerConfig,
+    "patterns": PatternsConfig,
+    "recall": RecallConfig,
+    "embedding": EmbeddingConfig,
+    "query_expansion": QueryExpansionConfig,
+    "archival": ArchivalConfig,
+    "database": DatabaseConfig,
+}
+
+
+def build_section(cls: type, raw: dict[str, Any]) -> Any:
+    """Build a config section dataclass from a raw dict, ignoring unknown keys."""
+    valid_keys = {f.name for f in fields(cls)}
+    filtered = {k: v for k, v in raw.items() if k in valid_keys}
+    return cls(**filtered)
+
+
+def merge_raw(
+    file_raw: dict[str, Any],
+    env_raw: dict[str, Any],
+) -> dict[str, Any]:
+    """Merge file config with env overrides. Env wins per-key. Does not mutate inputs."""
+    merged: dict[str, Any] = {}
+
+    all_sections = set(file_raw.keys()) | set(env_raw.keys())
+    for section in all_sections:
+        file_section = file_raw.get(section, {})
+        env_section = env_raw.get(section, {})
+        merged[section] = {**file_section, **env_section}
+
+    return merged
+
+
+def build_config(raw: dict[str, Any]) -> OPCConfig:
+    """Build a complete OPCConfig from a merged raw dict."""
+    sections = {}
+    for name, cls in _SECTION_MAP.items():
+        section_raw = raw.get(name, {})
+        sections[name] = build_section(cls, section_raw)
+    return OPCConfig(**sections)

--- a/scripts/core/config/core.py
+++ b/scripts/core/config/core.py
@@ -41,6 +41,31 @@ class ConfigValidationError(ValueError):
     """Raised when config values fail type or range validation."""
 
 
+# Per-field range constraints: (section, key) -> (min, max) inclusive.
+# None means unbounded on that side.
+_RANGE_RULES: dict[tuple[str, str], tuple[float | None, float | None]] = {
+    ("dedup", "threshold"): (0.0, 1.0),
+    ("daemon", "poll_interval"): (1, None),
+    ("daemon", "stale_threshold"): (1, None),
+    ("daemon", "max_concurrent_extractions"): (1, None),
+    ("daemon", "max_retries"): (0, None),
+    ("daemon", "extraction_timeout"): (1, None),
+    ("daemon", "pattern_detection_interval_hours"): (1, None),
+    ("daemon", "extraction_max_turns"): (1, None),
+    ("reranker", "recency_half_life_days"): (0.1, None),
+    ("reranker", "recall_log2_normalizer"): (1, None),
+    ("reranker", "rrf_scale_factor"): (0.1, None),
+    ("patterns", "min_cluster_size"): (2, None),
+    ("patterns", "min_samples"): (1, None),
+    ("patterns", "min_confidence"): (0.0, 1.0),
+    ("patterns", "overlap_threshold"): (0.0, 1.0),
+    ("recall", "default_k"): (1, None),
+    ("recall", "rrf_k"): (1, None),
+    ("recall", "max_expansion_terms"): (0, None),
+    ("database", "max_pool_size"): (1, None),
+}
+
+
 def _validate_type(section: str, key: str, value: Any, expected_type: type) -> Any:
     """Validate and coerce a config value to the expected type.
 
@@ -54,6 +79,18 @@ def _validate_type(section: str, key: str, value: Any, expected_type: type) -> A
     raise ConfigValidationError(
         f"[{section}] {key}: expected {expected_type.__name__}, got {type(value).__name__} ({value!r})"
     )
+
+
+def _validate_range(section: str, key: str, value: Any) -> None:
+    """Check numeric value against range rules. Raises on violation."""
+    bounds = _RANGE_RULES.get((section, key))
+    if bounds is None:
+        return
+    lo, hi = bounds
+    if lo is not None and value < lo:
+        raise ConfigValidationError(f"[{section}] {key}: {value} is below minimum {lo}")
+    if hi is not None and value > hi:
+        raise ConfigValidationError(f"[{section}] {key}: {value} is above maximum {hi}")
 
 
 def build_section(cls: type, raw: dict[str, Any], *, section_name: str = "") -> Any:
@@ -79,7 +116,9 @@ def build_section(cls: type, raw: dict[str, Any], *, section_name: str = "") -> 
         type_map = {"float": float, "int": int, "str": str, "bool": bool}
         resolved_type = type_map.get(expected, expected) if isinstance(expected, str) else expected
         try:
-            validated[key] = _validate_type(section_name, key, value, resolved_type)
+            typed_value = _validate_type(section_name, key, value, resolved_type)
+            _validate_range(section_name, key, typed_value)
+            validated[key] = typed_value
         except ConfigValidationError as e:
             errors.append(str(e))
 

--- a/scripts/core/config/core.py
+++ b/scripts/core/config/core.py
@@ -5,6 +5,7 @@ All functions are pure: same input produces same output, no side effects.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import fields
 from typing import Any
 
@@ -21,6 +22,7 @@ from scripts.core.config.models import (
     RecallConfig,
 )
 
+logger = logging.getLogger(__name__)
 
 _SECTION_MAP: dict[str, type] = {
     "dedup": DedupConfig,
@@ -35,11 +37,56 @@ _SECTION_MAP: dict[str, type] = {
 }
 
 
-def build_section(cls: type, raw: dict[str, Any]) -> Any:
-    """Build a config section dataclass from a raw dict, ignoring unknown keys."""
-    valid_keys = {f.name for f in fields(cls)}
-    filtered = {k: v for k, v in raw.items() if k in valid_keys}
-    return cls(**filtered)
+class ConfigValidationError(ValueError):
+    """Raised when config values fail type or range validation."""
+
+
+def _validate_type(section: str, key: str, value: Any, expected_type: type) -> Any:
+    """Validate and coerce a config value to the expected type.
+
+    Returns the validated value, or raises ConfigValidationError.
+    """
+    # TOML integers are valid for float fields
+    if expected_type is float and isinstance(value, int):
+        return float(value)
+    if isinstance(value, expected_type):
+        return value
+    raise ConfigValidationError(
+        f"[{section}] {key}: expected {expected_type.__name__}, got {type(value).__name__} ({value!r})"
+    )
+
+
+def build_section(cls: type, raw: dict[str, Any], *, section_name: str = "") -> Any:
+    """Build a config section dataclass from a raw dict.
+
+    Warns on unknown keys and validates types against the dataclass field types.
+    """
+    field_map = {f.name: f for f in fields(cls)}
+    errors: list[str] = []
+
+    # Warn on unknown keys
+    unknown = set(raw.keys()) - set(field_map.keys())
+    for key in sorted(unknown):
+        logger.warning("Config: unknown key [%s] %s — ignored", section_name or cls.__name__, key)
+
+    # Validate and collect known keys
+    validated: dict[str, Any] = {}
+    for key, value in raw.items():
+        if key not in field_map:
+            continue
+        expected = field_map[key].type
+        # Resolve string type annotations
+        type_map = {"float": float, "int": int, "str": str, "bool": bool}
+        resolved_type = type_map.get(expected, expected) if isinstance(expected, str) else expected
+        try:
+            validated[key] = _validate_type(section_name, key, value, resolved_type)
+        except ConfigValidationError as e:
+            errors.append(str(e))
+
+    if errors:
+        raise ConfigValidationError("; ".join(errors))
+
+    return cls(**validated)
 
 
 def merge_raw(
@@ -59,9 +106,16 @@ def merge_raw(
 
 
 def build_config(raw: dict[str, Any]) -> OPCConfig:
-    """Build a complete OPCConfig from a merged raw dict."""
+    """Build a complete OPCConfig from a merged raw dict.
+
+    Warns on unknown top-level sections.
+    """
+    unknown_sections = set(raw.keys()) - set(_SECTION_MAP.keys())
+    for name in sorted(unknown_sections):
+        logger.warning("Config: unknown section [%s] — ignored", name)
+
     sections = {}
     for name, cls in _SECTION_MAP.items():
         section_raw = raw.get(name, {})
-        sections[name] = build_section(cls, section_raw)
+        sections[name] = build_section(cls, section_raw, section_name=name)
     return OPCConfig(**sections)

--- a/scripts/core/config/handlers.py
+++ b/scripts/core/config/handlers.py
@@ -72,12 +72,25 @@ def load_config_file(paths: list[Path]) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 def read_env_overrides() -> dict[str, Any]:
-    """Read known env vars and return as a nested dict matching TOML structure."""
+    """Read known env vars and return as a nested dict matching TOML structure.
+
+    Invalid values (e.g. non-numeric for int fields) are logged and skipped
+    rather than crashing config loading.
+    """
+    import logging
+    _logger = logging.getLogger(__name__)
+
     result: dict[str, Any] = {}
     for env_var, section, key, cast in _ENV_OVERRIDES:
         value = os.environ.get(env_var)
         if value is not None:
-            result.setdefault(section, {})[key] = cast(value)
+            try:
+                result.setdefault(section, {})[key] = cast(value)
+            except (ValueError, TypeError):
+                _logger.warning(
+                    "Config: env var %s=%r cannot be cast to %s — ignored",
+                    env_var, value, cast.__name__,
+                )
     return result
 
 

--- a/scripts/core/config/handlers.py
+++ b/scripts/core/config/handlers.py
@@ -1,0 +1,110 @@
+"""Configuration I/O handlers — file discovery, TOML loading, env var reads.
+
+All side effects (disk reads, env var access, caching) live here.
+Pure construction logic is in core.py.
+"""
+
+from __future__ import annotations
+
+import os
+import tomllib
+from pathlib import Path
+from typing import Any
+
+from scripts.core.config.core import build_config, merge_raw
+from scripts.core.config.models import OPCConfig
+
+
+# ---------------------------------------------------------------------------
+# Env var → config mapping
+# ---------------------------------------------------------------------------
+
+_ENV_OVERRIDES: list[tuple[str, str, str, type]] = [
+    # (env_var, section, key, cast_type)
+    ("PATTERN_DETECTION_INTERVAL_HOURS", "daemon", "pattern_detection_interval_hours", int),
+    ("OLLAMA_EMBED_MODEL", "embedding", "ollama_model", str),
+    ("OLLAMA_HOST", "embedding", "ollama_host", str),
+    ("AGENTICA_MAX_POOL_SIZE", "database", "max_pool_size", int),
+]
+
+
+# ---------------------------------------------------------------------------
+# File discovery
+# ---------------------------------------------------------------------------
+
+def discover_config_paths() -> list[Path]:
+    """Return config file paths in precedence order (first wins)."""
+    paths: list[Path] = []
+
+    env_path = os.environ.get("OPC_CONFIG")
+    if env_path:
+        paths.append(Path(env_path))
+
+    # Walk up from this file to find opc.toml at project root
+    current = Path(__file__).resolve().parent
+    for _ in range(5):
+        candidate = current / "opc.toml"
+        if candidate.is_file():
+            paths.append(candidate)
+            break
+        current = current.parent
+
+    paths.append(Path.home() / ".config" / "opc" / "config.toml")
+
+    return paths
+
+
+# ---------------------------------------------------------------------------
+# TOML loading
+# ---------------------------------------------------------------------------
+
+def load_config_file(paths: list[Path]) -> dict[str, Any]:
+    """Load the first existing TOML file from the path list."""
+    for path in paths:
+        if path.is_file():
+            with open(path, "rb") as f:
+                return tomllib.load(f)
+    return {}
+
+
+# ---------------------------------------------------------------------------
+# Env var reading
+# ---------------------------------------------------------------------------
+
+def read_env_overrides() -> dict[str, Any]:
+    """Read known env vars and return as a nested dict matching TOML structure."""
+    result: dict[str, Any] = {}
+    for env_var, section, key, cast in _ENV_OVERRIDES:
+        value = os.environ.get(env_var)
+        if value is not None:
+            result.setdefault(section, {})[key] = cast(value)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Cached loader (the one side-effectful piece)
+# ---------------------------------------------------------------------------
+
+_cached_config: OPCConfig | None = None
+
+
+def get_config(*, reload: bool = False) -> OPCConfig:
+    """Load and return the OPC configuration (cached after first call).
+
+    Precedence: env vars > first found TOML file > built-in defaults.
+    """
+    global _cached_config
+    if _cached_config is not None and not reload:
+        return _cached_config
+
+    file_raw = load_config_file(discover_config_paths())
+    env_raw = read_env_overrides()
+    merged = merge_raw(file_raw, env_raw)
+    _cached_config = build_config(merged)
+    return _cached_config
+
+
+def reset_config() -> None:
+    """Clear the cached config. Used in tests."""
+    global _cached_config
+    _cached_config = None

--- a/scripts/core/config/models.py
+++ b/scripts/core/config/models.py
@@ -1,0 +1,118 @@
+"""Configuration data models — frozen dataclasses with defaults.
+
+No I/O, no logic beyond computed properties. Pure data definitions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class DedupConfig:
+    threshold: float = 0.85
+
+
+@dataclass(frozen=True)
+class DaemonConfig:
+    poll_interval: int = 60
+    stale_threshold: int = 900
+    max_concurrent_extractions: int = 4
+    max_retries: int = 5
+    extraction_timeout: int = 1800
+    pattern_detection_interval_hours: int = 6
+    extraction_model: str = "sonnet"
+    extraction_max_turns: int = 15
+
+
+@dataclass(frozen=True)
+class RerankerConfig:
+    project_weight: float = 0.15
+    recency_weight: float = 0.05
+    confidence_weight: float = 0.05
+    recall_weight: float = 0.05
+    type_affinity_weight: float = 0.05
+    tag_overlap_weight: float = 0.05
+    pattern_weight: float = 0.05
+    recency_half_life_days: float = 45.0
+    recall_log2_normalizer: int = 4
+    rrf_scale_factor: float = 60.0
+
+    @property
+    def total_signal_weight(self) -> float:
+        return (
+            self.project_weight
+            + self.recency_weight
+            + self.confidence_weight
+            + self.recall_weight
+            + self.type_affinity_weight
+            + self.tag_overlap_weight
+            + self.pattern_weight
+        )
+
+
+@dataclass(frozen=True)
+class PatternsConfig:
+    min_cluster_size: int = 5
+    min_samples: int = 3
+    min_confidence: float = 0.3
+    tag_noise_percentile: int = 10
+    min_cooccurrence: float = 1.0
+    min_component_size: int = 5
+    overlap_threshold: float = 0.3
+    max_cluster_size: int = 20
+    anti_pattern_threshold: float = 0.6
+    problem_solution_threshold: float = 0.4
+    expertise_threshold: float = 0.6
+    tool_cluster_threshold: float = 0.7
+    cross_project_days: int = 30
+    cross_project_contexts: int = 4
+    cross_project_sessions: int = 3
+
+
+@dataclass(frozen=True)
+class RecallConfig:
+    default_k: int = 5
+    rrf_k: int = 60
+    max_expansion_terms: int = 5
+    recall_boost_multiplier: float = 0.002
+    bm25_normalization_divisor: float = 25.0
+
+
+@dataclass(frozen=True)
+class EmbeddingConfig:
+    ollama_model: str = "nomic-embed-text"
+    ollama_host: str = "http://localhost:11434"
+    re_embed_batch_size: int = 64
+
+
+@dataclass(frozen=True)
+class QueryExpansionConfig:
+    idf_max_age_hours: int = 24
+    idf_drift_threshold: float = 0.10
+
+
+@dataclass(frozen=True)
+class ArchivalConfig:
+    compress_timeout: int = 300
+    upload_timeout: int = 300
+    skip_recent_minutes: int = 10
+
+
+@dataclass(frozen=True)
+class DatabaseConfig:
+    max_pool_size: int = 10
+    max_archival_context: int = 10
+
+
+@dataclass(frozen=True)
+class OPCConfig:
+    dedup: DedupConfig = field(default_factory=DedupConfig)
+    daemon: DaemonConfig = field(default_factory=DaemonConfig)
+    reranker: RerankerConfig = field(default_factory=RerankerConfig)
+    patterns: PatternsConfig = field(default_factory=PatternsConfig)
+    recall: RecallConfig = field(default_factory=RecallConfig)
+    embedding: EmbeddingConfig = field(default_factory=EmbeddingConfig)
+    query_expansion: QueryExpansionConfig = field(default_factory=QueryExpansionConfig)
+    archival: ArchivalConfig = field(default_factory=ArchivalConfig)
+    database: DatabaseConfig = field(default_factory=DatabaseConfig)

--- a/scripts/core/db/embedding_providers.py
+++ b/scripts/core/db/embedding_providers.py
@@ -443,9 +443,6 @@ class OllamaEmbeddingProvider(EmbeddingProvider):
     - OLLAMA_EMBED_MODEL: Model name (default: nomic-embed-text)
     """
 
-    DEFAULT_MODEL = "nomic-embed-text"
-    DEFAULT_HOST = "http://localhost:11434"
-
     MODELS = {
         "nomic-embed-text": 768,
         "nomic-embed-text-v1.5": 768,
@@ -461,8 +458,12 @@ class OllamaEmbeddingProvider(EmbeddingProvider):
         host: str | None = None,
         verify_tls: bool = True,
     ):
-        self.model = model or os.getenv("OLLAMA_EMBED_MODEL", self.DEFAULT_MODEL)
-        self.host = host or os.getenv("OLLAMA_HOST", self.DEFAULT_HOST)
+        # Defaults from opc.toml [embedding], resolved at instantiation time
+        from scripts.core.config import get_config
+        _emb_cfg = get_config().embedding
+
+        self.model = model or os.getenv("OLLAMA_EMBED_MODEL", _emb_cfg.ollama_model)
+        self.host = host or os.getenv("OLLAMA_HOST", _emb_cfg.ollama_host)
         self.verify_tls = verify_tls
         _validate_ollama_host(self.host)
         self._client = httpx.AsyncClient(timeout=30.0, verify=verify_tls)

--- a/scripts/core/db/postgres_pool.py
+++ b/scripts/core/db/postgres_pool.py
@@ -183,8 +183,11 @@ def resolve_connection_url(
 
 def _get_pool_config() -> dict[str, int]:
     """Read pool config from environment and delegate to build_pool_config."""
+    from scripts.core.config import get_config
     return build_pool_config(
-        max_size_str=os.environ.get("AGENTICA_MAX_POOL_SIZE", "10"),
+        max_size_str=os.environ.get(
+            "AGENTICA_MAX_POOL_SIZE", str(get_config().database.max_pool_size)
+        ),
     )
 
 

--- a/scripts/core/duplicate_density.py
+++ b/scripts/core/duplicate_density.py
@@ -162,9 +162,13 @@ def plot_density(
     similarities: np.ndarray,
     threshold_stats: list[dict],
     output_path: str,
-    current_threshold: float = 0.92,
+    current_threshold: float | None = None,
 ) -> None:
     """Generate a histogram of pairwise similarities with threshold annotations."""
+    if current_threshold is None:
+        from scripts.core.config import get_config
+        current_threshold = get_config().dedup.threshold
+
     import matplotlib
     matplotlib.use("Agg")
     import matplotlib.pyplot as plt
@@ -246,9 +250,13 @@ def format_summary(
     n_learnings: int,
     n_pairs: int,
     threshold_stats: list[dict],
-    current_threshold: float = 0.92,
+    current_threshold: float | None = None,
 ) -> str:
     """Format a text summary of the density analysis."""
+    if current_threshold is None:
+        from scripts.core.config import get_config
+        current_threshold = get_config().dedup.threshold
+
     lines = [
         "Near-Duplicate Density Report",
         f"Generated: {datetime.now(UTC).isoformat()}",

--- a/scripts/core/duplicate_density.py
+++ b/scripts/core/duplicate_density.py
@@ -56,8 +56,12 @@ from scripts.core.db.postgres_pool import close_pool, get_connection  # noqa: E4
 async def fetch_embeddings(conn: Any) -> tuple[list[str], list[str], np.ndarray]:
     """Fetch all active learning IDs, content previews, and embeddings.
 
+    Groups by embedding dimension and uses only the dominant dimension group.
+    Mixed-provider corpora (e.g. 1024-dim BGE + 768-dim Ollama) are handled
+    by analyzing the largest group and reporting skipped counts.
+
     Returns:
-        (ids, previews, embedding_matrix) where embedding_matrix is (N, 1024)
+        (ids, previews, embedding_matrix) where embedding_matrix is (N, D)
     """
     rows = await conn.fetch(
         """
@@ -69,17 +73,34 @@ async def fetch_embeddings(conn: Any) -> tuple[list[str], list[str], np.ndarray]
         """
     )
 
-    ids: list[str] = []
-    previews: list[str] = []
-    vectors: list[list[float]] = []
-
+    # Parse and group by dimension
+    by_dim: dict[int, tuple[list[str], list[str], list[list[float]]]] = {}
     for row in rows:
         raw = row["embedding"]
-        # pgvector returns "[0.1,0.2,...]" string
         vec = [float(x) for x in raw.strip("[]").split(",")]
-        ids.append(row["id"])
-        previews.append(row["preview"])
-        vectors.append(vec)
+        dim = len(vec)
+        if dim not in by_dim:
+            by_dim[dim] = ([], [], [])
+        ids_list, prev_list, vec_list = by_dim[dim]
+        ids_list.append(row["id"])
+        prev_list.append(row["preview"])
+        vec_list.append(vec)
+
+    if not by_dim:
+        return [], [], np.array([], dtype=np.float32)
+
+    # Use the largest dimension group
+    dominant_dim = max(by_dim, key=lambda d: len(by_dim[d][0]))
+    ids, previews, vectors = by_dim[dominant_dim]
+
+    skipped = sum(len(v[0]) for d, v in by_dim.items() if d != dominant_dim)
+    if skipped > 0:
+        other_dims = {d: len(v[0]) for d, v in by_dim.items() if d != dominant_dim}
+        print(
+            f"Using {len(ids)} embeddings (dim={dominant_dim}), "
+            f"skipped {skipped} with different dimensions: {other_dims}",
+            file=sys.stderr,
+        )
 
     matrix = np.array(vectors, dtype=np.float32)
     return ids, previews, matrix

--- a/scripts/core/duplicate_density.py
+++ b/scripts/core/duplicate_density.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""Near-duplicate density analysis for the memory system.
+
+Fetches all active learning embeddings from PostgreSQL, computes pairwise
+cosine similarities, and produces a histogram showing the distribution of
+similarity scores. This helps determine the optimal dedup threshold.
+
+USAGE:
+    # Generate histogram PNG (default: output to stdout path)
+    uv run python scripts/core/duplicate_density.py
+
+    # Save to specific path
+    uv run python scripts/core/duplicate_density.py --output /tmp/dedup_density.png
+
+    # Also dump the pairs above a threshold as JSON
+    uv run python scripts/core/duplicate_density.py --dump-pairs 0.85
+
+    # Text-only summary (no graph)
+    uv run python scripts/core/duplicate_density.py --text-only
+
+Environment:
+    DATABASE_URL or CONTINUOUS_CLAUDE_DB_URL - PostgreSQL connection string
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from dotenv import load_dotenv
+
+# Load .env files
+global_env = Path.home() / ".claude" / ".env"
+if global_env.exists():
+    load_dotenv(global_env)
+load_dotenv()
+
+# Add repository root to path
+repo_root = str(Path(__file__).parent.parent.parent)
+if repo_root not in sys.path:
+    sys.path.insert(0, repo_root)
+
+from scripts.core.db.postgres_pool import close_pool, get_connection  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Data fetching
+# ---------------------------------------------------------------------------
+
+async def fetch_embeddings(conn: Any) -> tuple[list[str], list[str], np.ndarray]:
+    """Fetch all active learning IDs, content previews, and embeddings.
+
+    Returns:
+        (ids, previews, embedding_matrix) where embedding_matrix is (N, 1024)
+    """
+    rows = await conn.fetch(
+        """
+        SELECT id::text, LEFT(content, 120) AS preview, embedding::text
+        FROM archival_memory
+        WHERE superseded_by IS NULL
+          AND embedding IS NOT NULL
+        ORDER BY created_at
+        """
+    )
+
+    ids: list[str] = []
+    previews: list[str] = []
+    vectors: list[list[float]] = []
+
+    for row in rows:
+        raw = row["embedding"]
+        # pgvector returns "[0.1,0.2,...]" string
+        vec = [float(x) for x in raw.strip("[]").split(",")]
+        ids.append(row["id"])
+        previews.append(row["preview"])
+        vectors.append(vec)
+
+    matrix = np.array(vectors, dtype=np.float32)
+    return ids, previews, matrix
+
+
+# ---------------------------------------------------------------------------
+# Similarity computation
+# ---------------------------------------------------------------------------
+
+def compute_pairwise_cosine(matrix: np.ndarray) -> np.ndarray:
+    """Compute pairwise cosine similarity for an (N, D) matrix.
+
+    Returns the upper-triangle values as a 1D array (N*(N-1)/2 elements).
+    """
+    # L2 normalize rows
+    norms = np.linalg.norm(matrix, axis=1, keepdims=True)
+    norms = np.where(norms == 0, 1.0, norms)  # avoid division by zero
+    normed = matrix / norms
+
+    # Cosine similarity matrix
+    sim_matrix = normed @ normed.T
+
+    # Extract upper triangle (excluding diagonal)
+    upper_indices = np.triu_indices(sim_matrix.shape[0], k=1)
+    return sim_matrix[upper_indices], upper_indices, sim_matrix
+
+
+def compute_threshold_stats(
+    similarities: np.ndarray,
+    thresholds: list[float],
+) -> list[dict]:
+    """Count pairs exceeding each threshold."""
+    total_pairs = len(similarities)
+    results = []
+    for threshold in thresholds:
+        count = int(np.sum(similarities >= threshold))
+        results.append({
+            "threshold": threshold,
+            "pair_count": count,
+            "pair_pct": round(100.0 * count / total_pairs, 4) if total_pairs else 0.0,
+        })
+    return results
+
+
+def find_pairs_above(
+    similarities: np.ndarray,
+    upper_indices: tuple,
+    threshold: float,
+    ids: list[str],
+    previews: list[str],
+    limit: int = 100,
+) -> list[dict]:
+    """Return the top pairs above a threshold, sorted by similarity descending."""
+    mask = similarities >= threshold
+    matching_sims = similarities[mask]
+    matching_i = upper_indices[0][mask]
+    matching_j = upper_indices[1][mask]
+
+    # Sort descending by similarity
+    sort_idx = np.argsort(-matching_sims)[:limit]
+
+    pairs = []
+    for idx in sort_idx:
+        i, j = int(matching_i[idx]), int(matching_j[idx])
+        pairs.append({
+            "similarity": round(float(matching_sims[idx]), 4),
+            "id_a": ids[i],
+            "id_b": ids[j],
+            "preview_a": previews[i],
+            "preview_b": previews[j],
+        })
+    return pairs
+
+
+# ---------------------------------------------------------------------------
+# Visualization
+# ---------------------------------------------------------------------------
+
+def plot_density(
+    similarities: np.ndarray,
+    threshold_stats: list[dict],
+    output_path: str,
+    current_threshold: float = 0.92,
+) -> None:
+    """Generate a histogram of pairwise similarities with threshold annotations."""
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    import matplotlib.ticker as ticker
+
+    fig, (ax_full, ax_tail) = plt.subplots(1, 2, figsize=(16, 6))
+    fig.suptitle(
+        f"Near-Duplicate Density Analysis  ({len(similarities):,} pairs)",
+        fontsize=14,
+        fontweight="bold",
+    )
+
+    # --- Left panel: full distribution (0.0 to 1.0) ---
+    ax_full.hist(
+        similarities,
+        bins=200,
+        color="#4a90d9",
+        alpha=0.8,
+        edgecolor="none",
+    )
+    ax_full.set_xlabel("Cosine Similarity")
+    ax_full.set_ylabel("Pair Count")
+    ax_full.set_title("Full Distribution")
+    ax_full.set_xlim(-0.1, 1.05)
+    ax_full.yaxis.set_major_formatter(ticker.FuncFormatter(lambda x, _: f"{x:,.0f}"))
+
+    # --- Right panel: tail distribution (0.5 to 1.0) ---
+    tail_mask = similarities >= 0.50
+    tail_sims = similarities[tail_mask]
+
+    if len(tail_sims) > 0:
+        ax_tail.hist(
+            tail_sims,
+            bins=100,
+            color="#4a90d9",
+            alpha=0.8,
+            edgecolor="none",
+        )
+
+    # Annotate thresholds
+    colors = {
+        0.80: "#2ecc71",
+        0.85: "#f39c12",
+        0.90: "#e74c3c",
+        0.92: "#9b59b6",
+        0.95: "#e91e63",
+        0.98: "#1a1a2e",
+    }
+
+    for stat in threshold_stats:
+        t = stat["threshold"]
+        color = colors.get(t, "#666666")
+        label = f"{t:.2f}: {stat['pair_count']:,} pairs"
+        style = "--" if t != current_threshold else "-"
+        width = 1.5 if t != current_threshold else 3.0
+
+        ax_tail.axvline(
+            x=t, color=color, linestyle=style, linewidth=width,
+            label=label, alpha=0.9,
+        )
+
+    ax_tail.set_xlabel("Cosine Similarity")
+    ax_tail.set_ylabel("Pair Count")
+    ax_tail.set_title("Tail Distribution (≥0.50)")
+    ax_tail.set_xlim(0.49, 1.01)
+    ax_tail.legend(loc="upper left", fontsize=9)
+    ax_tail.yaxis.set_major_formatter(ticker.FuncFormatter(lambda x, _: f"{x:,.0f}"))
+
+    plt.tight_layout()
+    plt.savefig(output_path, dpi=150, bbox_inches="tight")
+    plt.close()
+
+
+# ---------------------------------------------------------------------------
+# Text summary
+# ---------------------------------------------------------------------------
+
+def format_summary(
+    n_learnings: int,
+    n_pairs: int,
+    threshold_stats: list[dict],
+    current_threshold: float = 0.92,
+) -> str:
+    """Format a text summary of the density analysis."""
+    lines = [
+        "Near-Duplicate Density Report",
+        f"Generated: {datetime.now(UTC).isoformat()}",
+        "",
+        f"Learnings analyzed: {n_learnings:,}",
+        f"Total pairs:        {n_pairs:,}",
+        "",
+        "Threshold  │  Pairs Above  │  % of Total",
+        "───────────┼───────────────┼─────────────",
+    ]
+    for stat in threshold_stats:
+        marker = " ◄── current" if stat["threshold"] == current_threshold else ""
+        lines.append(
+            f"  {stat['threshold']:.2f}     │  {stat['pair_count']:>11,}  │  {stat['pair_pct']:>8.4f}%{marker}"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Near-duplicate density analysis for memory learnings"
+    )
+    parser.add_argument(
+        "--output", "-o",
+        default=None,
+        help="Output path for histogram PNG (default: thoughts/shared/duplicate_density.png)",
+    )
+    parser.add_argument(
+        "--dump-pairs",
+        type=float,
+        default=None,
+        metavar="THRESHOLD",
+        help="Dump pairs above this threshold as JSON to stdout",
+    )
+    parser.add_argument(
+        "--text-only",
+        action="store_true",
+        help="Print text summary only, no graph",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=100,
+        help="Max pairs to dump (default: 100)",
+    )
+    return parser
+
+
+async def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    output_path = args.output or str(
+        Path(repo_root) / "thoughts" / "shared" / "duplicate_density.png"
+    )
+
+    print("Fetching embeddings from PostgreSQL...", file=sys.stderr)
+    async with get_connection() as conn:
+        ids, previews, matrix = await fetch_embeddings(conn)
+    await close_pool()
+
+    n = len(ids)
+    if n < 2:
+        print(f"Only {n} learnings with embeddings — need at least 2.", file=sys.stderr)
+        return 1
+
+    print(f"Computing pairwise cosine similarity for {n:,} learnings...", file=sys.stderr)
+    similarities, upper_indices, _ = compute_pairwise_cosine(matrix)
+    n_pairs = len(similarities)
+
+    thresholds = [0.80, 0.85, 0.90, 0.92, 0.95, 0.98]
+    threshold_stats = compute_threshold_stats(similarities, thresholds)
+
+    # Print text summary
+    summary = format_summary(n, n_pairs, threshold_stats)
+    print(summary)
+
+    # Generate graph unless text-only
+    if not args.text_only:
+        print(f"Generating histogram → {output_path}", file=sys.stderr)
+        Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+        plot_density(similarities, threshold_stats, output_path)
+        print(f"Saved: {output_path}", file=sys.stderr)
+
+    # Dump pairs if requested
+    if args.dump_pairs is not None:
+        pairs = find_pairs_above(
+            similarities, upper_indices, args.dump_pairs,
+            ids, previews, args.limit,
+        )
+        print(json.dumps(pairs, indent=2))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/scripts/core/memory_daemon.py
+++ b/scripts/core/memory_daemon.py
@@ -90,12 +90,15 @@ def _normalize_project(path_str: str) -> str | None:
         return name or None
     return p.name or None
 
-# Global config
-POLL_INTERVAL = 60  # seconds
-STALE_THRESHOLD = 900  # 15 minutes in seconds
-MAX_CONCURRENT_EXTRACTIONS = 4
-MAX_RETRIES = 5
-EXTRACTION_TIMEOUT = 1800  # 30 minutes - kill stuck extraction subprocesses
+# Config from opc.toml [daemon]
+from scripts.core.config import get_config as _get_config
+_daemon_cfg = _get_config().daemon
+
+POLL_INTERVAL = _daemon_cfg.poll_interval
+STALE_THRESHOLD = _daemon_cfg.stale_threshold
+MAX_CONCURRENT_EXTRACTIONS = _daemon_cfg.max_concurrent_extractions
+MAX_RETRIES = _daemon_cfg.max_retries
+EXTRACTION_TIMEOUT = _daemon_cfg.extraction_timeout
 PID_FILE = Path.home() / ".claude" / "memory-daemon.pid"
 LOG_FILE = Path.home() / ".claude" / "memory-daemon.log"
 
@@ -105,9 +108,7 @@ pending_queue: list[tuple[str, str, str | None]] = []  # [(session_id, project, 
 
 # Pattern detection state (module-level for daemon process)
 # Interval configurable via PATTERN_DETECTION_INTERVAL_HOURS env var
-_PATTERN_DETECTION_INTERVAL = int(
-    os.environ.get("PATTERN_DETECTION_INTERVAL_HOURS", "6")
-) * 3600
+_PATTERN_DETECTION_INTERVAL = _daemon_cfg.pattern_detection_interval_hours * 3600
 _pattern_proc: subprocess.Popen | None = None
 _last_pattern_run: float = 0
 
@@ -536,9 +537,9 @@ Store each learning using store_learning.py with appropriate type and tags."""
         proc = subprocess.Popen(
             [
                 "claude", "-p",
-                "--model", "sonnet",
+                "--model", _daemon_cfg.extraction_model,
                 "--dangerously-skip-permissions",
-                "--max-turns", "15",
+                "--max-turns", str(_daemon_cfg.extraction_max_turns),
                 "--append-system-prompt", agent_prompt,
                 f"Extract learnings from session {session_id}. JSONL path: {jsonl_path}"
             ],

--- a/scripts/core/memory_metrics.py
+++ b/scripts/core/memory_metrics.py
@@ -245,6 +245,156 @@ async def get_dedup_stats(conn: Any) -> dict:
     }
 
 
+async def get_embedding_coverage(conn: Any) -> dict:
+    """Report what % of active learnings have valid embeddings (all-time)."""
+    row = await conn.fetchrow(
+        """
+        SELECT
+            COUNT(*) FILTER (WHERE embedding IS NOT NULL) AS with_embedding,
+            COUNT(*) FILTER (WHERE embedding IS NULL) AS without_embedding,
+            COUNT(*) AS total
+        FROM archival_memory
+        WHERE superseded_by IS NULL
+        """
+    )
+    total = row["total"]
+    return {
+        "with_embedding": row["with_embedding"],
+        "without_embedding": row["without_embedding"],
+        "coverage_pct": round(100.0 * row["with_embedding"] / total, 1) if total else 0.0,
+    }
+
+
+async def get_feedback_velocity(conn: Any) -> dict:
+    """Report feedback rate per week over the last 4 weeks (all-time table)."""
+    table_exists = await conn.fetchval(
+        "SELECT to_regclass('public.memory_feedback') IS NOT NULL"
+    )
+    if not table_exists:
+        return {"weeks": [], "avg_per_week": 0.0}
+
+    rows = await conn.fetch(
+        """
+        SELECT
+            date_trunc('week', created_at)::date AS week_start,
+            COUNT(*) AS feedback_count,
+            COUNT(*) FILTER (WHERE helpful) AS helpful_count,
+            COUNT(*) FILTER (WHERE NOT helpful) AS not_helpful_count
+        FROM memory_feedback
+        WHERE created_at >= NOW() - INTERVAL '4 weeks'
+        GROUP BY week_start
+        ORDER BY week_start
+        """
+    )
+    weeks = [
+        {
+            "week": str(r["week_start"]),
+            "total": r["feedback_count"],
+            "helpful": r["helpful_count"],
+            "not_helpful": r["not_helpful_count"],
+        }
+        for r in rows
+    ]
+    total = sum(w["total"] for w in weeks)
+    n_weeks = max(len(weeks), 1)
+    return {
+        "weeks": weeks,
+        "avg_per_week": round(total / n_weeks, 1),
+    }
+
+
+async def get_supersession_candidates(conn: Any) -> dict:
+    """Identify learnings that are candidates for supersession/cleanup.
+
+    Criteria: active, never recalled, low confidence, older than 30 days.
+    """
+    row = await conn.fetchrow(
+        """
+        SELECT
+            COUNT(*) AS candidate_count,
+            COUNT(*) FILTER (
+                WHERE metadata->>'confidence' = 'low'
+            ) AS low_confidence,
+            COUNT(*) FILTER (
+                WHERE metadata->>'confidence' = 'medium'
+            ) AS medium_confidence,
+            COUNT(*) FILTER (
+                WHERE metadata->>'confidence' = 'high'
+            ) AS high_confidence
+        FROM archival_memory
+        WHERE superseded_by IS NULL
+          AND (recall_count = 0 OR last_recalled IS NULL)
+          AND created_at < NOW() - INTERVAL '30 days'
+        """
+    )
+    return {
+        "total_candidates": row["candidate_count"],
+        "by_confidence": {
+            "low": row["low_confidence"],
+            "medium": row["medium_confidence"],
+            "high": row["high_confidence"],
+        },
+        "criteria": "active, never recalled, older than 30 days",
+    }
+
+
+async def get_recall_frequency(conn: Any) -> dict:
+    """Report recall usage across sessions (all-time).
+
+    Uses recall_count on archival_memory to infer how recall is distributed.
+    """
+    row = await conn.fetchrow(
+        """
+        SELECT
+            COUNT(*) FILTER (WHERE recall_count > 0) AS recalled_learnings,
+            COUNT(*) AS total_active,
+            COALESCE(SUM(recall_count), 0) AS total_recalls,
+            COALESCE(AVG(recall_count) FILTER (WHERE recall_count > 0), 0) AS avg_recalls_when_used,
+            COALESCE(MAX(recall_count), 0) AS max_recalls
+        FROM archival_memory
+        WHERE superseded_by IS NULL
+        """
+    )
+    total = row["total_active"]
+    recalled = row["recalled_learnings"]
+    return {
+        "recalled_learnings": recalled,
+        "total_active": total,
+        "recall_rate_pct": round(100.0 * recalled / total, 1) if total else 0.0,
+        "total_recall_events": int(row["total_recalls"]),
+        "avg_recalls_per_recalled_learning": round(float(row["avg_recalls_when_used"]), 1),
+        "max_recalls_single_learning": int(row["max_recalls"]),
+    }
+
+
+async def get_type_recall_correlation(conn: Any) -> dict:
+    """Compare learning_type distribution: stored vs. actually recalled."""
+    rows = await conn.fetch(
+        """
+        SELECT
+            COALESCE(metadata->>'learning_type', 'unset') AS learning_type,
+            COUNT(*) AS total,
+            COUNT(*) FILTER (WHERE recall_count > 0) AS recalled,
+            COALESCE(SUM(recall_count), 0) AS total_recalls
+        FROM archival_memory
+        WHERE superseded_by IS NULL
+        GROUP BY learning_type
+        ORDER BY total DESC
+        """
+    )
+    result = {}
+    for r in rows:
+        total = r["total"]
+        recalled = r["recalled"]
+        result[r["learning_type"]] = {
+            "stored": total,
+            "recalled": recalled,
+            "recall_rate_pct": round(100.0 * recalled / total, 1) if total else 0.0,
+            "total_recall_events": int(r["total_recalls"]),
+        }
+    return result
+
+
 async def get_extraction_stats(conn: Any) -> dict:
     """Count sessions by extraction status (all-time)."""
     row = await conn.fetchrow(
@@ -397,12 +547,17 @@ async def collect_all_metrics(
         confidence = await get_confidence_distribution(conn, start, end)
         classification = await get_classification_distribution(conn, start, end)
         dedup = await get_dedup_stats(conn)  # always all-time
+        embedding_cov = await get_embedding_coverage(conn)  # always all-time
         extraction = await get_extraction_stats(conn)  # always all-time
         stale = await get_stale_learnings(conn, start, end)
         tags = await get_top_tags(conn)  # always all-time
         superseded = await get_superseded_stats(conn)  # always all-time
         temporal = await get_temporal_stats(conn)  # always all-time
         feedback = await get_feedback_stats(conn)  # always all-time
+        feedback_vel = await get_feedback_velocity(conn)  # always all-time
+        supersession_cand = await get_supersession_candidates(conn)  # always all-time
+        recall_freq = await get_recall_frequency(conn)  # always all-time
+        type_recall = await get_type_recall_correlation(conn)  # always all-time
 
     period = None
     if start or end:
@@ -431,12 +586,17 @@ async def collect_all_metrics(
         "confidence_distribution": confidence,
         "classification_distribution": classification,
         "dedup_stats_alltime": dedup,
+        "embedding_coverage_alltime": embedding_cov,
         "extraction_stats_alltime": extraction,
         "stale_learnings": stale,
         "top_tags_alltime": tags,
         "superseded_alltime": superseded,
         "temporal_alltime": temporal,
         "feedback_alltime": feedback,
+        "feedback_velocity": feedback_vel,
+        "supersession_candidates": supersession_cand,
+        "recall_frequency": recall_freq,
+        "type_recall_correlation": type_recall,
         "version": _get_version(),
     }
 
@@ -479,10 +639,73 @@ def format_human(metrics: dict) -> str:
         lines.append(f"  {lt:28s}  {data['count']:4d}  ({data['pct']:.1f}%)")
     lines.append("")
 
+    # --- System Health ---
+    lines.append("═══ System Health ═══")
+    lines.append("")
+
+    emb = metrics.get("embedding_coverage_alltime", {})
+    lines.append(f"Embedding Coverage:  {emb.get('coverage_pct', 0):.1f}% "
+                 f"({emb.get('with_embedding', 0)} with, "
+                 f"{emb.get('without_embedding', 0)} without)")
+
     d = metrics["dedup_stats_alltime"]
-    lines.append(f"Dedup (all-time):  {d['hash_coverage_pct']:.1f}% hash coverage "
+    lines.append(f"Dedup Hash Coverage: {d['hash_coverage_pct']:.1f}% "
                  f"({d['learnings_with_content_hash']} with, "
                  f"{d['learnings_without_content_hash']} without)")
+
+    fb = metrics.get("feedback_alltime", {})
+    total_fb = fb.get("total_feedback", 0)
+    if total_fb > 0:
+        lines.append(
+            f"Feedback (all-time): {fb['helpful']} helpful, {fb['not_helpful']} not helpful "
+            f"out of {total_fb} ({fb['helpfulness_rate_pct']:.1f}% helpful), "
+            f"{fb['unique_learnings_rated']} unique learnings rated"
+        )
+    else:
+        lines.append("Feedback (all-time): No feedback recorded yet")
+
+    fv = metrics.get("feedback_velocity", {})
+    lines.append(f"Feedback Velocity:   {fv.get('avg_per_week', 0):.1f}/week (last 4 weeks)")
+
+    sc = metrics.get("supersession_candidates", {})
+    lines.append(f"Supersession Candidates: {sc.get('total_candidates', 0)} "
+                 f"(never recalled, >30d old)")
+    by_conf = sc.get("by_confidence", {})
+    if any(by_conf.values()):
+        lines.append(f"  low: {by_conf.get('low', 0)}, "
+                     f"medium: {by_conf.get('medium', 0)}, "
+                     f"high: {by_conf.get('high', 0)}")
+    lines.append("")
+
+    # --- Recall Quality ---
+    lines.append("═══ Recall Quality ═══")
+    lines.append("")
+
+    rf = metrics.get("recall_frequency", {})
+    lines.append(f"Recall Rate:  {rf.get('recalled_learnings', 0)}/{rf.get('total_active', 0)} "
+                 f"ever recalled ({rf.get('recall_rate_pct', 0):.1f}%)")
+    lines.append(f"  Total recall events: {rf.get('total_recall_events', 0)}, "
+                 f"avg per recalled: {rf.get('avg_recalls_per_recalled_learning', 0):.1f}, "
+                 f"max: {rf.get('max_recalls_single_learning', 0)}")
+
+    s = metrics["stale_learnings"]
+    lines.append(f"Stale:  {s['never_recalled']}/{s['total_active']} never recalled "
+                 f"({s['never_recalled_pct']:.1f}%)")
+
+    trc = metrics.get("type_recall_correlation", {})
+    if trc:
+        lines.append("")
+        lines.append("Type vs Recall:")
+        lines.append(f"  {'Type':28s}  {'Stored':>6s}  {'Recalled':>8s}  {'Rate':>6s}  {'Events':>6s}")
+        for lt, data in trc.items():
+            lines.append(
+                f"  {lt:28s}  {data['stored']:6d}  {data['recalled']:8d}  "
+                f"{data['recall_rate_pct']:5.1f}%  {data['total_recall_events']:6d}"
+            )
+    lines.append("")
+
+    # --- Storage & Extraction ---
+    lines.append("═══ Storage & Extraction ═══")
     lines.append("")
 
     e = metrics["extraction_stats_alltime"]
@@ -493,9 +716,9 @@ def format_human(metrics: dict) -> str:
     lines.append(f"  Learnings/Extraction:  {lpe:.2f}")
     lines.append("")
 
-    s = metrics["stale_learnings"]
-    lines.append(f"Stale:  {s['never_recalled']}/{s['total_active']} never recalled "
-                 f"({s['never_recalled_pct']:.1f}%)")
+    sup = metrics["superseded_alltime"]
+    lines.append(f"Superseded (all-time):  {sup['superseded_count']}/{sup['total_learnings']} "
+                 f"({sup['superseded_pct']:.1f}%)")
     lines.append("")
 
     lines.append("Top Tags (all-time):")
@@ -503,27 +726,10 @@ def format_human(metrics: dict) -> str:
         lines.append(f"  {tag_data['tag']:20s}  {tag_data['count']:4d}")
     lines.append("")
 
-    sup = metrics["superseded_alltime"]
-    lines.append(f"Superseded (all-time):  {sup['superseded_count']}/{sup['total_learnings']} "
-                 f"({sup['superseded_pct']:.1f}%)")
-    lines.append("")
-
     tmp = metrics["temporal_alltime"]
     lines.append(f"Temporal (all-time):  oldest {tmp['oldest_learning']}")
     lines.append(f"           newest {tmp['newest_learning']}")
     lines.append(f"           last 7d: {tmp['last_7_days']},  last 30d: {tmp['last_30_days']}")
-    lines.append("")
-
-    fb = metrics.get("feedback_alltime", {})
-    total_fb = fb.get("total_feedback", 0)
-    if total_fb > 0:
-        lines.append(
-            f"Feedback (all-time):  {fb['helpful']} helpful, {fb['not_helpful']} not helpful "
-            f"out of {total_fb} ({fb['helpfulness_rate_pct']:.1f}% helpful), "
-            f"{fb['unique_learnings_rated']} unique learnings rated"
-        )
-    else:
-        lines.append("Feedback (all-time):  No feedback recorded yet")
 
     return "\n".join(lines)
 

--- a/scripts/core/memory_metrics.py
+++ b/scripts/core/memory_metrics.py
@@ -371,8 +371,12 @@ async def get_recall_frequency(conn: Any) -> dict:
             WHERE superseded_by IS NULL
             """
         )
-    except Exception:
-        return dict(_RECALL_FREQ_UNAVAILABLE)
+    except Exception as e:
+        # Only degrade for schema-compatibility issues (missing column).
+        # asyncpg raises UndefinedColumnError; check by name to avoid import.
+        if "UndefinedColumn" in type(e).__name__ or "column" in str(e).lower():
+            return {**_RECALL_FREQ_UNAVAILABLE, "note": f"schema degraded: {e}"}
+        raise
     total = row["total_active"]
     recalled = row["recalled_learnings"]
     return {
@@ -404,8 +408,10 @@ async def get_type_recall_correlation(conn: Any) -> dict:
             ORDER BY total DESC
             """
         )
-    except Exception:
-        return {}
+    except Exception as e:
+        if "UndefinedColumn" in type(e).__name__ or "column" in str(e).lower():
+            return {}
+        raise
     result = {}
     for r in rows:
         total = r["total"]

--- a/scripts/core/memory_metrics.py
+++ b/scripts/core/memory_metrics.py
@@ -296,10 +296,10 @@ async def get_feedback_velocity(conn: Any) -> dict:
         for r in rows
     ]
     total = sum(w["total"] for w in weeks)
-    n_weeks = max(len(weeks), 1)
+    window_weeks = 4  # fixed window, not len(weeks) which omits zero-feedback weeks
     return {
         "weeks": weeks,
-        "avg_per_week": round(total / n_weeks, 1),
+        "avg_per_week": round(total / window_weeks, 1),
     }
 
 
@@ -340,23 +340,39 @@ async def get_supersession_candidates(conn: Any) -> dict:
     }
 
 
+_RECALL_FREQ_UNAVAILABLE = {
+    "recalled_learnings": 0,
+    "total_active": 0,
+    "recall_rate_pct": 0.0,
+    "total_recall_events": 0,
+    "avg_recalls_per_recalled_learning": 0.0,
+    "max_recalls_single_learning": 0,
+    "note": "recall_count column not available",
+}
+
+
 async def get_recall_frequency(conn: Any) -> dict:
     """Report recall usage across sessions (all-time).
 
-    Uses recall_count on archival_memory to infer how recall is distributed.
+    Uses recall_count on archival_memory. Degrades gracefully if the column
+    is missing on older schema versions.
     """
-    row = await conn.fetchrow(
-        """
-        SELECT
-            COUNT(*) FILTER (WHERE recall_count > 0) AS recalled_learnings,
-            COUNT(*) AS total_active,
-            COALESCE(SUM(recall_count), 0) AS total_recalls,
-            COALESCE(AVG(recall_count) FILTER (WHERE recall_count > 0), 0) AS avg_recalls_when_used,
-            COALESCE(MAX(recall_count), 0) AS max_recalls
-        FROM archival_memory
-        WHERE superseded_by IS NULL
-        """
-    )
+    try:
+        row = await conn.fetchrow(
+            """
+            SELECT
+                COUNT(*) FILTER (WHERE recall_count > 0) AS recalled_learnings,
+                COUNT(*) AS total_active,
+                COALESCE(SUM(recall_count), 0) AS total_recalls,
+                COALESCE(AVG(recall_count) FILTER (WHERE recall_count > 0), 0)
+                    AS avg_recalls_when_used,
+                COALESCE(MAX(recall_count), 0) AS max_recalls
+            FROM archival_memory
+            WHERE superseded_by IS NULL
+            """
+        )
+    except Exception:
+        return dict(_RECALL_FREQ_UNAVAILABLE)
     total = row["total_active"]
     recalled = row["recalled_learnings"]
     return {
@@ -370,20 +386,26 @@ async def get_recall_frequency(conn: Any) -> dict:
 
 
 async def get_type_recall_correlation(conn: Any) -> dict:
-    """Compare learning_type distribution: stored vs. actually recalled."""
-    rows = await conn.fetch(
-        """
-        SELECT
-            COALESCE(metadata->>'learning_type', 'unset') AS learning_type,
-            COUNT(*) AS total,
-            COUNT(*) FILTER (WHERE recall_count > 0) AS recalled,
-            COALESCE(SUM(recall_count), 0) AS total_recalls
-        FROM archival_memory
-        WHERE superseded_by IS NULL
-        GROUP BY learning_type
-        ORDER BY total DESC
-        """
-    )
+    """Compare learning_type distribution: stored vs. actually recalled.
+
+    Degrades gracefully if recall_count column is missing.
+    """
+    try:
+        rows = await conn.fetch(
+            """
+            SELECT
+                COALESCE(metadata->>'learning_type', 'unset') AS learning_type,
+                COUNT(*) AS total,
+                COUNT(*) FILTER (WHERE recall_count > 0) AS recalled,
+                COALESCE(SUM(recall_count), 0) AS total_recalls
+            FROM archival_memory
+            WHERE superseded_by IS NULL
+            GROUP BY learning_type
+            ORDER BY total DESC
+            """
+        )
+    except Exception:
+        return {}
     result = {}
     for r in rows:
         total = r["total"]

--- a/scripts/core/memory_metrics.py
+++ b/scripts/core/memory_metrics.py
@@ -304,9 +304,11 @@ async def get_feedback_velocity(conn: Any) -> dict:
 
 
 async def get_supersession_candidates(conn: Any) -> dict:
-    """Identify learnings that are candidates for supersession/cleanup.
+    """Report aged never-recalled learnings, broken down by confidence.
 
-    Criteria: active, never recalled, low confidence, older than 30 days.
+    Criteria: active, never recalled, older than 30 days.
+    Not a cleanup recommendation — high-confidence items may be valid long-tail knowledge.
+    Use the confidence breakdown to prioritize review.
     """
     row = await conn.fetchrow(
         """

--- a/scripts/core/pattern_detector.py
+++ b/scripts/core/pattern_detector.py
@@ -18,6 +18,10 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 
 import numpy as np
+
+from scripts.core.config import get_config as _get_config
+
+_patterns_cfg = _get_config().patterns
 from scipy.sparse.csgraph import connected_components
 from scipy.sparse import csr_matrix
 from sklearn.cluster import HDBSCAN
@@ -61,8 +65,8 @@ class DetectedPattern:
 
 def cluster_by_embeddings(
     learnings: list[Learning],
-    min_cluster_size: int = 5,
-    min_samples: int = 3,
+    min_cluster_size: int = _patterns_cfg.min_cluster_size,
+    min_samples: int = _patterns_cfg.min_samples,
 ) -> list[list[int]]:
     """Cluster learnings by embedding similarity using HDBSCAN.
 
@@ -127,7 +131,7 @@ def compute_tag_idf(
 
 def detect_noise_tags(
     tag_idf: dict[str, float],
-    threshold_percentile: float = 10,
+    threshold_percentile: float = _patterns_cfg.tag_noise_percentile,
 ) -> set[str]:
     """Tags with IDF in the bottom percentile are noise.
 
@@ -145,8 +149,8 @@ def detect_noise_tags(
 
 def cluster_by_tags(
     learnings: list[Learning],
-    min_cooccurrence: float = 1.0,
-    min_component_size: int = 5,
+    min_cooccurrence: float = _patterns_cfg.min_cooccurrence,
+    min_component_size: int = _patterns_cfg.min_component_size,
     exclude_tags: set[str] | None = None,
     tag_idf: dict[str, float] | None = None,
 ) -> list[list[int]]:
@@ -229,7 +233,7 @@ def cluster_by_tags(
     for members in components.values():
         if len(members) < min_component_size:
             continue
-        if len(members) <= 20:
+        if len(members) <= _patterns_cfg.max_cluster_size:
             clusters.append(members)
         else:
             # Split large components by raising threshold
@@ -292,7 +296,7 @@ def _split_large_component(
 def fuse_clusters(
     embedding_clusters: list[list[int]],
     tag_clusters: list[list[int]],
-    overlap_threshold: float = 0.3,
+    overlap_threshold: float = _patterns_cfg.overlap_threshold,
 ) -> list[list[int]]:
     """Merge embedding and tag clusters using Jaccard overlap.
 
@@ -364,31 +368,35 @@ def classify_pattern_heuristic(members: list[Learning], reference_time: datetime
     # 1. Anti-pattern: all or majority FAILED_APPROACH
     if len(types) == 1 and "FAILED_APPROACH" in types:
         return "anti_pattern"
-    if types.get("FAILED_APPROACH", 0) / total > 0.6:
+    if types.get("FAILED_APPROACH", 0) / total > _patterns_cfg.anti_pattern_threshold:
         return "anti_pattern"
 
     # 2. Problem-solution: both ERROR_FIX and WORKING_SOLUTION present, combined >=40%
     error_fix = types.get("ERROR_FIX", 0)
     working_sol = types.get("WORKING_SOLUTION", 0)
-    if error_fix > 0 and working_sol > 0 and (error_fix + working_sol) / total >= 0.4:
+    if error_fix > 0 and working_sol > 0 and (error_fix + working_sol) / total >= _patterns_cfg.problem_solution_threshold:
         return "problem_solution"
 
     # 3. Expertise: temporally concentrated + type-homogeneous + context-diverse + multi-session
     now = reference_time or datetime.now(UTC)
-    recent = [m for m in members if (now - m.created_at).total_seconds() <= 30 * 24 * 3600]
+    recent = [
+        m for m in members
+        if (now - m.created_at).total_seconds() <= _patterns_cfg.cross_project_days * 24 * 3600
+    ]
     max_type_count = max(types.values())
-    if (len(recent) >= len(members) * 0.6
-            and max_type_count / total >= 0.6
-            and len(contexts) >= 4
-            and len(sessions) >= 3):
+    if (len(recent) >= len(members) * _patterns_cfg.expertise_threshold
+            and max_type_count / total >= _patterns_cfg.expertise_threshold
+            and len(contexts) >= _patterns_cfg.cross_project_contexts
+            and len(sessions) >= _patterns_cfg.cross_project_sessions):
         return "expertise"
 
     # 4. Tool cluster: highly homogeneous type + narrow context
-    if max_type_count / total >= 0.7 and len(contexts) <= 3:
+    if max_type_count / total >= _patterns_cfg.tool_cluster_threshold and len(contexts) <= 3:
         return "tool_cluster"
 
     # 5. Cross-project: residual catch-all
-    if len(contexts) >= 4 or (len(members) >= 5 and len(sessions) / len(members) > 0.7):
+    if (len(contexts) >= _patterns_cfg.cross_project_contexts
+            or (len(members) >= 5 and len(sessions) / len(members) > 0.7)):
         return "cross_project"
 
     return "tool_cluster"
@@ -517,10 +525,10 @@ def compute_distances(
 
 async def detect_patterns(
     learnings: list[Learning],
-    min_cluster_size: int = 5,
-    min_samples: int = 3,
-    min_confidence: float = 0.3,
-    tag_noise_percentile: float = 10,
+    min_cluster_size: int = _patterns_cfg.min_cluster_size,
+    min_samples: int = _patterns_cfg.min_samples,
+    min_confidence: float = _patterns_cfg.min_confidence,
+    tag_noise_percentile: float = _patterns_cfg.tag_noise_percentile,
     classifier: PatternClassifier | None = None,
 ) -> list[DetectedPattern]:
     """Run the full pattern detection pipeline.

--- a/scripts/core/query_expansion.py
+++ b/scripts/core/query_expansion.py
@@ -16,6 +16,8 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 
+from scripts.core.config import get_config as _get_config
+
 logger = logging.getLogger(__name__)
 
 # Shared stopwords — merges recall_backends meta_words with standard English
@@ -39,8 +41,9 @@ STOPWORDS: frozenset[str] = frozenset({
 
 _ALNUM_RE = re.compile(r"[^a-zA-Z0-9]")
 _IDF_CACHE_PATH = Path.home() / ".claude" / "cache" / "idf_index.json"
-_IDF_MAX_AGE_HOURS = 24
-_IDF_DRIFT_THRESHOLD = 0.10  # rebuild if doc count drifts >10%
+_qe_cfg = _get_config().query_expansion
+_IDF_MAX_AGE_HOURS = _qe_cfg.idf_max_age_hours
+_IDF_DRIFT_THRESHOLD = _qe_cfg.idf_drift_threshold
 
 
 def _tokenize(text: str) -> list[str]:

--- a/scripts/core/re_embed_voyage.py
+++ b/scripts/core/re_embed_voyage.py
@@ -48,7 +48,9 @@ from scripts.core.db.postgres_pool import close_pool, get_connection  # noqa: E4
 
 faulthandler.enable(file=open(os.path.expanduser("~/.claude/logs/opc_crash.log"), "a"), all_threads=True)
 
-BATCH_SIZE = 64
+from scripts.core.config import get_config as _get_config
+
+BATCH_SIZE = _get_config().embedding.re_embed_batch_size
 TARGET_MODEL = "voyage-code-3"
 
 

--- a/scripts/core/recall_backends.py
+++ b/scripts/core/recall_backends.py
@@ -17,10 +17,16 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from scripts.core.config import get_config as _get_config
+
 logger = logging.getLogger(__name__)
 
+_recall_cfg = _get_config().recall
 
-async def search_learnings_text_only_postgres(query: str, k: int = 5) -> list[dict[str, Any]]:
+
+async def search_learnings_text_only_postgres(
+    query: str, k: int = _recall_cfg.default_k,
+) -> list[dict[str, Any]]:
     """Fast text-only search for PostgreSQL using full-text search.
 
     Uses tsvector/tsquery with GIN index. Automatic stopword handling.
@@ -153,7 +159,9 @@ async def search_learnings_text_only_postgres(query: str, k: int = 5) -> list[di
     return results
 
 
-async def search_learnings_sqlite(query: str, k: int = 5) -> list[dict[str, Any]]:
+async def search_learnings_sqlite(
+    query: str, k: int = _recall_cfg.default_k,
+) -> list[dict[str, Any]]:
     """Search learnings using SQLite FTS5 (BM25 ranking).
 
     Cross-session search - finds learnings from ALL sessions.
@@ -206,7 +214,7 @@ async def search_learnings_sqlite(query: str, k: int = 5) -> list[dict[str, Any]
             # BM25 returns negative scores (lower = better)
             # Normalize to 0.0-1.0 range
             raw_rank = row["rank"] if row["rank"] else 0
-            normalized_score = min(1.0, max(0.0, -raw_rank / 25.0))
+            normalized_score = min(1.0, max(0.0, -raw_rank / _recall_cfg.bm25_normalization_divisor))
 
             metadata = {}
             if row["metadata_json"]:
@@ -231,12 +239,12 @@ async def search_learnings_sqlite(query: str, k: int = 5) -> list[dict[str, Any]
 
 async def search_learnings_hybrid_rrf(
     query: str,
-    k: int = 5,
+    k: int = _recall_cfg.default_k,
     provider: str = "local",
-    rrf_k: int = 60,
+    rrf_k: int = _recall_cfg.rrf_k,
     similarity_threshold: float = 0.0,
     expand: bool = True,
-    max_expansion_terms: int = 5,
+    max_expansion_terms: int = _recall_cfg.max_expansion_terms,
 ) -> list[dict[str, Any]]:
     """Hybrid RRF search combining text and vector rankings.
 
@@ -336,7 +344,7 @@ async def search_learnings_hybrid_rrf(
                 a.last_recalled,
                 c.rrf_score +
                     CASE WHEN COALESCE(a.recall_count, 0) = 0 THEN 0
-                    ELSE log(2.0, 1 + COALESCE(a.recall_count, 0)) * 0.002
+                    ELSE log(2.0, 1 + COALESCE(a.recall_count, 0)) * {_recall_cfg.recall_boost_multiplier}
                     END as boosted_score,
                 c.rrf_score as raw_rrf_score,
                 c.fts_rank,
@@ -440,7 +448,7 @@ async def search_learnings_hybrid_rrf(
 
 async def search_learnings_postgres(
     query: str,
-    k: int = 5,
+    k: int = _recall_cfg.default_k,
     provider: str = "local",
     text_fallback: bool = True,
     similarity_threshold: float = 0.0,

--- a/scripts/core/reranker.py
+++ b/scripts/core/reranker.py
@@ -32,17 +32,22 @@ class RecallContext:
     now: datetime = field(default_factory=lambda: datetime.now(UTC))
 
 
+# Defaults from opc.toml [reranker]
+from scripts.core.config import get_config as _get_config
+_reranker_cfg = _get_config().reranker
+
+
 @dataclass
 class RerankerConfig:
     """Weights for each contextual signal (should sum to ~0.35)."""
 
-    project_weight: float = 0.15
-    recency_weight: float = 0.05
-    confidence_weight: float = 0.05
-    recall_weight: float = 0.05
-    type_affinity_weight: float = 0.05
-    tag_overlap_weight: float = 0.05
-    pattern_weight: float = 0.05
+    project_weight: float = _reranker_cfg.project_weight
+    recency_weight: float = _reranker_cfg.recency_weight
+    confidence_weight: float = _reranker_cfg.confidence_weight
+    recall_weight: float = _reranker_cfg.recall_weight
+    type_affinity_weight: float = _reranker_cfg.type_affinity_weight
+    tag_overlap_weight: float = _reranker_cfg.tag_overlap_weight
+    pattern_weight: float = _reranker_cfg.pattern_weight
 
     @property
     def total_signal_weight(self) -> float:
@@ -82,7 +87,7 @@ def calibrate_score(
         calibrated = (raw_score + 1) / 2
     elif mode == "hybrid_rrf":
         # RRF scores ~0.01-0.03 -> scale up
-        calibrated = raw_score * 60
+        calibrated = raw_score * _reranker_cfg.rrf_scale_factor
     elif mode in ("text", "sqlite"):
         # BM25 unbounded -> squash with kappa=1.0
         kappa = 1.0
@@ -138,7 +143,7 @@ def recency_score(result: dict, ctx: RecallContext) -> float:
 
     age = now - created_at
     age_days = max(0.0, age.total_seconds() / 86400)
-    return math.exp(-age_days / 45)
+    return math.exp(-age_days / _reranker_cfg.recency_half_life_days)
 
 
 def confidence_score(result: dict) -> float:
@@ -153,7 +158,7 @@ def recall_score(result: dict) -> float:
     count = result.get("recall_count")
     if count is None or count <= 0:
         return 0.0
-    return min(1.0, math.log2(1 + count) / 4)
+    return min(1.0, math.log2(1 + count) / _reranker_cfg.recall_log2_normalizer)
 
 
 def type_match(result: dict, ctx: RecallContext) -> float:

--- a/scripts/core/store_learning.py
+++ b/scripts/core/store_learning.py
@@ -185,9 +185,8 @@ async def store_learning_v2(
                     )
                     logger.info(
                         "Dedup rejected: session=%s similarity=%.3f "
-                        "existing_id=%s threshold=%.2f content=%.80s",
-                        session_id, similarity, existing_id,
-                        threshold, content,
+                        "existing_id=%s threshold=%.2f",
+                        session_id, similarity, existing_id, threshold,
                     )
                     await memory.close()
                     return {

--- a/scripts/core/store_learning.py
+++ b/scripts/core/store_learning.py
@@ -78,10 +78,17 @@ LEARNING_TYPES = [
 # Valid confidence levels
 CONFIDENCE_LEVELS = ["high", "medium", "low"]
 
-# Loaded from opc.toml [dedup] threshold. See config.py for precedence chain.
 from scripts.core.config import get_config as _get_config
 
-DEDUP_THRESHOLD = _get_config().dedup.threshold
+
+def _dedup_threshold() -> float:
+    """Read live dedup threshold from config (not cached at import time)."""
+    return _get_config().dedup.threshold
+
+
+# Module-level alias for backward compatibility (tests, external consumers).
+# Internal dedup logic uses _dedup_threshold() for live reads.
+DEDUP_THRESHOLD = _dedup_threshold()
 
 
 async def store_learning_v2(
@@ -152,12 +159,13 @@ async def store_learning_v2(
             embedding_model = embedder._provider.model
 
         # Semantic dedup: search ALL sessions for near-duplicates.
-        # The old code used search_vector() which was session-scoped —
-        # duplicates from other sessions slipped through.
+        # Read threshold live (not the module-level snapshot) so config
+        # changes take effect without process restart.
+        threshold = _dedup_threshold()
         try:
             if hasattr(memory, "search_vector_global"):
                 existing = await memory.search_vector_global(
-                    embedding, threshold=DEDUP_THRESHOLD, limit=1
+                    embedding, threshold=threshold, limit=1
                 )
             else:
                 # Fallback for non-PG backends that lack global search.
@@ -168,7 +176,7 @@ async def store_learning_v2(
             if existing and len(existing) > 0:
                 top_match = existing[0]
                 similarity = top_match.get("similarity", 0)
-                if similarity >= DEDUP_THRESHOLD:
+                if similarity >= threshold:
                     existing_session = top_match.get("session_id", session_id)
                     existing_id = str(top_match.get("id", ""))
                     reason = (
@@ -179,7 +187,7 @@ async def store_learning_v2(
                         "Dedup rejected: session=%s similarity=%.3f "
                         "existing_id=%s threshold=%.2f content=%.80s",
                         session_id, similarity, existing_id,
-                        DEDUP_THRESHOLD, content,
+                        threshold, content,
                     )
                     await memory.close()
                     return {

--- a/scripts/core/store_learning.py
+++ b/scripts/core/store_learning.py
@@ -78,9 +78,10 @@ LEARNING_TYPES = [
 # Valid confidence levels
 CONFIDENCE_LEVELS = ["high", "medium", "low"]
 
-# Semantic deduplication threshold (0.92 = 92% cosine similarity).
-# Global cross-session check — catches near-duplicates from ANY session.
-DEDUP_THRESHOLD = 0.92
+# Loaded from opc.toml [dedup] threshold. See config.py for precedence chain.
+from scripts.core.config import get_config as _get_config
+
+DEDUP_THRESHOLD = _get_config().dedup.threshold
 
 
 async def store_learning_v2(

--- a/scripts/core/store_learning.py
+++ b/scripts/core/store_learning.py
@@ -170,15 +170,23 @@ async def store_learning_v2(
                 similarity = top_match.get("similarity", 0)
                 if similarity >= DEDUP_THRESHOLD:
                     existing_session = top_match.get("session_id", session_id)
+                    existing_id = str(top_match.get("id", ""))
+                    reason = (
+                        f"duplicate (similarity: {similarity:.2f},"
+                        f" session: {existing_session})"
+                    )
+                    logger.info(
+                        "Dedup rejected: session=%s similarity=%.3f "
+                        "existing_id=%s threshold=%.2f content=%.80s",
+                        session_id, similarity, existing_id,
+                        DEDUP_THRESHOLD, content,
+                    )
                     await memory.close()
                     return {
                         "success": True,
                         "skipped": True,
-                        "reason": (
-                            f"duplicate (similarity: {similarity:.2f},"
-                            f" session: {existing_session})"
-                        ),
-                        "existing_id": str(top_match.get("id", "")),
+                        "reason": reason,
+                        "existing_id": existing_id,
                     }
         except Exception:
             # If search fails, proceed with storing (don't block on dedup errors)

--- a/tests/test_config_core.py
+++ b/tests/test_config_core.py
@@ -113,3 +113,29 @@ class TestBuildConfig:
         raw = {"daemon": {"poll_interval": "not_a_number"}}
         with pytest.raises(ConfigValidationError):
             build_config(raw)
+
+    def test_zero_poll_interval_rejected(self):
+        raw = {"daemon": {"poll_interval": 0}}
+        with pytest.raises(ConfigValidationError, match="below minimum"):
+            build_config(raw)
+
+    def test_zero_max_concurrent_rejected(self):
+        raw = {"daemon": {"max_concurrent_extractions": 0}}
+        with pytest.raises(ConfigValidationError, match="below minimum"):
+            build_config(raw)
+
+    def test_negative_timeout_rejected(self):
+        raw = {"daemon": {"extraction_timeout": -1}}
+        with pytest.raises(ConfigValidationError, match="below minimum"):
+            build_config(raw)
+
+    def test_threshold_above_one_rejected(self):
+        raw = {"dedup": {"threshold": 1.5}}
+        with pytest.raises(ConfigValidationError, match="above maximum"):
+            build_config(raw)
+
+    def test_threshold_at_boundaries_accepted(self):
+        cfg = build_config({"dedup": {"threshold": 0.0}})
+        assert cfg.dedup.threshold == 0.0
+        cfg = build_config({"dedup": {"threshold": 1.0}})
+        assert cfg.dedup.threshold == 1.0

--- a/tests/test_config_core.py
+++ b/tests/test_config_core.py
@@ -1,0 +1,89 @@
+"""Tests for config core — pure functions, no I/O."""
+
+from scripts.core.config.core import build_config, build_section, merge_raw
+from scripts.core.config.models import (
+    DedupConfig,
+    OPCConfig,
+    RerankerConfig,
+)
+
+
+class TestBuildSection:
+    def test_empty_dict_returns_defaults(self):
+        result = build_section(DedupConfig, {})
+        assert result == DedupConfig()
+
+    def test_overrides_known_keys(self):
+        result = build_section(DedupConfig, {"threshold": 0.90})
+        assert result.threshold == 0.90
+
+    def test_ignores_unknown_keys(self):
+        result = build_section(DedupConfig, {"threshold": 0.90, "bogus": 42})
+        assert result.threshold == 0.90
+
+    def test_partial_override_keeps_other_defaults(self):
+        result = build_section(RerankerConfig, {"project_weight": 0.25})
+        assert result.project_weight == 0.25
+        assert result.recency_weight == 0.05  # default preserved
+
+
+class TestMergeRaw:
+    def test_env_overrides_file(self):
+        file_raw = {"dedup": {"threshold": 0.85}}
+        env_raw = {"dedup": {"threshold": 0.90}}
+        merged = merge_raw(file_raw, env_raw)
+        assert merged["dedup"]["threshold"] == 0.90
+
+    def test_env_adds_missing_keys(self):
+        file_raw = {"dedup": {"threshold": 0.85}}
+        env_raw = {"daemon": {"poll_interval": 30}}
+        merged = merge_raw(file_raw, env_raw)
+        assert merged["dedup"]["threshold"] == 0.85
+        assert merged["daemon"]["poll_interval"] == 30
+
+    def test_file_preserved_when_no_env(self):
+        file_raw = {"dedup": {"threshold": 0.85}, "daemon": {"poll_interval": 60}}
+        env_raw = {}
+        merged = merge_raw(file_raw, env_raw)
+        assert merged == file_raw
+
+    def test_both_empty(self):
+        merged = merge_raw({}, {})
+        assert merged == {}
+
+    def test_does_not_mutate_inputs(self):
+        file_raw = {"dedup": {"threshold": 0.85}}
+        env_raw = {"dedup": {"threshold": 0.90}}
+        merge_raw(file_raw, env_raw)
+        assert file_raw["dedup"]["threshold"] == 0.85
+        assert env_raw["dedup"]["threshold"] == 0.90
+
+
+class TestBuildConfig:
+    def test_empty_dict_returns_all_defaults(self):
+        cfg = build_config({})
+        assert cfg == OPCConfig()
+
+    def test_partial_override(self):
+        raw = {"dedup": {"threshold": 0.90}}
+        cfg = build_config(raw)
+        assert cfg.dedup.threshold == 0.90
+        assert cfg.daemon.poll_interval == 60  # other sections default
+
+    def test_unknown_section_ignored(self):
+        raw = {"nonexistent_section": {"key": "value"}}
+        cfg = build_config(raw)
+        assert cfg == OPCConfig()
+
+    def test_multiple_sections(self):
+        raw = {
+            "dedup": {"threshold": 0.80},
+            "daemon": {"poll_interval": 30, "max_retries": 10},
+            "recall": {"default_k": 10},
+        }
+        cfg = build_config(raw)
+        assert cfg.dedup.threshold == 0.80
+        assert cfg.daemon.poll_interval == 30
+        assert cfg.daemon.max_retries == 10
+        assert cfg.daemon.stale_threshold == 900  # default
+        assert cfg.recall.default_k == 10

--- a/tests/test_config_core.py
+++ b/tests/test_config_core.py
@@ -1,7 +1,15 @@
 """Tests for config core — pure functions, no I/O."""
 
-from scripts.core.config.core import build_config, build_section, merge_raw
+import pytest
+
+from scripts.core.config.core import (
+    ConfigValidationError,
+    build_config,
+    build_section,
+    merge_raw,
+)
 from scripts.core.config.models import (
+    DaemonConfig,
     DedupConfig,
     OPCConfig,
     RerankerConfig,
@@ -17,14 +25,25 @@ class TestBuildSection:
         result = build_section(DedupConfig, {"threshold": 0.90})
         assert result.threshold == 0.90
 
-    def test_ignores_unknown_keys(self):
-        result = build_section(DedupConfig, {"threshold": 0.90, "bogus": 42})
+    def test_unknown_keys_warns(self, caplog):
+        result = build_section(DedupConfig, {"threshold": 0.90, "bogus": 42}, section_name="dedup")
         assert result.threshold == 0.90
+        assert "unknown key" in caplog.text
+        assert "bogus" in caplog.text
 
     def test_partial_override_keeps_other_defaults(self):
         result = build_section(RerankerConfig, {"project_weight": 0.25})
         assert result.project_weight == 0.25
         assert result.recency_weight == 0.05  # default preserved
+
+    def test_wrong_type_raises(self):
+        with pytest.raises(ConfigValidationError, match="expected int.*got str"):
+            build_section(DaemonConfig, {"poll_interval": "fast"}, section_name="daemon")
+
+    def test_int_accepted_for_float_field(self):
+        result = build_section(DedupConfig, {"threshold": 1})
+        assert result.threshold == 1.0
+        assert isinstance(result.threshold, float)
 
 
 class TestMergeRaw:
@@ -70,10 +89,12 @@ class TestBuildConfig:
         assert cfg.dedup.threshold == 0.90
         assert cfg.daemon.poll_interval == 60  # other sections default
 
-    def test_unknown_section_ignored(self):
+    def test_unknown_section_warns(self, caplog):
         raw = {"nonexistent_section": {"key": "value"}}
         cfg = build_config(raw)
         assert cfg == OPCConfig()
+        assert "unknown section" in caplog.text
+        assert "nonexistent_section" in caplog.text
 
     def test_multiple_sections(self):
         raw = {
@@ -87,3 +108,8 @@ class TestBuildConfig:
         assert cfg.daemon.max_retries == 10
         assert cfg.daemon.stale_threshold == 900  # default
         assert cfg.recall.default_k == 10
+
+    def test_wrong_type_in_section_raises(self):
+        raw = {"daemon": {"poll_interval": "not_a_number"}}
+        with pytest.raises(ConfigValidationError):
+            build_config(raw)

--- a/tests/test_config_handlers.py
+++ b/tests/test_config_handlers.py
@@ -1,0 +1,126 @@
+"""Tests for config handlers — I/O boundary (file discovery, TOML loading, env reads)."""
+
+import os
+from pathlib import Path
+
+from scripts.core.config.handlers import (
+    discover_config_paths,
+    load_config_file,
+    read_env_overrides,
+    get_config,
+    reset_config,
+)
+from scripts.core.config.models import OPCConfig
+
+
+class TestDiscoverConfigPaths:
+    def test_returns_list(self):
+        paths = discover_config_paths()
+        assert isinstance(paths, list)
+        assert all(isinstance(p, Path) for p in paths)
+
+    def test_env_var_first(self, monkeypatch, tmp_path):
+        config_file = tmp_path / "custom.toml"
+        config_file.touch()
+        monkeypatch.setenv("OPC_CONFIG", str(config_file))
+        paths = discover_config_paths()
+        assert paths[0] == config_file
+
+    def test_includes_user_global(self):
+        paths = discover_config_paths()
+        user_global = Path.home() / ".config" / "opc" / "config.toml"
+        assert user_global in paths
+
+
+class TestLoadConfigFile:
+    def test_returns_empty_for_no_files(self):
+        result = load_config_file([Path("/nonexistent/path.toml")])
+        assert result == {}
+
+    def test_loads_first_existing(self, tmp_path):
+        first = tmp_path / "first.toml"
+        second = tmp_path / "second.toml"
+        first.write_text('[dedup]\nthreshold = 0.75\n')
+        second.write_text('[dedup]\nthreshold = 0.99\n')
+        result = load_config_file([first, second])
+        assert result["dedup"]["threshold"] == 0.75
+
+    def test_skips_missing_to_find_existing(self, tmp_path):
+        missing = tmp_path / "nope.toml"
+        present = tmp_path / "yes.toml"
+        present.write_text('[daemon]\npoll_interval = 30\n')
+        result = load_config_file([missing, present])
+        assert result["daemon"]["poll_interval"] == 30
+
+    def test_empty_toml_returns_empty_dict(self, tmp_path):
+        empty = tmp_path / "empty.toml"
+        empty.write_text("")
+        result = load_config_file([empty])
+        assert result == {}
+
+
+class TestReadEnvOverrides:
+    def test_returns_empty_when_no_vars(self, monkeypatch):
+        monkeypatch.delenv("PATTERN_DETECTION_INTERVAL_HOURS", raising=False)
+        monkeypatch.delenv("OLLAMA_EMBED_MODEL", raising=False)
+        monkeypatch.delenv("OLLAMA_HOST", raising=False)
+        monkeypatch.delenv("AGENTICA_MAX_POOL_SIZE", raising=False)
+        result = read_env_overrides()
+        assert result == {}
+
+    def test_picks_up_set_vars(self, monkeypatch):
+        monkeypatch.setenv("OLLAMA_HOST", "http://custom:1234")
+        result = read_env_overrides()
+        assert result["embedding"]["ollama_host"] == "http://custom:1234"
+
+    def test_casts_int_vars(self, monkeypatch):
+        monkeypatch.setenv("PATTERN_DETECTION_INTERVAL_HOURS", "12")
+        result = read_env_overrides()
+        assert result["daemon"]["pattern_detection_interval_hours"] == 12
+
+    def test_multiple_vars(self, monkeypatch):
+        monkeypatch.setenv("OLLAMA_HOST", "http://gpu:11434")
+        monkeypatch.setenv("AGENTICA_MAX_POOL_SIZE", "20")
+        result = read_env_overrides()
+        assert result["embedding"]["ollama_host"] == "http://gpu:11434"
+        assert result["database"]["max_pool_size"] == 20
+
+
+class TestGetConfig:
+    def setup_method(self):
+        reset_config()
+
+    def teardown_method(self):
+        reset_config()
+
+    def test_returns_opc_config(self):
+        cfg = get_config()
+        assert isinstance(cfg, OPCConfig)
+
+    def test_caches_result(self):
+        cfg1 = get_config()
+        cfg2 = get_config()
+        assert cfg1 is cfg2
+
+    def test_reload_returns_fresh(self):
+        cfg1 = get_config()
+        cfg2 = get_config(reload=True)
+        # Both valid OPCConfig but not necessarily same object
+        assert isinstance(cfg2, OPCConfig)
+
+    def test_respects_opc_config_env(self, monkeypatch, tmp_path):
+        reset_config()
+        config_file = tmp_path / "test.toml"
+        config_file.write_text('[dedup]\nthreshold = 0.77\n')
+        monkeypatch.setenv("OPC_CONFIG", str(config_file))
+        cfg = get_config(reload=True)
+        assert cfg.dedup.threshold == 0.77
+
+    def test_env_override_beats_file(self, monkeypatch, tmp_path):
+        reset_config()
+        config_file = tmp_path / "test.toml"
+        config_file.write_text('[embedding]\nollama_host = "http://file:1234"\n')
+        monkeypatch.setenv("OPC_CONFIG", str(config_file))
+        monkeypatch.setenv("OLLAMA_HOST", "http://env:5678")
+        cfg = get_config(reload=True)
+        assert cfg.embedding.ollama_host == "http://env:5678"

--- a/tests/test_config_handlers.py
+++ b/tests/test_config_handlers.py
@@ -85,6 +85,19 @@ class TestReadEnvOverrides:
         assert result["embedding"]["ollama_host"] == "http://gpu:11434"
         assert result["database"]["max_pool_size"] == 20
 
+    def test_invalid_int_var_skipped(self, monkeypatch, caplog):
+        monkeypatch.setenv("AGENTICA_MAX_POOL_SIZE", "abc")
+        result = read_env_overrides()
+        assert "database" not in result
+        assert "AGENTICA_MAX_POOL_SIZE" in caplog.text
+
+    def test_invalid_var_does_not_block_valid_vars(self, monkeypatch):
+        monkeypatch.setenv("AGENTICA_MAX_POOL_SIZE", "not_a_number")
+        monkeypatch.setenv("OLLAMA_HOST", "http://valid:1234")
+        result = read_env_overrides()
+        assert result["embedding"]["ollama_host"] == "http://valid:1234"
+        assert "database" not in result
+
 
 class TestGetConfig:
     def setup_method(self):

--- a/tests/test_config_models.py
+++ b/tests/test_config_models.py
@@ -1,0 +1,124 @@
+"""Tests for config models (frozen dataclasses with defaults)."""
+
+from scripts.core.config.models import (
+    ArchivalConfig,
+    DatabaseConfig,
+    DaemonConfig,
+    DedupConfig,
+    EmbeddingConfig,
+    OPCConfig,
+    PatternsConfig,
+    QueryExpansionConfig,
+    RerankerConfig,
+    RecallConfig,
+)
+
+
+class TestDedupConfig:
+    def test_default_threshold(self):
+        cfg = DedupConfig()
+        assert cfg.threshold == 0.85
+
+    def test_custom_threshold(self):
+        cfg = DedupConfig(threshold=0.90)
+        assert cfg.threshold == 0.90
+
+    def test_frozen(self):
+        cfg = DedupConfig()
+        try:
+            cfg.threshold = 0.50  # type: ignore[misc]
+            assert False, "Should raise FrozenInstanceError"
+        except AttributeError:
+            pass
+
+
+class TestDaemonConfig:
+    def test_defaults(self):
+        cfg = DaemonConfig()
+        assert cfg.poll_interval == 60
+        assert cfg.stale_threshold == 900
+        assert cfg.max_concurrent_extractions == 4
+        assert cfg.max_retries == 5
+        assert cfg.extraction_timeout == 1800
+        assert cfg.pattern_detection_interval_hours == 6
+        assert cfg.extraction_model == "sonnet"
+        assert cfg.extraction_max_turns == 15
+
+
+class TestRerankerConfig:
+    def test_defaults(self):
+        cfg = RerankerConfig()
+        assert cfg.project_weight == 0.15
+        assert cfg.recency_half_life_days == 45.0
+        assert cfg.rrf_scale_factor == 60.0
+
+    def test_total_signal_weight(self):
+        cfg = RerankerConfig()
+        expected = 0.15 + 0.05 * 6  # project + 6 others at 0.05
+        assert abs(cfg.total_signal_weight - expected) < 1e-9
+
+
+class TestRecallConfig:
+    def test_defaults(self):
+        cfg = RecallConfig()
+        assert cfg.default_k == 5
+        assert cfg.rrf_k == 60
+        assert cfg.max_expansion_terms == 5
+
+
+class TestPatternsConfig:
+    def test_defaults(self):
+        cfg = PatternsConfig()
+        assert cfg.min_cluster_size == 5
+        assert cfg.min_samples == 3
+        assert cfg.overlap_threshold == 0.3
+
+
+class TestEmbeddingConfig:
+    def test_defaults(self):
+        cfg = EmbeddingConfig()
+        assert cfg.ollama_model == "nomic-embed-text"
+        assert cfg.ollama_host == "http://localhost:11434"
+
+
+class TestQueryExpansionConfig:
+    def test_defaults(self):
+        cfg = QueryExpansionConfig()
+        assert cfg.idf_max_age_hours == 24
+        assert cfg.idf_drift_threshold == 0.10
+
+
+class TestArchivalConfig:
+    def test_defaults(self):
+        cfg = ArchivalConfig()
+        assert cfg.compress_timeout == 300
+        assert cfg.skip_recent_minutes == 10
+
+
+class TestDatabaseConfig:
+    def test_defaults(self):
+        cfg = DatabaseConfig()
+        assert cfg.max_pool_size == 10
+        assert cfg.max_archival_context == 10
+
+
+class TestOPCConfig:
+    def test_all_sections_have_defaults(self):
+        cfg = OPCConfig()
+        assert isinstance(cfg.dedup, DedupConfig)
+        assert isinstance(cfg.daemon, DaemonConfig)
+        assert isinstance(cfg.reranker, RerankerConfig)
+        assert isinstance(cfg.patterns, PatternsConfig)
+        assert isinstance(cfg.recall, RecallConfig)
+        assert isinstance(cfg.embedding, EmbeddingConfig)
+        assert isinstance(cfg.query_expansion, QueryExpansionConfig)
+        assert isinstance(cfg.archival, ArchivalConfig)
+        assert isinstance(cfg.database, DatabaseConfig)
+
+    def test_frozen(self):
+        cfg = OPCConfig()
+        try:
+            cfg.dedup = DedupConfig(threshold=0.5)  # type: ignore[misc]
+            assert False, "Should raise FrozenInstanceError"
+        except AttributeError:
+            pass

--- a/tests/test_memory_metrics.py
+++ b/tests/test_memory_metrics.py
@@ -272,9 +272,12 @@ class TestCollectMetrics:
         expected_keys = {
             "generated_at", "period", "totals", "per_session",
             "confidence_distribution", "classification_distribution",
-            "dedup_stats_alltime", "extraction_stats_alltime", "stale_learnings",
+            "dedup_stats_alltime", "embedding_coverage_alltime",
+            "extraction_stats_alltime", "stale_learnings",
             "top_tags_alltime", "superseded_alltime", "temporal_alltime",
-            "feedback_alltime", "version",
+            "feedback_alltime", "feedback_velocity",
+            "supersession_candidates", "recall_frequency",
+            "type_recall_correlation", "version",
         }
         assert set(metrics.keys()) == expected_keys
 

--- a/tests/test_semantic_dedup.py
+++ b/tests/test_semantic_dedup.py
@@ -66,9 +66,10 @@ def _patches(mock_memory_service, mock_embedder):
     )
 
 
-def test_dedup_threshold_is_092():
-    """Threshold should be 0.92 per the enhancement spec."""
-    assert DEDUP_THRESHOLD == 0.92
+def test_dedup_threshold_from_config():
+    """Threshold should match opc.toml [dedup] threshold (default 0.85)."""
+    from scripts.core.config import get_config
+    assert DEDUP_THRESHOLD == get_config().dedup.threshold
 
 
 @pytest.mark.asyncio
@@ -158,13 +159,13 @@ async def test_global_dedup_rejects_at_exact_threshold(
 async def test_global_dedup_allows_just_below_threshold(
     mock_memory_service, mock_embedder
 ):
-    """Similarity just below 0.92 should be stored."""
+    """Similarity just below threshold should be stored."""
     mock_memory_service.search_vector_global.return_value = [
         {
             "id": "near-miss-uuid",
             "session_id": "other-session",
             "content": "Almost a match",
-            "similarity": 0.9199,
+            "similarity": DEDUP_THRESHOLD - 0.001,
         }
     ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -2081,6 +2081,7 @@ dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
     { name = "radon" },
     { name = "ruff" },
     { name = "types-aiofiles" },
@@ -2147,6 +2148,7 @@ dev = [
     { name = "mypy", specifier = ">=1.19.1" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-asyncio", specifier = ">=0.23.0" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "radon", specifier = ">=6.0.1" },
     { name = "ruff", specifier = ">=0.14.10" },
     { name = "types-aiofiles", specifier = ">=25.1.0.20251011" },
@@ -3425,6 +3427,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add `opc.toml` config file and `scripts/core/config/` package to externalize ~50 hardcoded values across the memory system
- Wire 11 consumer files to read from config instead of hardcoding thresholds, weights, and timeouts
- Add system health metrics (embedding coverage, feedback velocity, supersession candidates, recall frequency, type-vs-recall correlation)
- Add `duplicate_density.py` for pairwise cosine similarity analysis to inform dedup threshold tuning
- Lower dedup threshold from 0.92 to 0.85 based on density analysis showing 15,443 pairs of same-fact rewording above 0.85

## Config system

- **TDD + FP compliant**: 53 tests, 100% coverage on config package
- **Structure**: `models.py` (frozen dataclasses) / `core.py` (pure functions) / `handlers.py` (I/O boundary)
- **Precedence**: `OPC_CONFIG` env var > `./opc.toml` > `~/.config/opc/config.toml` > built-in defaults
- **Validation**: Type checking, range enforcement (e.g. poll_interval >= 1, threshold in [0,1]), unknown key warnings
- **Defensive env parsing**: Invalid env var values logged and skipped, not crashed

## Consumers wired

| File | Values externalized |
|------|-------------------|
| `store_learning.py` | dedup threshold (live read, not import-time snapshot) |
| `memory_daemon.py` | poll interval, stale threshold, concurrency, timeouts, model, max_turns |
| `reranker.py` | signal weights, half-life, RRF scale, recall normalizer |
| `pattern_detector.py` | clustering params, classification thresholds, noise percentile |
| `recall_backends.py` | default k, RRF k, expansion terms, boost multiplier, BM25 normalizer |
| `query_expansion.py` | IDF cache age, drift threshold |
| `re_embed_voyage.py` | batch size |
| `backfill_archive.py` | subprocess timeouts, skip-recent cutoff |
| `postgres_pool.py` | max pool size default |
| `embedding_providers.py` | Ollama model/host defaults |

Skipped `memory_service_pg.py` (active refactor in `refactor/tdd-fp-memory-service-pg`). TODO logged.

## Adversarial review cycle (3 rounds)

- **Round 1**: Added type validation, defensive env parsing, fixed supersession_candidates docstring, added dedup audit logging
- **Round 2**: Added range validation, fixed feedback velocity averaging, graceful schema degradation, live config threshold in density tool
- **Round 3**: Made dedup threshold live-read (not import snapshot), narrowed exception handling to schema errors only, handled mixed embedding dimensions, added tag_noise_percentile range check

## Security review

0 critical, 0 new high findings. Removed learning content from dedup audit log (MEDIUM-4). Pre-existing HIGHs (tsquery injection, `--dangerously-skip-permissions`) logged to TODO.

## Test coverage

```
Name                              Stmts   Miss  Cover
---------------------------------------------------------------
scripts/core/config/__init__.py       3      0   100%
scripts/core/config/core.py          63      0   100%
scripts/core/config/handlers.py      51      0   100%
scripts/core/config/models.py        83      0   100%
---------------------------------------------------------------
TOTAL                               200      0   100%
```

Full suite: 655 passed, 0 failed.

## Test plan

- [ ] Verify `uv run python scripts/core/memory_metrics.py --human` shows new System Health and Recall Quality sections
- [ ] Verify `uv run python scripts/core/duplicate_density.py --text-only` runs without error
- [ ] Verify editing `opc.toml` values changes behavior without code changes
- [ ] Verify setting `OPC_CONFIG=/dev/null` falls back to built-in defaults
- [ ] Verify invalid env vars (e.g. `AGENTICA_MAX_POOL_SIZE=abc`) are logged and skipped
