### PR TITLE
S20: TDD+FP refactor of query_expansion.py

### DIFF
--- a/scripts/core/query_expansion.py
+++ b/scripts/core/query_expansion.py
@@ -68,7 +68,8 @@ def _sanitize_query_words(query: str) -> list[str]:
     """Extract and sanitize query words for tsquery output.
 
     Lowercases, replaces hyphens, strips non-alnum, filters short words.
-    Falls back to first cleaned word (or empty string) when no words survive.
+    Falls back to the first cleaned word, or returns an empty list when
+    nothing usable is found.
     """
     words = [
         clean
@@ -364,7 +365,9 @@ async def expand_query(
     """
     from scripts.core.db.postgres_pool import get_pool
 
-    max_neighbors = min(max_neighbors, 100)
+    max_neighbors = max(0, min(max_neighbors, 100))
+    if max_neighbors == 0:
+        return _format_tsquery(_sanitize_query_words(query), [])
     original_tokens = set(_tokenize(query))
     original_words = _sanitize_query_words(query)
 

--- a/scripts/core/query_expansion.py
+++ b/scripts/core/query_expansion.py
@@ -159,17 +159,11 @@ def _format_tsquery(original_words: list[str], expansion_terms: list[str]) -> st
     return " | ".join(all_terms)
 
 
-def _is_cache_stale(
-    cached: IDFIndex,
-    *,
-    max_age_hours: float,
-    current_count: int,
-    drift_threshold: float,
-) -> bool:
-    """Determine whether a cached IDF index needs rebuilding.
+def _is_cache_locally_invalid(cached: IDFIndex, *, max_age_hours: float) -> bool:
+    """Check cache validity using only local metadata (no DB query needed).
 
-    Stale when: age exceeds max_age_hours, doc count drift exceeds threshold,
-    zero cached docs, or unparseable timestamp.
+    Returns True (stale) when: timestamp unparseable, age exceeds max_age_hours,
+    or doc_count is non-integer / non-positive.
     """
     try:
         built = datetime.fromisoformat(cached.built_at)
@@ -182,8 +176,36 @@ def _is_cache_stale(
     if not isinstance(cached.doc_count, int) or cached.doc_count <= 0:
         return True
 
+    return False
+
+
+def _is_cache_drifted(
+    cached: IDFIndex, *, current_count: int, drift_threshold: float
+) -> bool:
+    """Check whether the cached doc count has drifted beyond threshold.
+
+    Caller must ensure cached.doc_count > 0 before calling.
+    """
     drift = abs(current_count - cached.doc_count) / cached.doc_count
     return drift > drift_threshold
+
+
+def _is_cache_stale(
+    cached: IDFIndex,
+    *,
+    max_age_hours: float,
+    current_count: int,
+    drift_threshold: float,
+) -> bool:
+    """Determine whether a cached IDF index needs rebuilding.
+
+    Checks local metadata first, then drift. Provided for test compatibility.
+    """
+    if _is_cache_locally_invalid(cached, max_age_hours=max_age_hours):
+        return True
+    return _is_cache_drifted(
+        cached, current_count=current_count, drift_threshold=drift_threshold
+    )
 
 
 # --- Data structures ---
@@ -283,27 +305,31 @@ async def get_idf_index(
     if not force_rebuild:
         cached = load_idf_index(path)
         if cached is not None:
-            from scripts.core.db.postgres_pool import get_pool
+            # Short-circuit: check local metadata before querying DB
+            if _is_cache_locally_invalid(cached, max_age_hours=_IDF_MAX_AGE_HOURS):
+                logger.info("IDF cache locally invalid, rebuilding")
+            else:
+                # Cache metadata looks good; check drift against DB count
+                from scripts.core.db.postgres_pool import get_pool
 
-            pool = await get_pool()
-            async with pool.acquire() as conn:
-                row = await conn.fetchrow(
-                    """
-                    SELECT COUNT(*) as cnt FROM archival_memory
-                    WHERE metadata->>'type' = 'session_learning'
-                    AND superseded_by IS NULL
-                    """
-                )
-            current_count = row["cnt"] if row else 0
+                pool = await get_pool()
+                async with pool.acquire() as conn:
+                    row = await conn.fetchrow(
+                        """
+                        SELECT COUNT(*) as cnt FROM archival_memory
+                        WHERE metadata->>'type' = 'session_learning'
+                        AND superseded_by IS NULL
+                        """
+                    )
+                current_count = row["cnt"] if row else 0
 
-            if not _is_cache_stale(
-                cached,
-                max_age_hours=_IDF_MAX_AGE_HOURS,
-                current_count=current_count,
-                drift_threshold=_IDF_DRIFT_THRESHOLD,
-            ):
-                return cached
-            logger.info("IDF cache stale, rebuilding")
+                if not _is_cache_drifted(
+                    cached,
+                    current_count=current_count,
+                    drift_threshold=_IDF_DRIFT_THRESHOLD,
+                ):
+                    return cached
+                logger.info("IDF cache drift exceeded, rebuilding")
 
     return await build_idf_index(path)
 
@@ -335,6 +361,10 @@ async def expand_query(
 
     original_tokens = set(_tokenize(query))
     original_words = _sanitize_query_words(query)
+
+    # Skip expansion entirely if no usable original terms survive sanitization
+    if not original_words:
+        return query
 
     # Fetch vector neighbors (I/O boundary)
     pool = await get_pool()

--- a/scripts/core/query_expansion.py
+++ b/scripts/core/query_expansion.py
@@ -94,17 +94,29 @@ def _compute_neighbor_df(contents: Iterable[str]) -> dict[str, int]:
     return df
 
 
+def _fold_document(
+    word_df: dict[str, int], doc_count: int, text: str
+) -> tuple[dict[str, int], int]:
+    """Fold a single document into the word-DF accumulator.
+
+    Returns updated (word_df, doc_count). The caller's dict is mutated
+    for efficiency on large corpora, but the return value is canonical.
+    """
+    for w in set(_tokenize(text)):
+        word_df[w] = word_df.get(w, 0) + 1
+    return word_df, doc_count + 1
+
+
 def _compute_word_df(documents: Iterable[str]) -> tuple[dict[str, int], int]:
     """Compute corpus-wide word document frequency.
 
-    Returns (word_df dict, document count).
+    Returns (word_df dict, document count). Delegates to _fold_document
+    for each document.
     """
     word_df: dict[str, int] = {}
     doc_count = 0
     for text in documents:
-        doc_count += 1
-        for w in set(_tokenize(text)):
-            word_df[w] = word_df.get(w, 0) + 1
+        word_df, doc_count = _fold_document(word_df, doc_count, text)
     return word_df, doc_count
 
 
@@ -222,12 +234,14 @@ def load_idf_index(path: Path | None = None) -> IDFIndex | None:
 async def build_idf_index(path: Path | None = None) -> IDFIndex:
     """Build IDF index from all active learnings in the database.
 
-    Streams rows via cursor, delegates counting to _compute_word_df.
+    Streams rows via cursor, folding each document into the DF accumulator
+    without buffering the full corpus in memory.
     """
     from scripts.core.db.postgres_pool import get_pool
 
     pool = await get_pool()
-    documents: list[str] = []
+    word_df: dict[str, int] = {}
+    doc_count = 0
 
     async with pool.acquire() as conn:
         async with conn.transaction():
@@ -238,9 +252,7 @@ async def build_idf_index(path: Path | None = None) -> IDFIndex:
                 AND superseded_by IS NULL
                 """
             ):
-                documents.append(row["content"])
-
-    word_df, doc_count = _compute_word_df(documents)
+                word_df, doc_count = _fold_document(word_df, doc_count, row["content"])
 
     index = IDFIndex(
         word_df=word_df,

--- a/scripts/core/query_expansion.py
+++ b/scripts/core/query_expansion.py
@@ -73,13 +73,13 @@ def _sanitize_query_words(query: str) -> list[str]:
     words = [
         clean
         for w in query.lower().replace("-", " ").split()
-        if len(clean := re.sub(r"[^a-zA-Z0-9]", "", w)) > 2
+        if len(clean := _ALNUM_RE.sub("", w)) > 2
     ]
     if words:
         return words
     # Fallback: try first word cleaned; return empty list if nothing usable
     if query.strip():
-        fallback = re.sub(r"[^a-zA-Z0-9]", "", query.lower().split()[0])
+        fallback = _ALNUM_RE.sub("", query.lower().split()[0])
         if fallback:
             return [fallback]
     return []
@@ -141,7 +141,7 @@ def _score_expansion_candidates(
         corpus_idf = idf_index.idf(term)
         if corpus_idf < min_idf:
             continue
-        clean = re.sub(r"[^a-zA-Z0-9]", "", term)
+        clean = _ALNUM_RE.sub("", term)
         if not clean or len(clean) <= 2:
             continue
         candidates.append((clean, ndf * corpus_idf))
@@ -153,10 +153,15 @@ def _score_expansion_candidates(
 def _format_tsquery(original_words: list[str], expansion_terms: list[str]) -> str:
     """Join original and expansion terms into an OR-joined tsquery string.
 
-    Filters out empty/blank terms to prevent malformed tsquery syntax.
+    Defense-in-depth: strips tsquery metacharacters and empty/blank terms
+    to prevent injection even if upstream sanitizers are bypassed.
     """
-    all_terms = [t for t in original_words + expansion_terms if t.strip()]
-    return " | ".join(all_terms)
+    all_terms = [
+        _ALNUM_RE.sub("", t)
+        for t in original_words + expansion_terms
+        if t.strip()
+    ]
+    return " | ".join(t for t in all_terms if t)
 
 
 def _is_cache_locally_invalid(cached: IDFIndex, *, max_age_hours: float) -> bool:
@@ -359,6 +364,7 @@ async def expand_query(
     """
     from scripts.core.db.postgres_pool import get_pool
 
+    max_neighbors = min(max_neighbors, 100)
     original_tokens = set(_tokenize(query))
     original_words = _sanitize_query_words(query)
 

--- a/scripts/core/query_expansion.py
+++ b/scripts/core/query_expansion.py
@@ -12,6 +12,7 @@ import json
 import logging
 import math
 import re
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -46,6 +47,9 @@ _IDF_MAX_AGE_HOURS = _qe_cfg.idf_max_age_hours
 _IDF_DRIFT_THRESHOLD = _qe_cfg.idf_drift_threshold
 
 
+# --- Pure functions ---
+
+
 def _tokenize(text: str) -> list[str]:
     """Tokenize text for IDF computation.
 
@@ -53,12 +57,118 @@ def _tokenize(text: str) -> list[str]:
     filter short words and stopwords.
     """
     text = text.lower().replace("-", " ")
-    words = []
-    for w in text.split():
-        w = _ALNUM_RE.sub("", w)
-        if len(w) > 2 and w not in STOPWORDS:
-            words.append(w)
-    return words
+    return [
+        clean
+        for w in text.split()
+        if len(clean := _ALNUM_RE.sub("", w)) > 2 and clean not in STOPWORDS
+    ]
+
+
+def _sanitize_query_words(query: str) -> list[str]:
+    """Extract and sanitize query words for tsquery output.
+
+    Lowercases, replaces hyphens, strips non-alnum, filters short words.
+    Falls back to first cleaned word (or empty string) when no words survive.
+    """
+    words = [
+        clean
+        for w in query.lower().replace("-", " ").split()
+        if len(clean := re.sub(r"[^a-zA-Z0-9]", "", w)) > 2
+    ]
+    if words:
+        return words
+    # Fallback: take first word cleaned, or empty string
+    fallback = re.sub(r"[^a-zA-Z0-9]", "", query.lower().split()[0]) if query.strip() else ""
+    return [fallback] if fallback else [""]
+
+
+def _compute_neighbor_df(contents: Iterable[str]) -> dict[str, int]:
+    """Compute document frequency of tokens across neighbor documents.
+
+    Each document contributes at most once per unique token (set-based).
+    """
+    df: dict[str, int] = {}
+    for text in contents:
+        for w in set(_tokenize(text)):
+            df[w] = df.get(w, 0) + 1
+    return df
+
+
+def _compute_word_df(documents: Iterable[str]) -> tuple[dict[str, int], int]:
+    """Compute corpus-wide word document frequency.
+
+    Returns (word_df dict, document count).
+    """
+    word_df: dict[str, int] = {}
+    doc_count = 0
+    for text in documents:
+        doc_count += 1
+        for w in set(_tokenize(text)):
+            word_df[w] = word_df.get(w, 0) + 1
+    return word_df, doc_count
+
+
+def _score_expansion_candidates(
+    neighbor_df: dict[str, int],
+    idf_index: IDFIndex,
+    original_tokens: set[str],
+    min_idf: float,
+) -> list[tuple[str, float]]:
+    """Score and filter expansion candidates by neighbor_df * corpus_idf.
+
+    Excludes original tokens, stopwords, short terms, and low-IDF terms.
+    Returns sorted list of (term, score) descending by score.
+    """
+    candidates: list[tuple[str, float]] = []
+    for term, ndf in neighbor_df.items():
+        if term in original_tokens or term in STOPWORDS or len(term) <= 2:
+            continue
+        corpus_idf = idf_index.idf(term)
+        if corpus_idf < min_idf:
+            continue
+        clean = re.sub(r"[^a-zA-Z0-9]", "", term)
+        if not clean or len(clean) <= 2:
+            continue
+        candidates.append((clean, ndf * corpus_idf))
+
+    candidates.sort(key=lambda x: x[1], reverse=True)
+    return candidates
+
+
+def _format_tsquery(original_words: list[str], expansion_terms: list[str]) -> str:
+    """Join original and expansion terms into an OR-joined tsquery string."""
+    all_terms = original_words + expansion_terms
+    return " | ".join(all_terms)
+
+
+def _is_cache_stale(
+    cached: IDFIndex,
+    *,
+    max_age_hours: float,
+    current_count: int,
+    drift_threshold: float,
+) -> bool:
+    """Determine whether a cached IDF index needs rebuilding.
+
+    Stale when: age exceeds max_age_hours, doc count drift exceeds threshold,
+    zero cached docs, or unparseable timestamp.
+    """
+    try:
+        built = datetime.fromisoformat(cached.built_at)
+        age_hours = (datetime.now(UTC) - built).total_seconds() / 3600
+        if age_hours >= max_age_hours:
+            return True
+    except (ValueError, TypeError):
+        return True
+
+    if cached.doc_count == 0:
+        return True
+
+    drift = abs(current_count - cached.doc_count) / cached.doc_count
+    return drift > drift_threshold
+
+
+# --- Data structures ---
 
 
 @dataclass
@@ -75,6 +185,9 @@ class IDFIndex:
         if df == 0:
             return math.log(self.doc_count + 1)  # max IDF for unknown
         return math.log(self.doc_count / (1 + df))
+
+
+# --- I/O boundary functions ---
 
 
 def save_idf_index(index: IDFIndex, path: Path | None = None) -> None:
@@ -109,16 +222,12 @@ def load_idf_index(path: Path | None = None) -> IDFIndex | None:
 async def build_idf_index(path: Path | None = None) -> IDFIndex:
     """Build IDF index from all active learnings in the database.
 
-    Uses a cursor to stream rows instead of loading the entire corpus into RAM.
-
-    Args:
-        path: Where to save the index. Defaults to _IDF_CACHE_PATH.
+    Streams rows via cursor, delegates counting to _compute_word_df.
     """
     from scripts.core.db.postgres_pool import get_pool
 
     pool = await get_pool()
-    word_df: dict[str, int] = {}
-    doc_count = 0
+    documents: list[str] = []
 
     async with pool.acquire() as conn:
         async with conn.transaction():
@@ -129,10 +238,9 @@ async def build_idf_index(path: Path | None = None) -> IDFIndex:
                 AND superseded_by IS NULL
                 """
             ):
-                doc_count += 1
-                unique_words = set(_tokenize(row["content"]))
-                for w in unique_words:
-                    word_df[w] = word_df.get(w, 0) + 1
+                documents.append(row["content"])
+
+    word_df, doc_count = _compute_word_df(documents)
 
     index = IDFIndex(
         word_df=word_df,
@@ -151,42 +259,33 @@ async def get_idf_index(
 
     Rebuilds when:
     - No cached index exists
-    - Cache is older than 24 hours
-    - Doc count has drifted >10% from cached count
+    - Cache is older than configured max age
+    - Doc count has drifted beyond configured threshold
     """
     if not force_rebuild:
         cached = load_idf_index(path)
         if cached is not None:
-            # Check age
-            try:
-                built = datetime.fromisoformat(cached.built_at)
-                age_hours = (datetime.now(UTC) - built).total_seconds() / 3600
-                if age_hours < _IDF_MAX_AGE_HOURS:
-                    # Check drift
-                    from scripts.core.db.postgres_pool import get_pool
+            from scripts.core.db.postgres_pool import get_pool
 
-                    pool = await get_pool()
-                    async with pool.acquire() as conn:
-                        row = await conn.fetchrow(
-                            """
-                            SELECT COUNT(*) as cnt FROM archival_memory
-                            WHERE metadata->>'type' = 'session_learning'
-                            AND superseded_by IS NULL
-                            """
-                        )
-                    current_count = row["cnt"] if row else 0
-                    if cached.doc_count > 0:
-                        drift = abs(current_count - cached.doc_count) / cached.doc_count
-                    else:
-                        drift = 1.0
-                    if drift <= _IDF_DRIFT_THRESHOLD:
-                        return cached
-                    logger.info(
-                        "IDF index drift %.1f%% exceeds threshold, rebuilding",
-                        drift * 100,
-                    )
-            except (ValueError, TypeError):
-                pass  # bad timestamp, rebuild
+            pool = await get_pool()
+            async with pool.acquire() as conn:
+                row = await conn.fetchrow(
+                    """
+                    SELECT COUNT(*) as cnt FROM archival_memory
+                    WHERE metadata->>'type' = 'session_learning'
+                    AND superseded_by IS NULL
+                    """
+                )
+            current_count = row["cnt"] if row else 0
+
+            if not _is_cache_stale(
+                cached,
+                max_age_hours=_IDF_MAX_AGE_HOURS,
+                current_count=current_count,
+                drift_threshold=_IDF_DRIFT_THRESHOLD,
+            ):
+                return cached
+            logger.info("IDF cache stale, rebuilding")
 
     return await build_idf_index(path)
 
@@ -216,20 +315,10 @@ async def expand_query(
     """
     from scripts.core.db.postgres_pool import get_pool
 
-    # Build original query terms for the OR string
     original_tokens = set(_tokenize(query))
-    # Sanitize original words for tsquery safety (strip FTS operators and non-alnum)
-    original_words = []
-    for w in query.lower().replace("-", " ").split():
-        clean = re.sub(r"[^a-zA-Z0-9]", "", w)
-        if len(clean) > 2:
-            original_words.append(clean)
-    if not original_words:
-        # Last resort: take first word, cleaned
-        fallback = re.sub(r"[^a-zA-Z0-9]", "", query.lower().split()[0]) if query.strip() else ""
-        original_words = [fallback] if fallback else [""]
+    original_words = _sanitize_query_words(query)
 
-    # Fetch vector neighbors (pool init registers pgvector codec per connection)
+    # Fetch vector neighbors (I/O boundary)
     pool = await get_pool()
     async with pool.acquire() as conn:
         rows = await conn.fetch(
@@ -246,40 +335,14 @@ async def expand_query(
         )
 
     if not rows:
-        return " | ".join(original_words)
+        return _format_tsquery(original_words, [])
 
-    # Tokenize neighbors and count doc frequency within neighbor set
-    neighbor_df: dict[str, int] = {}
-    for row in rows:
-        unique_words = set(_tokenize(row["content"]))
-        for w in unique_words:
-            neighbor_df[w] = neighbor_df.get(w, 0) + 1
-
-    # Get corpus IDF
+    # Pure logic: compute neighbor df, score candidates, format output
+    neighbor_df = _compute_neighbor_df(row["content"] for row in rows)
     idf_index = await get_idf_index()
-
-    # Score: neighbor_df * corpus_idf
-    # High score = common among neighbors AND rare in corpus
-    candidates: list[tuple[str, float]] = []
-    for term, ndf in neighbor_df.items():
-        if term in original_tokens:
-            continue
-        if term in STOPWORDS or len(term) <= 2:
-            continue
-        corpus_idf = idf_index.idf(term)
-        if corpus_idf < min_idf:
-            continue
-        # Sanitize for tsquery safety
-        clean = re.sub(r"[^a-zA-Z0-9]", "", term)
-        if not clean or len(clean) <= 2:
-            continue
-        score = ndf * corpus_idf
-        candidates.append((clean, score))
-
-    # Sort by score descending, take top N
-    candidates.sort(key=lambda x: x[1], reverse=True)
+    candidates = _score_expansion_candidates(
+        neighbor_df, idf_index, original_tokens, min_idf
+    )
     expansion_terms = [t for t, _ in candidates[:max_expansion_terms]]
 
-    # Build OR-joined tsquery string
-    all_terms = original_words + expansion_terms
-    return " | ".join(all_terms)
+    return _format_tsquery(original_words, expansion_terms)

--- a/scripts/core/query_expansion.py
+++ b/scripts/core/query_expansion.py
@@ -77,9 +77,12 @@ def _sanitize_query_words(query: str) -> list[str]:
     ]
     if words:
         return words
-    # Fallback: take first word cleaned, or empty string
-    fallback = re.sub(r"[^a-zA-Z0-9]", "", query.lower().split()[0]) if query.strip() else ""
-    return [fallback] if fallback else [""]
+    # Fallback: try first word cleaned; return empty list if nothing usable
+    if query.strip():
+        fallback = re.sub(r"[^a-zA-Z0-9]", "", query.lower().split()[0])
+        if fallback:
+            return [fallback]
+    return []
 
 
 def _compute_neighbor_df(contents: Iterable[str]) -> dict[str, int]:
@@ -148,8 +151,11 @@ def _score_expansion_candidates(
 
 
 def _format_tsquery(original_words: list[str], expansion_terms: list[str]) -> str:
-    """Join original and expansion terms into an OR-joined tsquery string."""
-    all_terms = original_words + expansion_terms
+    """Join original and expansion terms into an OR-joined tsquery string.
+
+    Filters out empty/blank terms to prevent malformed tsquery syntax.
+    """
+    all_terms = [t for t in original_words + expansion_terms if t.strip()]
     return " | ".join(all_terms)
 
 
@@ -173,7 +179,7 @@ def _is_cache_stale(
     except (ValueError, TypeError):
         return True
 
-    if cached.doc_count == 0:
+    if not isinstance(cached.doc_count, int) or cached.doc_count <= 0:
         return True
 
     drift = abs(current_count - cached.doc_count) / cached.doc_count

--- a/tests/test_query_expansion.py
+++ b/tests/test_query_expansion.py
@@ -216,15 +216,19 @@ class TestIDFIndex:
 
     async def test_build_idf_index_streams_without_buffering(self):
         """Regression: build_idf_index must fold each row incrementally,
-        not buffer the entire corpus into a list first."""
-        consumed_count = 0
+        not buffer the entire corpus into a list first.
+
+        Proves interleaved iteration by patching _fold_document to record
+        call order relative to cursor consumption.
+        """
+        events: list[str] = []
 
         class StreamingCursor:
-            """Cursor that tracks consumption order."""
+            """Cursor that records 'read' events on each row consumed."""
 
             def __init__(self):
                 self._items = [
-                    {"content": f"document number {i} with unique content"} for i in range(100)
+                    {"content": f"document number {i} with unique content"} for i in range(5)
                 ]
                 self._idx = 0
 
@@ -232,13 +236,18 @@ class TestIDFIndex:
                 return self
 
             async def __anext__(self):
-                nonlocal consumed_count
                 if self._idx >= len(self._items):
                     raise StopAsyncIteration
                 item = self._items[self._idx]
                 self._idx += 1
-                consumed_count += 1
+                events.append("read")
                 return item
+
+        from scripts.core.query_expansion import _fold_document as real_fold
+
+        def tracking_fold(word_df, doc_count, text):
+            events.append("fold")
+            return real_fold(word_df, doc_count, text)
 
         mock_pool, _ = _make_pool_and_conn(
             cursor=MagicMock(return_value=StreamingCursor()),
@@ -246,10 +255,18 @@ class TestIDFIndex:
 
         with patch("scripts.core.db.postgres_pool.get_pool", return_value=mock_pool):
             with patch("scripts.core.query_expansion.save_idf_index"):  # noqa: SIM117
-                index = await build_idf_index()
+                with patch(
+                    "scripts.core.query_expansion._fold_document",
+                    side_effect=tracking_fold,
+                ):
+                    index = await build_idf_index()
 
-        assert index.doc_count == 100
-        assert consumed_count == 100
+        assert index.doc_count == 5
+        # Events must be interleaved: read, fold, read, fold, ...
+        # If buffered, it would be: read, read, read, ..., fold, fold, fold, ...
+        for i in range(0, len(events) - 1, 2):
+            assert events[i] == "read", f"Expected 'read' at position {i}, got {events[i]}"
+            assert events[i + 1] == "fold", f"Expected 'fold' at position {i+1}, got {events[i+1]}"
 
     async def test_get_idf_index_caches(self, tmp_path: Path):
         """Second call uses cached index when fresh."""

--- a/tests/test_query_expansion.py
+++ b/tests/test_query_expansion.py
@@ -214,6 +214,43 @@ class TestIDFIndex:
         assert "authentication" in index.word_df
         assert index.word_df["authentication"] == 1
 
+    async def test_build_idf_index_streams_without_buffering(self):
+        """Regression: build_idf_index must fold each row incrementally,
+        not buffer the entire corpus into a list first."""
+        consumed_count = 0
+
+        class StreamingCursor:
+            """Cursor that tracks consumption order."""
+
+            def __init__(self):
+                self._items = [
+                    {"content": f"document number {i} with unique content"} for i in range(100)
+                ]
+                self._idx = 0
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                nonlocal consumed_count
+                if self._idx >= len(self._items):
+                    raise StopAsyncIteration
+                item = self._items[self._idx]
+                self._idx += 1
+                consumed_count += 1
+                return item
+
+        mock_pool, _ = _make_pool_and_conn(
+            cursor=MagicMock(return_value=StreamingCursor()),
+        )
+
+        with patch("scripts.core.db.postgres_pool.get_pool", return_value=mock_pool):
+            with patch("scripts.core.query_expansion.save_idf_index"):  # noqa: SIM117
+                index = await build_idf_index()
+
+        assert index.doc_count == 100
+        assert consumed_count == 100
+
     async def test_get_idf_index_caches(self, tmp_path: Path):
         """Second call uses cached index when fresh."""
         path = tmp_path / "idf.json"
@@ -469,6 +506,32 @@ class TestFormatTsquery:
 
         result = _format_tsquery([], [])
         assert result == ""
+
+
+class TestFoldDocument:
+    def test_folds_single_document(self):
+        from scripts.core.query_expansion import _fold_document
+
+        word_df, count = _fold_document({}, 0, "authentication tokens important")
+        assert count == 1
+        assert "authentication" in word_df
+        assert "tokens" in word_df
+
+    def test_folds_incrementally(self):
+        from scripts.core.query_expansion import _fold_document
+
+        word_df, count = _fold_document({}, 0, "authentication tokens")
+        word_df, count = _fold_document(word_df, count, "tokens expire")
+        assert count == 2
+        assert word_df["tokens"] == 2
+        assert word_df["authentication"] == 1
+
+    def test_deduplicates_within_document(self):
+        from scripts.core.query_expansion import _fold_document
+
+        word_df, count = _fold_document({}, 0, "tokens tokens tokens")
+        assert count == 1
+        assert word_df["tokens"] == 1
 
 
 class TestComputeWordDf:

--- a/tests/test_query_expansion.py
+++ b/tests/test_query_expansion.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -107,6 +108,19 @@ class TestTokenize:
         assert "world" in result
         assert "test" in result
 
+    def test_empty_string(self):
+        assert _tokenize("") == []
+
+    def test_only_stopwords(self):
+        assert _tokenize("the and or but") == []
+
+    def test_only_short_words(self):
+        assert _tokenize("a I am") == []
+
+    def test_returns_list_type(self):
+        result = _tokenize("hello world")
+        assert isinstance(result, list)
+
 
 # --- IDFIndex tests ---
 
@@ -129,6 +143,24 @@ class TestIDFIndex:
         unknown_idf = index.idf("unknown")
         known_idf = index.idf("known")
         assert unknown_idf > known_idf  # unknown gets max IDF
+
+    def test_idf_formula_correctness(self):
+        index = IDFIndex(
+            word_df={"term": 10},
+            doc_count=100,
+            built_at="2026-01-01T00:00:00",
+        )
+        expected = math.log(100 / (1 + 10))
+        assert index.idf("term") == pytest.approx(expected)
+
+    def test_idf_unknown_formula(self):
+        index = IDFIndex(
+            word_df={},
+            doc_count=100,
+            built_at="2026-01-01T00:00:00",
+        )
+        expected = math.log(101)
+        assert index.idf("unknown") == pytest.approx(expected)
 
     def test_save_load_roundtrip(self, tmp_path: Path):
         path = tmp_path / "idf_test.json"
@@ -155,6 +187,12 @@ class TestIDFIndex:
         path.write_text("not valid json {{{")
         result = load_idf_index(path)
         assert result is None
+
+    def test_save_creates_parent_dirs(self, tmp_path: Path):
+        path = tmp_path / "nested" / "deep" / "idf.json"
+        index = IDFIndex(word_df={"x": 1}, doc_count=1, built_at="t")
+        save_idf_index(index, path)
+        assert path.exists()
 
     async def test_build_idf_index(self):
         mock_rows = [
@@ -214,6 +252,339 @@ class TestIDFIndex:
         assert "fresh" in result.word_df
 
 
+# --- Pure function tests (extracted for FP compliance) ---
+
+
+class TestSanitizeQueryWords:
+    def test_basic_extraction(self):
+        from scripts.core.query_expansion import _sanitize_query_words
+
+        result = _sanitize_query_words("auth patterns")
+        assert "auth" in result
+        assert "patterns" in result
+
+    def test_strips_punctuation(self):
+        from scripts.core.query_expansion import _sanitize_query_words
+
+        result = _sanitize_query_words("hello! world?")
+        assert result == ["hello", "world"]
+
+    def test_filters_short_words(self):
+        from scripts.core.query_expansion import _sanitize_query_words
+
+        result = _sanitize_query_words("a I am big dog")
+        assert "big" in result
+        assert "dog" in result
+        assert "am" not in result
+
+    def test_lowercases(self):
+        from scripts.core.query_expansion import _sanitize_query_words
+
+        result = _sanitize_query_words("Auth PATTERNS")
+        assert result == ["auth", "patterns"]
+
+    def test_replaces_hyphens(self):
+        from scripts.core.query_expansion import _sanitize_query_words
+
+        result = _sanitize_query_words("multi-terminal")
+        assert "multi" in result
+        assert "terminal" in result
+
+    def test_empty_query_fallback(self):
+        from scripts.core.query_expansion import _sanitize_query_words
+
+        result = _sanitize_query_words("")
+        assert result == [""]
+
+    def test_only_short_words_fallback(self):
+        from scripts.core.query_expansion import _sanitize_query_words
+
+        result = _sanitize_query_words("a I")
+        assert isinstance(result, list)
+        assert len(result) >= 1
+
+
+class TestComputeNeighborDf:
+    def test_basic_counting(self):
+        from scripts.core.query_expansion import _compute_neighbor_df
+
+        contents = [
+            "authentication tokens are important",
+            "tokens expire after timeout",
+        ]
+        result = _compute_neighbor_df(contents)
+        assert result["tokens"] == 2
+        assert result["authentication"] == 1
+
+    def test_empty_contents(self):
+        from scripts.core.query_expansion import _compute_neighbor_df
+
+        result = _compute_neighbor_df([])
+        assert result == {}
+
+    def test_deduplicates_within_document(self):
+        from scripts.core.query_expansion import _compute_neighbor_df
+
+        contents = ["tokens tokens tokens"]
+        result = _compute_neighbor_df(contents)
+        assert result["tokens"] == 1  # unique per doc
+
+    def test_stopwords_excluded(self):
+        from scripts.core.query_expansion import _compute_neighbor_df
+
+        contents = ["the authentication with help"]
+        result = _compute_neighbor_df(contents)
+        assert "the" not in result
+        assert "with" not in result
+        assert "help" not in result
+        assert "authentication" in result
+
+
+class TestScoreExpansionCandidates:
+    def _make_idf(self) -> IDFIndex:
+        return IDFIndex(
+            word_df={"authentication": 5, "tokens": 8, "database": 50},
+            doc_count=200,
+            built_at="2026-01-01T00:00:00",
+        )
+
+    def test_scores_by_ndf_times_idf(self):
+        from scripts.core.query_expansion import _score_expansion_candidates
+
+        idf_index = self._make_idf()
+        neighbor_df = {"authentication": 3, "tokens": 2}
+        original_tokens: set[str] = set()
+
+        result = _score_expansion_candidates(
+            neighbor_df, idf_index, original_tokens, min_idf=0.0
+        )
+        result_dict = dict(result)
+        assert "authentication" in result_dict
+        assert "tokens" in result_dict
+
+    def test_excludes_original_tokens(self):
+        from scripts.core.query_expansion import _score_expansion_candidates
+
+        idf_index = self._make_idf()
+        neighbor_df = {"authentication": 3, "tokens": 2}
+        original_tokens = {"authentication"}
+
+        result = _score_expansion_candidates(
+            neighbor_df, idf_index, original_tokens, min_idf=0.0
+        )
+        terms = [t for t, _ in result]
+        assert "authentication" not in terms
+        assert "tokens" in terms
+
+    def test_excludes_stopwords(self):
+        from scripts.core.query_expansion import _score_expansion_candidates
+
+        idf_index = self._make_idf()
+        neighbor_df = {"the": 5, "authentication": 3}
+        original_tokens: set[str] = set()
+
+        result = _score_expansion_candidates(
+            neighbor_df, idf_index, original_tokens, min_idf=0.0
+        )
+        terms = [t for t, _ in result]
+        assert "the" not in terms
+
+    def test_excludes_short_terms(self):
+        from scripts.core.query_expansion import _score_expansion_candidates
+
+        idf_index = self._make_idf()
+        neighbor_df = {"ab": 5, "authentication": 3}
+        original_tokens: set[str] = set()
+
+        result = _score_expansion_candidates(
+            neighbor_df, idf_index, original_tokens, min_idf=0.0
+        )
+        terms = [t for t, _ in result]
+        assert "ab" not in terms
+
+    def test_min_idf_filter(self):
+        from scripts.core.query_expansion import _score_expansion_candidates
+
+        idf_index = IDFIndex(
+            word_df={"common": 190},  # IDF ~ log(200/191) ~ 0.046
+            doc_count=200,
+            built_at="2026-01-01T00:00:00",
+        )
+        neighbor_df = {"common": 5}
+        original_tokens: set[str] = set()
+
+        result = _score_expansion_candidates(
+            neighbor_df, idf_index, original_tokens, min_idf=1.0
+        )
+        assert len(result) == 0  # filtered by min_idf
+
+    def test_sorted_descending(self):
+        from scripts.core.query_expansion import _score_expansion_candidates
+
+        idf_index = self._make_idf()
+        neighbor_df = {"authentication": 10, "tokens": 1}
+        original_tokens: set[str] = set()
+
+        result = _score_expansion_candidates(
+            neighbor_df, idf_index, original_tokens, min_idf=0.0
+        )
+        scores = [s for _, s in result]
+        assert scores == sorted(scores, reverse=True)
+
+    def test_sanitizes_non_alnum(self):
+        from scripts.core.query_expansion import _score_expansion_candidates
+
+        idf_index = IDFIndex(word_df={}, doc_count=100, built_at="t")
+        neighbor_df = {"hello": 3}
+        original_tokens: set[str] = set()
+
+        result = _score_expansion_candidates(
+            neighbor_df, idf_index, original_tokens, min_idf=0.0
+        )
+        for term, _ in result:
+            assert term.isalnum()
+
+
+class TestFormatTsquery:
+    def test_basic_format(self):
+        from scripts.core.query_expansion import _format_tsquery
+
+        result = _format_tsquery(["auth", "patterns"], ["authentication", "workflow"])
+        assert result == "auth | patterns | authentication | workflow"
+
+    def test_no_expansion_terms(self):
+        from scripts.core.query_expansion import _format_tsquery
+
+        result = _format_tsquery(["auth", "patterns"], [])
+        assert result == "auth | patterns"
+
+    def test_single_original_term(self):
+        from scripts.core.query_expansion import _format_tsquery
+
+        result = _format_tsquery(["auth"], ["workflow"])
+        assert result == "auth | workflow"
+
+    def test_empty_lists_returns_empty_string(self):
+        from scripts.core.query_expansion import _format_tsquery
+
+        result = _format_tsquery([], [])
+        assert result == ""
+
+
+class TestComputeWordDf:
+    def test_basic_counting(self):
+        from scripts.core.query_expansion import _compute_word_df
+
+        documents = [
+            "authentication tokens important",
+            "tokens expire timeout",
+            "database connection pooling",
+        ]
+        word_df, doc_count = _compute_word_df(documents)
+        assert doc_count == 3
+        assert word_df["tokens"] == 2
+        assert word_df["authentication"] == 1
+
+    def test_empty_documents(self):
+        from scripts.core.query_expansion import _compute_word_df
+
+        word_df, doc_count = _compute_word_df([])
+        assert doc_count == 0
+        assert word_df == {}
+
+    def test_deduplicates_within_document(self):
+        from scripts.core.query_expansion import _compute_word_df
+
+        documents = ["tokens tokens tokens"]
+        word_df, doc_count = _compute_word_df(documents)
+        assert doc_count == 1
+        assert word_df["tokens"] == 1
+
+
+class TestIsCacheStale:
+    def test_fresh_cache_not_stale(self):
+        from datetime import UTC, datetime
+
+        from scripts.core.query_expansion import _is_cache_stale
+
+        cached = IDFIndex(
+            word_df={"test": 1},
+            doc_count=100,
+            built_at=datetime.now(UTC).isoformat(),
+        )
+        assert _is_cache_stale(
+            cached, max_age_hours=24, current_count=100, drift_threshold=0.1
+        ) is False
+
+    def test_old_cache_is_stale(self):
+        from scripts.core.query_expansion import _is_cache_stale
+
+        cached = IDFIndex(
+            word_df={"test": 1},
+            doc_count=100,
+            built_at="2020-01-01T00:00:00+00:00",
+        )
+        assert _is_cache_stale(
+            cached, max_age_hours=24, current_count=100, drift_threshold=0.1
+        ) is True
+
+    def test_high_drift_is_stale(self):
+        from datetime import UTC, datetime
+
+        from scripts.core.query_expansion import _is_cache_stale
+
+        cached = IDFIndex(
+            word_df={"test": 1},
+            doc_count=100,
+            built_at=datetime.now(UTC).isoformat(),
+        )
+        # 50% drift exceeds 10% threshold
+        assert _is_cache_stale(
+            cached, max_age_hours=24, current_count=150, drift_threshold=0.1
+        ) is True
+
+    def test_zero_doc_count_is_stale(self):
+        from datetime import UTC, datetime
+
+        from scripts.core.query_expansion import _is_cache_stale
+
+        cached = IDFIndex(
+            word_df={},
+            doc_count=0,
+            built_at=datetime.now(UTC).isoformat(),
+        )
+        assert _is_cache_stale(
+            cached, max_age_hours=24, current_count=10, drift_threshold=0.1
+        ) is True
+
+    def test_bad_timestamp_is_stale(self):
+        from scripts.core.query_expansion import _is_cache_stale
+
+        cached = IDFIndex(
+            word_df={"test": 1},
+            doc_count=100,
+            built_at="not-a-timestamp",
+        )
+        assert _is_cache_stale(
+            cached, max_age_hours=24, current_count=100, drift_threshold=0.1
+        ) is True
+
+    def test_within_drift_threshold(self):
+        from datetime import UTC, datetime
+
+        from scripts.core.query_expansion import _is_cache_stale
+
+        cached = IDFIndex(
+            word_df={"test": 1},
+            doc_count=100,
+            built_at=datetime.now(UTC).isoformat(),
+        )
+        # 5% drift is within 10% threshold
+        assert _is_cache_stale(
+            cached, max_age_hours=24, current_count=105, drift_threshold=0.1
+        ) is False
+
+
 # --- expand_query tests ---
 
 
@@ -250,7 +621,8 @@ class TestExpandQuery:
             patch("scripts.core.db.postgres_pool.init_pgvector", new_callable=AsyncMock),
             patch(
                 "scripts.core.query_expansion.get_idf_index",
-                new_callable=AsyncMock, return_value=idf_index,
+                new_callable=AsyncMock,
+                return_value=idf_index,
             ),
         ):
             result = await expand_query("auth patterns", [0.1] * 1024)
@@ -280,7 +652,8 @@ class TestExpandQuery:
             patch("scripts.core.db.postgres_pool.init_pgvector", new_callable=AsyncMock),
             patch(
                 "scripts.core.query_expansion.get_idf_index",
-                new_callable=AsyncMock, return_value=idf_index,
+                new_callable=AsyncMock,
+                return_value=idf_index,
             ),
         ):
             result = await expand_query("authentication setup", [0.1] * 1024)
@@ -305,7 +678,8 @@ class TestExpandQuery:
             patch("scripts.core.db.postgres_pool.init_pgvector", new_callable=AsyncMock),
             patch(
                 "scripts.core.query_expansion.get_idf_index",
-                new_callable=AsyncMock, return_value=idf_index,
+                new_callable=AsyncMock,
+                return_value=idf_index,
             ),
         ):
             result = await expand_query("auth test", [0.1] * 1024)
@@ -331,7 +705,8 @@ class TestExpandQuery:
             patch("scripts.core.db.postgres_pool.init_pgvector", new_callable=AsyncMock),
             patch(
                 "scripts.core.query_expansion.get_idf_index",
-                new_callable=AsyncMock, return_value=idf_index,
+                new_callable=AsyncMock,
+                return_value=idf_index,
             ),
         ):
             result = await expand_query(
@@ -383,7 +758,8 @@ class TestExpandQuery:
             patch("scripts.core.db.postgres_pool.init_pgvector", new_callable=AsyncMock),
             patch(
                 "scripts.core.query_expansion.get_idf_index",
-                new_callable=AsyncMock, return_value=idf_index,
+                new_callable=AsyncMock,
+                return_value=idf_index,
             ),
         ):
             result = await expand_query("auth", [0.1] * 1024)
@@ -487,7 +863,9 @@ class TestHybridRRFWithExpansion:
             await search_learnings_hybrid_rrf("auth patterns", k=5, expand=True)
 
         # The SQL should contain to_tsquery (not plainto_tsquery)
-        assert any("to_tsquery" in sql and "plainto_tsquery" not in sql for sql in captured_sql)
+        assert any(
+            "to_tsquery" in sql and "plainto_tsquery" not in sql for sql in captured_sql
+        )
 
     async def test_plainto_tsquery_when_not_expanded(self):
         """When no expansion, plainto_tsquery should be used."""

--- a/tests/test_query_expansion.py
+++ b/tests/test_query_expansion.py
@@ -327,18 +327,31 @@ class TestSanitizeQueryWords:
         assert "multi" in result
         assert "terminal" in result
 
-    def test_empty_query_fallback(self):
+    def test_empty_query_returns_empty_list(self):
         from scripts.core.query_expansion import _sanitize_query_words
 
         result = _sanitize_query_words("")
-        assert result == [""]
+        assert result == []
 
-    def test_only_short_words_fallback(self):
+    def test_only_short_words_uses_fallback(self):
         from scripts.core.query_expansion import _sanitize_query_words
 
+        # Fallback takes first cleaned word even if short
         result = _sanitize_query_words("a I")
-        assert isinstance(result, list)
-        assert len(result) >= 1
+        assert result == ["a"]
+
+    def test_punctuation_only_returns_empty_list(self):
+        from scripts.core.query_expansion import _sanitize_query_words
+
+        result = _sanitize_query_words("!!! ??? ...")
+        assert result == []
+
+    def test_stopwords_only_returns_short_fallback(self):
+        from scripts.core.query_expansion import _sanitize_query_words
+
+        # "the" is only 3 chars but passes the >2 length check
+        result = _sanitize_query_words("the")
+        assert result == ["the"]
 
 
 class TestComputeNeighborDf:
@@ -507,6 +520,18 @@ class TestFormatTsquery:
         result = _format_tsquery([], [])
         assert result == ""
 
+    def test_filters_blank_terms(self):
+        from scripts.core.query_expansion import _format_tsquery
+
+        result = _format_tsquery(["", "auth"], ["", "workflow"])
+        assert result == "auth | workflow"
+
+    def test_all_blank_terms_returns_empty(self):
+        from scripts.core.query_expansion import _format_tsquery
+
+        result = _format_tsquery(["", " "], [])
+        assert result == ""
+
 
 class TestFoldDocument:
     def test_folds_single_document(self):
@@ -627,6 +652,34 @@ class TestIsCacheStale:
             word_df={"test": 1},
             doc_count=100,
             built_at="not-a-timestamp",
+        )
+        assert _is_cache_stale(
+            cached, max_age_hours=24, current_count=100, drift_threshold=0.1
+        ) is True
+
+    def test_negative_doc_count_is_stale(self):
+        from datetime import UTC, datetime
+
+        from scripts.core.query_expansion import _is_cache_stale
+
+        cached = IDFIndex(
+            word_df={"test": 1},
+            doc_count=-5,
+            built_at=datetime.now(UTC).isoformat(),
+        )
+        assert _is_cache_stale(
+            cached, max_age_hours=24, current_count=100, drift_threshold=0.1
+        ) is True
+
+    def test_string_doc_count_is_stale(self):
+        from datetime import UTC, datetime
+
+        from scripts.core.query_expansion import _is_cache_stale
+
+        cached = IDFIndex(
+            word_df={"test": 1},
+            doc_count="ten",  # type: ignore[arg-type]
+            built_at=datetime.now(UTC).isoformat(),
         )
         assert _is_cache_stale(
             cached, max_age_hours=24, current_count=100, drift_threshold=0.1

--- a/tests/test_query_expansion.py
+++ b/tests/test_query_expansion.py
@@ -589,6 +589,94 @@ class TestComputeWordDf:
         assert word_df["tokens"] == 1
 
 
+class TestIsCacheLocallyInvalid:
+    def test_fresh_valid_cache(self):
+        from datetime import UTC, datetime
+
+        from scripts.core.query_expansion import _is_cache_locally_invalid
+
+        cached = IDFIndex(
+            word_df={"test": 1},
+            doc_count=100,
+            built_at=datetime.now(UTC).isoformat(),
+        )
+        assert _is_cache_locally_invalid(cached, max_age_hours=24) is False
+
+    def test_expired_cache(self):
+        from scripts.core.query_expansion import _is_cache_locally_invalid
+
+        cached = IDFIndex(
+            word_df={"test": 1},
+            doc_count=100,
+            built_at="2020-01-01T00:00:00+00:00",
+        )
+        assert _is_cache_locally_invalid(cached, max_age_hours=24) is True
+
+    def test_bad_timestamp(self):
+        from scripts.core.query_expansion import _is_cache_locally_invalid
+
+        cached = IDFIndex(word_df={}, doc_count=100, built_at="garbage")
+        assert _is_cache_locally_invalid(cached, max_age_hours=24) is True
+
+    def test_zero_doc_count(self):
+        from datetime import UTC, datetime
+
+        from scripts.core.query_expansion import _is_cache_locally_invalid
+
+        cached = IDFIndex(
+            word_df={}, doc_count=0, built_at=datetime.now(UTC).isoformat()
+        )
+        assert _is_cache_locally_invalid(cached, max_age_hours=24) is True
+
+    def test_negative_doc_count(self):
+        from datetime import UTC, datetime
+
+        from scripts.core.query_expansion import _is_cache_locally_invalid
+
+        cached = IDFIndex(
+            word_df={}, doc_count=-5, built_at=datetime.now(UTC).isoformat()
+        )
+        assert _is_cache_locally_invalid(cached, max_age_hours=24) is True
+
+    def test_string_doc_count(self):
+        from datetime import UTC, datetime
+
+        from scripts.core.query_expansion import _is_cache_locally_invalid
+
+        cached = IDFIndex(
+            word_df={},
+            doc_count="ten",  # type: ignore[arg-type]
+            built_at=datetime.now(UTC).isoformat(),
+        )
+        assert _is_cache_locally_invalid(cached, max_age_hours=24) is True
+
+
+class TestIsCacheDrifted:
+    def test_no_drift(self):
+        from scripts.core.query_expansion import _is_cache_drifted
+
+        cached = IDFIndex(word_df={}, doc_count=100, built_at="t")
+        assert _is_cache_drifted(
+            cached, current_count=100, drift_threshold=0.1
+        ) is False
+
+    def test_within_threshold(self):
+        from scripts.core.query_expansion import _is_cache_drifted
+
+        cached = IDFIndex(word_df={}, doc_count=100, built_at="t")
+        assert _is_cache_drifted(
+            cached, current_count=105, drift_threshold=0.1
+        ) is False
+
+    def test_exceeds_threshold(self):
+        from scripts.core.query_expansion import _is_cache_drifted
+
+        cached = IDFIndex(word_df={}, doc_count=100, built_at="t")
+        assert _is_cache_drifted(
+            cached, current_count=150, drift_threshold=0.1
+        ) is True
+
+
 class TestIsCacheStale:
     def test_fresh_cache_not_stale(self):
         from datetime import UTC, datetime
@@ -844,6 +932,16 @@ class TestExpandQuery:
 
         assert "auth" in result
         assert "patterns" in result
+
+    async def test_unsanitizable_query_skips_expansion(self):
+        """Punctuation-only queries skip expansion and return original."""
+        result = await expand_query("!!! ???", [0.1] * 1024)
+        assert result == "!!! ???"
+
+    async def test_empty_query_skips_expansion(self):
+        """Empty queries skip expansion and return original."""
+        result = await expand_query("", [0.1] * 1024)
+        assert result == ""
 
     async def test_expansion_failure_returns_original(self):
         """If expand_query raises, the caller should handle gracefully."""

--- a/tests/test_query_expansion.py
+++ b/tests/test_query_expansion.py
@@ -532,6 +532,17 @@ class TestFormatTsquery:
         result = _format_tsquery(["", " "], [])
         assert result == ""
 
+    def test_strips_tsquery_metacharacters(self):
+        from scripts.core.query_expansion import _format_tsquery
+
+        result = _format_tsquery(["auth!"], ["work&flow", "tok:*ens"])
+        assert "!" not in result
+        assert "&" not in result
+        assert ":*" not in result
+        assert "auth" in result
+        assert "workflow" in result
+        assert "tokens" in result
+
 
 class TestFoldDocument:
     def test_folds_single_document(self):


### PR DESCRIPTION
## Summary

- Extract 8 pure functions from `expand_query` god function, `build_idf_index`, and `get_idf_index`: `_sanitize_query_words`, `_compute_neighbor_df`, `_compute_word_df`, `_fold_document`, `_score_expansion_candidates`, `_format_tsquery`, `_is_cache_locally_invalid`, `_is_cache_drifted`
- Convert `_tokenize` from imperative loop to list comprehension
- Reorganize file into Pure functions / Data structures / I/O boundary sections
- Security hardening: tsquery metacharacter stripping in `_format_tsquery`, `max_neighbors` clamped to 100, compiled regex reuse throughout

### Adversarial review findings addressed (3 rounds)

1. **Round 1**: Restored streaming aggregation in `build_idf_index` via `_fold_document` — prevents OOM on large corpora
2. **Round 2**: Blank tsquery term filtering, non-integer/negative `doc_count` cache validation
3. **Round 3**: Split `_is_cache_stale` into `_is_cache_locally_invalid` + `_is_cache_drifted` — avoids unnecessary DB COUNT(*) on expired/corrupt caches; `expand_query` skips expansion on unsanitizable queries

### Coverage

```
Name                              Stmts   Miss  Cover   Missing
---------------------------------------------------------------
scripts/core/query_expansion.py     150      3    98%   146, 315, 337
---------------------------------------------------------------
TOTAL                               150      3    98%
```

## Test plan

- [x] 84 unit tests pass (20 existing + 64 new)
- [x] Full test suite: 1590 passed, 0 failed
- [x] `ruff check` clean
- [x] 3 rounds of adversarial review completed
- [x] Security audit completed (aegis)
- [x] Streaming regression test validates cursor consumption
- [x] Edge cases: punctuation-only queries, corrupt cache, negative doc_count, tsquery metacharacters
