### PR TITLE
S25: TDD+FP refactor of push_learnings.py

### DIFF
--- a/scripts/core/push_learnings.py
+++ b/scripts/core/push_learnings.py
@@ -93,6 +93,8 @@ def _row_to_dict(row: Mapping[str, Any]) -> dict[str, Any]:
             metadata = json.loads(metadata)
         except (json.JSONDecodeError, TypeError):
             metadata = {}
+    if not isinstance(metadata, Mapping):
+        metadata = {}
     return {
         "id": str(row["id"]),
         "content": row["content"],
@@ -329,7 +331,10 @@ async def main() -> int:
             "error": type(e).__name__, "push_source": "session_start",
             "project": project, "results": [],
         }
-        write_cache_file(error_envelope)
+        try:
+            write_cache_file(error_envelope)
+        except OSError:
+            logger.debug("Failed to write error cache file", exc_info=True)
         if json_output:
             print(json.dumps(error_envelope))
         else:
@@ -352,7 +357,10 @@ async def main() -> int:
     else:
         cache_data = format_results(candidates, project, config["max_chars"])
 
-    write_cache_file(cache_data)
+    try:
+        write_cache_file(cache_data)
+    except OSError:
+        logger.debug("Failed to write cache file", exc_info=True)
 
     output_str = build_cli_output(
         candidates, project,

--- a/scripts/core/push_learnings.py
+++ b/scripts/core/push_learnings.py
@@ -26,26 +26,27 @@ import json
 import logging
 import os
 import sys
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
 import asyncpg
 
+from scripts.core.db.postgres_pool import get_pool
+from scripts.core.recall_formatters import get_api_version
+from scripts.core.recall_learnings import get_backend
+
 logger = logging.getLogger(__name__)
 
 
-async def get_stale_learnings(
-    project: str, k: int, *, conn: Any = None
-) -> list[dict[str, Any]]:
-    """Fetch never-recalled, high/medium confidence learnings for a project."""
-    if conn is None:
-        from scripts.core.db.postgres_pool import get_pool
+# ---------------------------------------------------------------------------
+# SQL query builders (pure)
+# ---------------------------------------------------------------------------
 
-        pool = await get_pool()
-        async with pool.acquire() as conn:
-            return await get_stale_learnings(project, k, conn=conn)
-    rows = await conn.fetch(
-        """
+
+def build_stale_query_params(project: str, k: int) -> tuple[str, list[Any]]:
+    """Build SQL and params for fetching stale learnings."""
+    sql = """
         SELECT id, content, metadata, created_at, recall_count
         FROM archival_memory
         WHERE metadata->>'type' = 'session_learning'
@@ -57,25 +58,13 @@ async def get_stale_learnings(
           CASE metadata->>'confidence' WHEN 'high' THEN 0 ELSE 1 END,
           created_at DESC
         LIMIT $2
-        """,
-        project,
-        k,
-    )
-    return [_row_to_dict(row) for row in rows]
+    """
+    return sql, [project, k]
 
 
-async def get_pattern_representatives(
-    k: int, *, conn: Any = None
-) -> list[dict[str, Any]]:
-    """Fetch never-recalled pattern representatives from high-value clusters."""
-    if conn is None:
-        from scripts.core.db.postgres_pool import get_pool
-
-        pool = await get_pool()
-        async with pool.acquire() as conn:
-            return await get_pattern_representatives(k, conn=conn)
-    rows = await conn.fetch(
-        """
+def build_pattern_query_params(k: int) -> tuple[str, list[Any]]:
+    """Build SQL and params for fetching pattern representatives."""
+    sql = """
         SELECT a.id, a.content, a.metadata, a.created_at, a.recall_count,
                dp.pattern_type, dp.label AS pattern_label,
                dp.confidence AS pattern_confidence
@@ -87,24 +76,23 @@ async def get_pattern_representatives(
           AND a.superseded_by IS NULL
         ORDER BY dp.confidence DESC, a.created_at DESC
         LIMIT $1
-        """,
-        k,
-    )
-    results = []
-    for row in rows:
-        d = _row_to_dict(row)
-        d["pattern_label"] = row.get("pattern_label")
-        raw_conf = row.get("pattern_confidence")
-        d["pattern_confidence"] = float(raw_conf) if raw_conf is not None else None
-        results.append(d)
-    return results
+    """
+    return sql, [k]
 
 
-def _row_to_dict(row: Any) -> dict[str, Any]:
+# ---------------------------------------------------------------------------
+# Row converters (pure)
+# ---------------------------------------------------------------------------
+
+
+def _row_to_dict(row: Mapping[str, Any]) -> dict[str, Any]:
     """Convert an asyncpg Record to a plain dict."""
     metadata = row["metadata"]
     if isinstance(metadata, str):
-        metadata = json.loads(metadata)
+        try:
+            metadata = json.loads(metadata)
+        except (json.JSONDecodeError, TypeError):
+            metadata = {}
     return {
         "id": str(row["id"]),
         "content": row["content"],
@@ -116,6 +104,20 @@ def _row_to_dict(row: Any) -> dict[str, Any]:
         "pattern_label": None,
         "pattern_confidence": None,
     }
+
+
+def parse_pattern_row(row: Mapping[str, Any]) -> dict[str, Any]:
+    """Convert a pattern query row to a candidate dict with pattern fields."""
+    d = _row_to_dict(row)
+    d["pattern_label"] = row.get("pattern_label")
+    raw_conf = row.get("pattern_confidence")
+    d["pattern_confidence"] = float(raw_conf) if raw_conf is not None else None
+    return d
+
+
+# ---------------------------------------------------------------------------
+# Pure domain functions
+# ---------------------------------------------------------------------------
 
 
 def merge_candidates(
@@ -138,7 +140,6 @@ def merge_candidates(
 
 def truncate_content(content: str, max_chars: int) -> str:
     """Truncate content to max_chars, appending '...' if trimmed."""
-    # Collapse to single line for compact display
     one_line = " ".join(
         line.strip() for line in content.split("\n") if line.strip()
     )
@@ -151,11 +152,8 @@ def format_results(
     candidates: list[dict[str, Any]], project: str, max_chars: int
 ) -> dict[str, Any]:
     """Build the JSON output structure."""
-    from scripts.core.recall_formatters import get_api_version
-
-    results = []
-    for c in candidates:
-        results.append({
+    results = [
+        {
             "id": c["id"],
             "content": truncate_content(c["content"], max_chars),
             "learning_type": c["learning_type"],
@@ -166,13 +164,95 @@ def format_results(
                 if hasattr(c["created_at"], "isoformat")
                 else str(c["created_at"])
             ),
-        })
+        }
+        for c in candidates
+    ]
     return {
         "version": get_api_version(),
         "push_source": "session_start",
         "project": project,
         "results": results,
     }
+
+
+# ---------------------------------------------------------------------------
+# CLI helpers (pure)
+# ---------------------------------------------------------------------------
+
+
+def parse_args(argv: list[str] | None = None) -> dict[str, Any]:
+    """Parse CLI arguments into a config dict."""
+    parser = argparse.ArgumentParser(
+        description="Proactive memory push — surface never-recalled high-value learnings",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--project",
+        default=(
+            Path(os.environ["CLAUDE_PROJECT_DIR"]).name
+            if os.environ.get("CLAUDE_PROJECT_DIR")
+            else None
+        ),
+        help="Project name to filter by (default: auto-detect from CLAUDE_PROJECT_DIR)",
+    )
+    parser.add_argument(
+        "--k", type=int, default=5,
+        help="Max number of learnings to push (default: 5)",
+    )
+    parser.add_argument(
+        "--json", action="store_true", dest="json_output",
+        help="Output as JSON (for hook consumption)",
+    )
+    parser.add_argument(
+        "--no-record", action="store_true",
+        help="Don't update recall_count (dry run / testing)",
+    )
+    parser.add_argument(
+        "--max-chars", type=int, default=150,
+        help="Max characters per learning content (default: 150)",
+    )
+    args = parser.parse_args(argv)
+    return {
+        "project": args.project,
+        "k": args.k,
+        "json_output": args.json_output,
+        "no_record": args.no_record,
+        "max_chars": args.max_chars,
+    }
+
+
+def build_cli_output(
+    candidates: list[dict[str, Any]],
+    project: str,
+    *,
+    max_chars: int,
+    json_output: bool,
+) -> str:
+    """Build CLI output string from candidates (JSON or text)."""
+    if not candidates:
+        if json_output:
+            empty = {"push_source": "session_start", "project": project, "results": []}
+            return json.dumps(empty)
+        return ""
+
+    output = format_results(candidates, project, max_chars)
+    if json_output:
+        return json.dumps(output, default=str)
+
+    lines = [f"Pushing {len(candidates)} learnings for project '{project}':"]
+    for i, c in enumerate(candidates, 1):
+        label = f" (Pattern: {c['pattern_label']})" if c.get("pattern_label") else ""
+        lines.append(
+            f"  {i}. [{c['learning_type']}|{c['confidence']}] "
+            f"{truncate_content(c['content'], max_chars)}{label}"
+        )
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# I/O boundary
+# ---------------------------------------------------------------------------
 
 
 def write_cache_file(output: dict[str, Any]) -> None:
@@ -183,13 +263,36 @@ def write_cache_file(output: dict[str, Any]) -> None:
     cache_file.write_text(json.dumps(output, default=str))
 
 
+async def get_stale_learnings(
+    project: str, k: int, *, conn: Any = None
+) -> list[dict[str, Any]]:
+    """Fetch never-recalled, high/medium confidence learnings for a project."""
+    if conn is None:
+        pool = await get_pool()
+        async with pool.acquire() as conn:
+            return await get_stale_learnings(project, k, conn=conn)
+    sql, params = build_stale_query_params(project, k)
+    rows = await conn.fetch(sql, *params)
+    return [_row_to_dict(row) for row in rows]
+
+
+async def get_pattern_representatives(
+    k: int, *, conn: Any = None
+) -> list[dict[str, Any]]:
+    """Fetch never-recalled pattern representatives from high-value clusters."""
+    if conn is None:
+        pool = await get_pool()
+        async with pool.acquire() as conn:
+            return await get_pattern_representatives(k, conn=conn)
+    sql, params = build_pattern_query_params(k)
+    rows = await conn.fetch(sql, *params)
+    return [parse_pattern_row(row) for row in rows]
+
+
 async def get_push_candidates(
     project: str, k: int = 5
 ) -> list[dict[str, Any]]:
     """Main entry: fetch and merge push candidates from PostgreSQL."""
-    from scripts.core.db.postgres_pool import get_pool
-    from scripts.core.recall_learnings import get_backend
-
     if get_backend() != "postgres":
         return []
 
@@ -207,87 +310,48 @@ async def get_push_candidates(
 
 async def main() -> int:
     """CLI entry point for push_learnings."""
-    parser = argparse.ArgumentParser(
-        description="Proactive memory push — surface never-recalled high-value learnings",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog=__doc__,
-    )
-    parser.add_argument(
-        "--project",
-        default=Path(os.environ["CLAUDE_PROJECT_DIR"]).name if os.environ.get("CLAUDE_PROJECT_DIR") else None,  # noqa: E501
-        help="Project name to filter by (default: auto-detect from CLAUDE_PROJECT_DIR)",
-    )
-    parser.add_argument(
-        "--k",
-        type=int,
-        default=5,
-        help="Max number of learnings to push (default: 5)",
-    )
-    parser.add_argument(
-        "--json",
-        action="store_true",
-        dest="json_output",
-        help="Output as JSON (for hook consumption)",
-    )
-    parser.add_argument(
-        "--no-record",
-        action="store_true",
-        help="Don't update recall_count (dry run / testing)",
-    )
-    parser.add_argument(
-        "--max-chars",
-        type=int,
-        default=150,
-        help="Max characters per learning content (default: 150)",
-    )
-    args = parser.parse_args()
+    config = parse_args()
+    project = config["project"]
+    json_output = config["json_output"]
 
-    if not args.project:
-        if args.json_output:
+    if not project:
+        if json_output:
             print(json.dumps({"error": "No project specified", "results": []}))
         else:
             print("Error: --project required (or set CLAUDE_PROJECT_DIR)", file=sys.stderr)
         return 1
 
     try:
-        candidates = await get_push_candidates(args.project, args.k)
-    except Exception as e:
-        if args.json_output:
-            print(json.dumps({"error": str(e), "results": []}))
+        candidates = await get_push_candidates(project, config["k"])
+    except (asyncpg.PostgresError, ConnectionError, OSError) as e:
+        logger.debug("push_learnings error", exc_info=True)
+        if json_output:
+            print(json.dumps({"error": type(e).__name__, "results": []}))
         else:
-            print(f"Error: {e}", file=sys.stderr)
+            print(f"Error: {type(e).__name__}: see logs for details", file=sys.stderr)
         return 1
 
+    # Build cache data (always, even when empty)
     if not candidates:
-        empty = {
-            "push_source": "session_start",
-            "project": args.project,
-            "results": [],
+        cache_data: dict[str, Any] = {
+            "push_source": "session_start", "project": project, "results": [],
         }
-        # Always overwrite cache so stale data from previous runs isn't reused
-        write_cache_file(empty)
-        if args.json_output:
-            print(json.dumps(empty))
-        return 0
+    else:
+        cache_data = format_results(candidates, project, config["max_chars"])
+
+    write_cache_file(cache_data)
 
     # Record recall to break the death spiral (unless dry run)
-    if not args.no_record:
+    if candidates and not config["no_record"]:
         from scripts.core.recall_learnings import record_recall
         await record_recall([c["id"] for c in candidates])
 
-    output = format_results(candidates, args.project, args.max_chars)
-
-    # Write cache file for compaction survival
-    write_cache_file(output)
-
-    if args.json_output:
-        print(json.dumps(output, default=str))
-    else:
-        print(f"Pushing {len(candidates)} learnings for project '{args.project}':")
-        for i, c in enumerate(candidates, 1):
-            label = f" (Pattern: {c['pattern_label']})" if c.get("pattern_label") else ""
-            print(f"  {i}. [{c['learning_type']}|{c['confidence']}] "
-                  f"{truncate_content(c['content'], args.max_chars)}{label}")
+    output_str = build_cli_output(
+        candidates, project,
+        max_chars=config["max_chars"], json_output=json_output,
+    )
+    if output_str:
+        print(output_str)
 
     return 0
 

--- a/scripts/core/push_learnings.py
+++ b/scripts/core/push_learnings.py
@@ -215,6 +215,10 @@ def parse_args(argv: list[str] | None = None) -> dict[str, Any]:
         help="Max characters per learning content (default: 150)",
     )
     args = parser.parse_args(argv)
+    if args.k < 1:
+        parser.error("--k must be >= 1")
+    if args.max_chars < 1:
+        parser.error("--max-chars must be >= 1")
     return {
         "project": args.project,
         "k": args.k,

--- a/scripts/core/push_learnings.py
+++ b/scripts/core/push_learnings.py
@@ -323,15 +323,28 @@ async def main() -> int:
 
     try:
         candidates = await get_push_candidates(project, config["k"])
-    except (asyncpg.PostgresError, ConnectionError, OSError) as e:
+    except Exception as e:
         logger.debug("push_learnings error", exc_info=True)
+        error_envelope: dict[str, Any] = {
+            "error": type(e).__name__, "push_source": "session_start",
+            "project": project, "results": [],
+        }
+        write_cache_file(error_envelope)
         if json_output:
-            print(json.dumps({"error": type(e).__name__, "results": []}))
+            print(json.dumps(error_envelope))
         else:
             print(f"Error: {type(e).__name__}: see logs for details", file=sys.stderr)
         return 1
 
-    # Build cache data (always, even when empty)
+    # Record recall BEFORE writing cache to prevent duplicate pushes on crash.
+    # If record_recall succeeds but cache write fails, worst case is a missed
+    # push (safe). If cache writes first but record_recall crashes, the same
+    # learnings get re-pushed indefinitely (the death spiral this script prevents).
+    if candidates and not config["no_record"]:
+        from scripts.core.recall_learnings import record_recall
+        await record_recall([c["id"] for c in candidates])
+
+    # Build and persist cache data (always, even when empty)
     if not candidates:
         cache_data: dict[str, Any] = {
             "push_source": "session_start", "project": project, "results": [],
@@ -340,11 +353,6 @@ async def main() -> int:
         cache_data = format_results(candidates, project, config["max_chars"])
 
     write_cache_file(cache_data)
-
-    # Record recall to break the death spiral (unless dry run)
-    if candidates and not config["no_record"]:
-        from scripts.core.recall_learnings import record_recall
-        await record_recall([c["id"] for c in candidates])
 
     output_str = build_cli_output(
         candidates, project,

--- a/tests/test_push_learnings.py
+++ b/tests/test_push_learnings.py
@@ -5,22 +5,34 @@ Validates that:
 2. truncate_content handles edge cases correctly
 3. format_results builds expected JSON structure
 4. get_push_candidates integrates queries and merge
+5. _row_to_dict converts asyncpg Records correctly
+6. build_stale_query / build_pattern_query return correct SQL params
+7. parse_args builds CLI config from argv
+8. build_cli_output produces text/JSON output
 """
 
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import asyncpg
 import pytest
 
-from scripts.core.push_learnings import (  # noqa: E402
+from scripts.core.push_learnings import (
+    _row_to_dict,
+    build_cli_output,
+    build_pattern_query_params,
+    build_stale_query_params,
     format_results,
     get_push_candidates,
     merge_candidates,
+    parse_args,
+    parse_pattern_row,
     truncate_content,
     write_cache_file,
 )
@@ -28,6 +40,7 @@ from scripts.core.push_learnings import (  # noqa: E402
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _make_candidate(
     *,
@@ -58,9 +71,157 @@ def _make_candidate(
     }
 
 
+def _make_row(
+    *,
+    id: str = "aaaa-bbbb-cccc-dddd",
+    content: str = "Test learning content",
+    metadata: dict[str, Any] | str | None = None,
+    created_at: datetime | None = None,
+    recall_count: int = 0,
+    pattern_label: str | None = None,
+    pattern_confidence: float | None = None,
+    pattern_type: str | None = None,
+) -> Mapping[str, Any]:
+    """Build a mock asyncpg-like row (Mapping)."""
+    if metadata is None:
+        metadata = {
+            "type": "session_learning",
+            "learning_type": "WORKING_SOLUTION",
+            "confidence": "high",
+        }
+    row: dict[str, Any] = {
+        "id": id,
+        "content": content,
+        "metadata": metadata,
+        "created_at": created_at or datetime(2026, 3, 15, tzinfo=UTC),
+        "recall_count": recall_count,
+    }
+    if pattern_label is not None:
+        row["pattern_label"] = pattern_label
+    if pattern_confidence is not None:
+        row["pattern_confidence"] = pattern_confidence
+    if pattern_type is not None:
+        row["pattern_type"] = pattern_type
+    return row
+
+
+# ---------------------------------------------------------------------------
+# _row_to_dict
+# ---------------------------------------------------------------------------
+
+
+class TestRowToDict:
+    def test_basic_conversion(self):
+        row = _make_row()
+        result = _row_to_dict(row)
+        assert result["id"] == "aaaa-bbbb-cccc-dddd"
+        assert result["content"] == "Test learning content"
+        assert result["learning_type"] == "WORKING_SOLUTION"
+        assert result["confidence"] == "high"
+        assert result["recall_count"] == 0
+        assert result["pattern_label"] is None
+        assert result["pattern_confidence"] is None
+
+    def test_metadata_as_json_string(self):
+        meta_str = json.dumps({"learning_type": "ERROR_FIX", "confidence": "low"})
+        row = _make_row(metadata=meta_str)
+        result = _row_to_dict(row)
+        assert result["learning_type"] == "ERROR_FIX"
+        assert result["confidence"] == "low"
+        assert isinstance(result["metadata"], dict)
+
+    def test_missing_metadata_keys_use_defaults(self):
+        row = _make_row(metadata={"type": "session_learning"})
+        result = _row_to_dict(row)
+        assert result["learning_type"] == "UNKNOWN"
+        assert result["confidence"] == "medium"
+
+    def test_null_recall_count_defaults_to_zero(self):
+        row = dict(_make_row())
+        row["recall_count"] = None
+        result = _row_to_dict(row)
+        assert result["recall_count"] == 0
+
+    def test_id_converted_to_string(self):
+        import uuid
+
+        uid = uuid.uuid4()
+        row = _make_row(id=uid)
+        result = _row_to_dict(row)
+        assert result["id"] == str(uid)
+
+    def test_malformed_json_metadata_defaults_to_empty(self):
+        row = _make_row(metadata="{invalid json")
+        result = _row_to_dict(row)
+        assert result["metadata"] == {}
+        assert result["learning_type"] == "UNKNOWN"
+        assert result["confidence"] == "medium"
+
+
+# ---------------------------------------------------------------------------
+# parse_pattern_row
+# ---------------------------------------------------------------------------
+
+
+class TestParsePatternRow:
+    def test_adds_pattern_fields(self):
+        row = _make_row(
+            pattern_label="hook errors",
+            pattern_confidence=0.85,
+        )
+        result = parse_pattern_row(row)
+        assert result["pattern_label"] == "hook errors"
+        assert result["pattern_confidence"] == 0.85
+
+    def test_none_pattern_confidence(self):
+        row = _make_row(pattern_label="test")
+        # No pattern_confidence key at all — .get returns None
+        result = parse_pattern_row(row)
+        assert result["pattern_confidence"] is None
+
+    def test_preserves_base_fields(self):
+        row = _make_row(
+            id="pat-id",
+            content="Pattern content",
+            pattern_label="test",
+            pattern_confidence=0.5,
+        )
+        result = parse_pattern_row(row)
+        assert result["id"] == "pat-id"
+        assert result["content"] == "Pattern content"
+
+
+# ---------------------------------------------------------------------------
+# build_stale_query_params / build_pattern_query_params
+# ---------------------------------------------------------------------------
+
+
+class TestBuildStaleQueryParams:
+    def test_returns_project_and_k(self):
+        sql, params = build_stale_query_params("opc", 5)
+        assert "opc" in params
+        assert 5 in params
+        assert "archival_memory" in sql
+        assert "recall_count = 0" in sql
+
+    def test_different_project(self):
+        sql, params = build_stale_query_params("myproject", 10)
+        assert "myproject" in params
+        assert 10 in params
+
+
+class TestBuildPatternQueryParams:
+    def test_returns_k(self):
+        sql, params = build_pattern_query_params(3)
+        assert 3 in params
+        assert "detected_patterns" in sql
+        assert "recall_count = 0" in sql
+
+
 # ---------------------------------------------------------------------------
 # merge_candidates
 # ---------------------------------------------------------------------------
+
 
 class TestMergeCandidates:
     def test_pattern_reps_come_first(self):
@@ -110,6 +271,7 @@ class TestMergeCandidates:
 # truncate_content
 # ---------------------------------------------------------------------------
 
+
 class TestTruncateContent:
     def test_short_content_unchanged(self):
         assert truncate_content("hello world", 150) == "hello world"
@@ -146,6 +308,7 @@ class TestTruncateContent:
 # ---------------------------------------------------------------------------
 # format_results
 # ---------------------------------------------------------------------------
+
 
 class TestFormatResults:
     def test_basic_structure(self):
@@ -191,6 +354,7 @@ class TestFormatResults:
 # write_cache_file
 # ---------------------------------------------------------------------------
 
+
 class TestWriteCacheFile:
     def test_writes_json(self, tmp_path, monkeypatch):
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
@@ -208,8 +372,82 @@ class TestWriteCacheFile:
 
 
 # ---------------------------------------------------------------------------
+# parse_args (pure)
+# ---------------------------------------------------------------------------
+
+
+class TestParseArgs:
+    def test_defaults(self):
+        config = parse_args(["--project", "opc", "--json"])
+        assert config["project"] == "opc"
+        assert config["k"] == 5
+        assert config["json_output"] is True
+        assert config["no_record"] is False
+        assert config["max_chars"] == 150
+
+    def test_custom_values(self):
+        config = parse_args([
+            "--project", "myproj",
+            "--k", "10",
+            "--max-chars", "200",
+            "--no-record",
+        ])
+        assert config["project"] == "myproj"
+        assert config["k"] == 10
+        assert config["max_chars"] == 200
+        assert config["no_record"] is True
+
+    def test_project_from_env(self, monkeypatch):
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/test/myproject")
+        config = parse_args([])
+        assert config["project"] == "myproject"
+
+    def test_no_project_returns_none(self, monkeypatch):
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+        config = parse_args([])
+        assert config["project"] is None
+
+
+# ---------------------------------------------------------------------------
+# build_cli_output (pure)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCliOutput:
+    def test_json_output(self):
+        candidates = [_make_candidate(id="test-1")]
+        result = build_cli_output(candidates, "opc", max_chars=150, json_output=True)
+        parsed = json.loads(result)
+        assert parsed["project"] == "opc"
+        assert len(parsed["results"]) == 1
+
+    def test_text_output(self):
+        candidates = [_make_candidate(id="test-1", content="Hello world")]
+        result = build_cli_output(candidates, "opc", max_chars=150, json_output=False)
+        assert "Hello world" in result
+        assert "opc" in result
+
+    def test_pattern_label_in_text(self):
+        candidates = [
+            _make_candidate(id="p-1", content="Fix hooks", pattern_label="hook errors")
+        ]
+        result = build_cli_output(candidates, "opc", max_chars=150, json_output=False)
+        assert "hook errors" in result
+
+    def test_empty_candidates_json(self):
+        result = build_cli_output([], "opc", max_chars=150, json_output=True)
+        parsed = json.loads(result)
+        assert parsed["results"] == []
+
+    def test_empty_candidates_text(self):
+        result = build_cli_output([], "opc", max_chars=150, json_output=False)
+        assert result == ""
+
+
+# ---------------------------------------------------------------------------
 # get_push_candidates (integration with mocked DB)
 # ---------------------------------------------------------------------------
+
 
 def _make_pool_mock() -> AsyncMock:
     """Create an AsyncMock pool that supports `async with pool.acquire() as conn`."""
@@ -226,7 +464,7 @@ class TestGetPushCandidates:
     @pytest.mark.asyncio
     async def test_returns_empty_for_sqlite(self):
         with patch(
-            "scripts.core.recall_learnings.get_backend", return_value="sqlite"
+            "scripts.core.push_learnings.get_backend", return_value="sqlite"
         ):
             result = await get_push_candidates("opc", k=5)
             assert result == []
@@ -243,7 +481,7 @@ class TestGetPushCandidates:
         ]
 
         with (
-            patch("scripts.core.recall_learnings.get_backend", return_value="postgres"),
+            patch("scripts.core.push_learnings.get_backend", return_value="postgres"),
             patch(
                 "scripts.core.push_learnings.get_stale_learnings",
                 new_callable=AsyncMock, return_value=stale,
@@ -253,7 +491,7 @@ class TestGetPushCandidates:
                 new_callable=AsyncMock, return_value=patterns,
             ),
             patch(
-                "scripts.core.db.postgres_pool.get_pool",
+                "scripts.core.push_learnings.get_pool",
                 new_callable=AsyncMock, return_value=_make_pool_mock(),
             ),
         ):
@@ -269,7 +507,7 @@ class TestGetPushCandidates:
         stale = [_make_candidate(id="stale-1", content="Stale learning")]
 
         with (
-            patch("scripts.core.recall_learnings.get_backend", return_value="postgres"),
+            patch("scripts.core.push_learnings.get_backend", return_value="postgres"),
             patch(
                 "scripts.core.push_learnings.get_stale_learnings",
                 new_callable=AsyncMock, return_value=stale,
@@ -280,7 +518,7 @@ class TestGetPushCandidates:
                 side_effect=asyncpg.exceptions.UndefinedTableError("relation does not exist"),
             ),
             patch(
-                "scripts.core.db.postgres_pool.get_pool",
+                "scripts.core.push_learnings.get_pool",
                 new_callable=AsyncMock, return_value=_make_pool_mock(),
             ),
         ):
@@ -292,7 +530,7 @@ class TestGetPushCandidates:
     @pytest.mark.asyncio
     async def test_no_results(self):
         with (
-            patch("scripts.core.recall_learnings.get_backend", return_value="postgres"),
+            patch("scripts.core.push_learnings.get_backend", return_value="postgres"),
             patch(
                 "scripts.core.push_learnings.get_stale_learnings",
                 new_callable=AsyncMock, return_value=[],
@@ -302,12 +540,10 @@ class TestGetPushCandidates:
                 new_callable=AsyncMock, return_value=[],
             ),
             patch(
-                "scripts.core.db.postgres_pool.get_pool",
+                "scripts.core.push_learnings.get_pool",
                 new_callable=AsyncMock, return_value=_make_pool_mock(),
             ),
         ):
             result = await get_push_candidates("opc", k=5)
 
         assert result == []
-
-

--- a/tests/test_push_learnings.py
+++ b/tests/test_push_learnings.py
@@ -426,6 +426,14 @@ class TestParseArgs:
         config = parse_args([])
         assert config["project"] is None
 
+    def test_negative_k_rejected(self):
+        with pytest.raises(SystemExit):
+            parse_args(["--project", "opc", "--k", "-1"])
+
+    def test_negative_max_chars_rejected(self):
+        with pytest.raises(SystemExit):
+            parse_args(["--project", "opc", "--max-chars", "-5"])
+
 
 # ---------------------------------------------------------------------------
 # build_cli_output (pure)

--- a/tests/test_push_learnings.py
+++ b/tests/test_push_learnings.py
@@ -71,11 +71,14 @@ def _make_candidate(
     }
 
 
+_UNSET = object()
+
+
 def _make_row(
     *,
     id: str = "aaaa-bbbb-cccc-dddd",
     content: str = "Test learning content",
-    metadata: dict[str, Any] | str | None = None,
+    metadata: Any = _UNSET,
     created_at: datetime | None = None,
     recall_count: int = 0,
     pattern_label: str | None = None,
@@ -83,7 +86,7 @@ def _make_row(
     pattern_type: str | None = None,
 ) -> Mapping[str, Any]:
     """Build a mock asyncpg-like row (Mapping)."""
-    if metadata is None:
+    if metadata is _UNSET:
         metadata = {
             "type": "session_learning",
             "learning_type": "WORKING_SOLUTION",
@@ -156,6 +159,22 @@ class TestRowToDict:
         assert result["metadata"] == {}
         assert result["learning_type"] == "UNKNOWN"
         assert result["confidence"] == "medium"
+
+    def test_null_metadata_defaults_to_empty(self):
+        row = _make_row(metadata=None)
+        result = _row_to_dict(row)
+        assert result["metadata"] == {}
+        assert result["learning_type"] == "UNKNOWN"
+
+    def test_list_metadata_defaults_to_empty(self):
+        row = _make_row(metadata=["not", "a", "dict"])
+        result = _row_to_dict(row)
+        assert result["metadata"] == {}
+
+    def test_numeric_metadata_defaults_to_empty(self):
+        row = _make_row(metadata=42)
+        result = _row_to_dict(row)
+        assert result["metadata"] == {}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Extract pure functions from I/O code: `build_stale_query_params`, `build_pattern_query_params`, `parse_pattern_row`, `parse_args`, `build_cli_output`
- Use `Mapping[str, Any]` for asyncpg row type hints per project convention
- Move inline imports (`get_pool`, `get_api_version`, `get_backend`) to top-level
- Add graceful handling for malformed JSON metadata in `_row_to_dict`
- Sanitize error messages in `main()` to avoid leaking DB connection details
- Reorder `record_recall()` before `write_cache_file()` to prevent duplicate push death spiral on crash
- Write error envelope to cache on failure to clear stale data

## Test Coverage

```
Name                             Stmts   Miss  Cover   Missing
--------------------------------------------------------------
scripts/core/push_learnings.py     142     44    69%%   270-276, 283-289, 313-364, 368
--------------------------------------------------------------
TOTAL                              142     44    69%%
```

46 tests (up from 25). Uncovered lines are async I/O functions and `main()` CLI entrypoint — expected for TDD+FP refactors per project convention.

## Adversarial Review

3 rounds completed. Round 1 findings (death spiral, narrow exception catch) were fixed. Rounds 2-3 surfaced pre-existing design issues (not regressions) logged to `thoughts/shared/Tasks.md`:
- Pattern query lacks project filter (pre-existing)
- Non-atomic selection + recall marking (requires schema change)
- `record_recall()` silently swallows errors (in `recall_learnings.py`, not this file)

## Test plan

- [x] `uv run pytest tests/test_push_learnings.py -x` — 46 passed
- [x] `uv run pytest tests/ -x` — 1776 passed, no regressions
- [x] `uv run ruff check scripts/core/push_learnings.py` — clean
- [x] Security audit (aegis) — 0 CRITICAL/HIGH, 2 MEDIUM addressed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Separated query construction from execution, cleaned up CLI parsing/validation, and made output generation more deterministic (JSON vs human-readable); improved logging and consistent cache write behavior.

* **Bug Fixes**
  * Hardened row/metadata parsing to tolerate malformed or missing data and avoid crashes; improved error reporting and resilient cache handling.

* **Tests**
  * Expanded unit tests to cover parsing, query builders, CLI output, and edge cases for increased reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->