### PR TITLE
S16: TDD+FP compliance for backfill_learnings.py

### DIFF
--- a/scripts/core/backfill_learnings.py
+++ b/scripts/core/backfill_learnings.py
@@ -61,7 +61,7 @@ def parse_s3_listing(
 
     sessions: list[dict] = []
     for line in stdout.strip().splitlines():
-        parts = line.split()
+        parts = line.split(maxsplit=3)
         if len(parts) < 4:
             continue
         key = parts[3]
@@ -109,34 +109,34 @@ def build_extraction_cmd(
     ]
 
 
+_ALLOW_ENV_EXACT = frozenset({
+    "PATH", "HOME", "USER", "LANG", "TERM", "SHELL", "TMPDIR",
+    "PYTHONPATH", "VIRTUAL_ENV",
+})
+
 _ALLOW_ENV_PREFIXES = (
-    "PATH",
-    "HOME",
-    "USER",
-    "LANG",
     "LC_",
-    "TERM",
-    "SHELL",
-    "TMPDIR",
     "XDG_",
     "CLAUDE_",
     "UV_",
-    "PYTHONPATH",
-    "VIRTUAL_ENV",
 )
+
+
+def _is_env_allowed(key: str) -> bool:
+    """Check if an env var key is on the extraction allowlist."""
+    if key in _ALLOW_ENV_EXACT:
+        return True
+    return any(key.startswith(prefix) for prefix in _ALLOW_ENV_PREFIXES)
 
 
 def build_extraction_env(project_dir: str | None) -> dict[str, str]:
     """Build allowlisted environment dict for extraction subprocess.
 
-    Only passes env vars matching known-safe prefixes. This prevents
-    leaking DB credentials, API keys, or tokens to the LLM process.
+    Only passes env vars matching known-safe exact names or prefixes.
+    This prevents leaking DB credentials, API keys, or tokens to the
+    LLM process.
     """
-    env = {
-        k: v
-        for k, v in os.environ.items()
-        if any(k.startswith(prefix) for prefix in _ALLOW_ENV_PREFIXES)
-    }
+    env = {k: v for k, v in os.environ.items() if _is_env_allowed(k)}
     env["CLAUDE_MEMORY_EXTRACTION"] = "1"
     if project_dir:
         env["CLAUDE_PROJECT_DIR"] = project_dir
@@ -259,8 +259,12 @@ def _bootstrap() -> None:
         load_dotenv(opc_env, override=True)
 
 
-def list_s3_keys(bucket: str) -> str:
-    """Run ``aws s3 ls`` and return raw stdout. Returns empty string on error."""
+def list_s3_keys(bucket: str) -> str | None:
+    """Run ``aws s3 ls`` and return raw stdout.
+
+    Returns ``None`` on error (distinguishable from an empty archive
+    which returns ``""``).
+    """
     try:
         result = subprocess.run(
             ["aws", "s3", "ls", f"s3://{bucket}/sessions/", "--recursive"],
@@ -270,14 +274,14 @@ def list_s3_keys(bucket: str) -> str:
         )
         if result.returncode != 0:
             _log(f"S3 list failed: {result.stderr}")
-            return ""
+            return None
         return result.stdout
     except subprocess.TimeoutExpired:
         _log("S3 list timed out")
-        return ""
+        return None
     except FileNotFoundError:
         _log("ERROR: 'aws' CLI not found. Install AWS CLI to use S3 backfill.")
-        return ""
+        return None
 
 
 _UUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
@@ -442,9 +446,15 @@ def run_extraction(
 
 
 def load_agent_prompt(agent_file: Path | None = None) -> str:
-    """Load memory-extractor agent body, stripping YAML frontmatter."""
+    """Load memory-extractor agent body, stripping YAML frontmatter.
+
+    Checks the repo-local ``agents/`` directory first, then falls back
+    to ``~/.claude/agents/``.
+    """
     if agent_file is None:
-        agent_file = Path.home() / ".claude" / "agents" / "memory-extractor.md"
+        repo_file = Path(__file__).parent.parent.parent / "agents" / "memory-extractor.md"
+        home_file = Path.home() / ".claude" / "agents" / "memory-extractor.md"
+        agent_file = repo_file if repo_file.exists() else home_file
     if not agent_file.exists():
         return "Extract learnings from this session. Store each with store_learning.py."
     content = agent_file.read_text()
@@ -534,6 +544,9 @@ def main() -> int:
 
     # List and parse S3 sessions
     raw_listing = list_s3_keys(bucket)
+    if raw_listing is None:
+        _log("ERROR: Failed to list S3 sessions")
+        return 1
     sessions = parse_s3_listing(raw_listing, bucket, args.project or None)
     _log(f"Found {len(sessions)} archived sessions")
 

--- a/tests/test_backfill_learnings.py
+++ b/tests/test_backfill_learnings.py
@@ -206,6 +206,8 @@ class TestBuildExtractionEnv:
                 "POSTGRES_URL": "pg://creds2",
                 "GITHUB_TOKEN": "tok",
                 "PGPASSWORD": "pass",
+                "LANGSMITH_API_KEY": "ls",
+                "USER_TOKEN": "ut",
                 "PATH": "/usr/bin",
                 "HOME": "/home/test",
                 "CLAUDE_CONFIG_DIR": "/tmp/claude",
@@ -221,7 +223,10 @@ class TestBuildExtractionEnv:
             assert "POSTGRES_URL" not in env
             assert "GITHUB_TOKEN" not in env
             assert "PGPASSWORD" not in env
-            # Safe keys included (in allowlist)
+            # Prefix-like names that aren't exact matches are excluded
+            assert "LANGSMITH_API_KEY" not in env
+            assert "USER_TOKEN" not in env
+            # Safe exact-match keys included
             assert env["PATH"] == "/usr/bin"
             assert env["HOME"] == "/home/test"
             assert env["CLAUDE_CONFIG_DIR"] == "/tmp/claude"
@@ -370,24 +375,24 @@ class TestListS3Keys:
         mock_sub.run.assert_called_once()
 
     @patch("scripts.core.backfill_learnings.subprocess")
-    def test_failure_returns_empty(self, mock_sub):
+    def test_failure_returns_none(self, mock_sub):
         mock_sub.run.return_value = MagicMock(returncode=1, stderr="access denied")
         result = list_s3_keys("my-bucket")
-        assert result == ""
+        assert result is None
 
     @patch("scripts.core.backfill_learnings.subprocess")
-    def test_timeout_returns_empty(self, mock_sub):
+    def test_timeout_returns_none(self, mock_sub):
         mock_sub.run.side_effect = subprocess.TimeoutExpired(cmd="aws", timeout=60)
         mock_sub.TimeoutExpired = subprocess.TimeoutExpired
         result = list_s3_keys("my-bucket")
-        assert result == ""
+        assert result is None
 
     @patch("scripts.core.backfill_learnings.subprocess")
-    def test_missing_aws_cli(self, mock_sub):
+    def test_missing_aws_cli_returns_none(self, mock_sub):
         mock_sub.run.side_effect = FileNotFoundError("aws")
         mock_sub.TimeoutExpired = subprocess.TimeoutExpired
         result = list_s3_keys("my-bucket")
-        assert result == ""
+        assert result is None
 
 
 class TestLookupSessionId:


### PR DESCRIPTION
## Summary

- Rebuild `backfill_learnings.py` with TDD+FP compliance (S16 of the refactor plan)
- Original script was built 2026-04-01 in session `s-mngfha7b` but never committed; source recovered from S3-archived transcript
- 14 pure functions separated from 11 I/O handlers, matching `backfill_sessions.py` (S14) patterns

## Key Improvements Over Original

- **Allowlisted env** for extraction subprocess — only safe prefixes (PATH, HOME, CLAUDE_*, etc.) passed to LLM; no DB creds, API keys, or tokens leaked
- **Atomic pre-extraction claims** — `in_progress` row inserted in `backfill_log` before work starts, preventing duplicate processing across concurrent runs
- **Upsert on conflict** — failed→ok state transitions persist correctly (no more permanent blackholing after transient failures)
- **DB required for non-dry runs** — prevents synthetic session ID drift when PostgreSQL is unavailable
- **UUID format validation** — prevents LIKE query wildcards from crafted filenames
- **Thread-safe DB writes** — serialized on main thread, not shared across worker threads
- **Full S3 URIs** — `parse_s3_listing` constructs complete `s3://bucket/key` URIs

## Test Coverage

```
Name                                 Stmts   Miss  Cover   Missing
------------------------------------------------------------------
scripts/core/backfill_learnings.py     293     28    90%   234-246, 512-513, 535-536, 539-540, 569-572, 588, 601-609, 622-623, 642
------------------------------------------------------------------
TOTAL                                  293     28    90%
```

81 tests across 20 test classes. 1233 total suite tests pass (0 regressions).

## Review History

- 3 rounds of `/codex:adversarial-review` — all findings addressed
- Security audit (aegis) — 2 HIGH, 3 MEDIUM findings addressed
- HIGH-1 (prompt injection via Bash-enabled LLM) accepted as matching daemon pattern (PR #32)

## Test plan

- [ ] `uv run pytest tests/test_backfill_learnings.py -x -v` — 81 tests pass
- [ ] `uv run pytest tests/ -x` — full suite, 0 regressions
- [ ] `uv run ruff check scripts/core/backfill_learnings.py` — lint clean
- [ ] `uv run python scripts/core/backfill_learnings.py --dry-run --project opc` — dry run shows archived sessions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI tool to backfill and recover "learnings" from archived session artifacts in cloud storage, with options for dry-run, filtering, concurrency, and per-session progress reporting.

* **Tests**
  * Added comprehensive tests covering parsing, batching, env/command construction, download/extraction behavior, DB claim/logging workflows, and error/timeout handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->