### PR TITLE
S29: TDD+FP refactor of pattern_report.py

### DIFF
--- a/scripts/core/pattern_report.py
+++ b/scripts/core/pattern_report.py
@@ -201,27 +201,32 @@ def _make_parse_error() -> dict:
     return {"_parse_error": True}
 
 
-def parse_pattern_metadata(metadata: dict | str | None) -> dict:
-    """Parse pattern metadata from dict or JSON string.
+def parse_pattern_metadata(metadata: object | None) -> dict:
+    """Parse pattern metadata from a dict, JSON string, or decoded JSON value.
 
-    Returns empty dict for None, empty strings, or non-dict/non-string types.
-    Returns a fresh ``_parse_error`` sentinel dict for malformed or non-object
-    JSON so callers can distinguish parse failures from legitimately empty
-    metadata without risking shared-state mutation.
+    Returns empty dict only for ``None`` or empty strings. Returns a fresh
+    ``_parse_error`` sentinel dict for malformed JSON or any non-object JSON
+    value (including pre-decoded lists, ints, bools from asyncpg JSONB) so
+    callers can distinguish parse failures from legitimately empty metadata.
     """
     if isinstance(metadata, dict):
         return metadata
-    if not isinstance(metadata, str) or not metadata:
+    if metadata is None:
         return {}
-    try:
-        parsed = json.loads(metadata)
-    except (json.JSONDecodeError, ValueError):
-        logger.warning("Malformed pattern metadata: %r", metadata[:80])
-        return _make_parse_error()
-    if not isinstance(parsed, dict):
-        logger.warning("Non-object pattern metadata: %s", type(parsed).__name__)
-        return _make_parse_error()
-    return parsed
+    if isinstance(metadata, str):
+        if not metadata:
+            return {}
+        try:
+            parsed = json.loads(metadata)
+        except (json.JSONDecodeError, ValueError):
+            logger.warning("Malformed pattern metadata: %r", metadata[:80])
+            return _make_parse_error()
+        if not isinstance(parsed, dict):
+            logger.warning("Non-object pattern metadata: %s", type(parsed).__name__)
+            return _make_parse_error()
+        return parsed
+    logger.warning("Non-object pattern metadata: %s", type(metadata).__name__)
+    return _make_parse_error()
 
 
 def format_type_breakdown(rows: list[dict]) -> str:

--- a/tests/test_pattern_report.py
+++ b/tests/test_pattern_report.py
@@ -188,8 +188,17 @@ class TestParsePatternMetadata:
         result = parse_pattern_metadata("not-json")
         assert result.get("_parse_error") is True
 
-    def test_numeric_value_returns_empty_dict(self):
-        assert parse_pattern_metadata(42) == {}
+    def test_numeric_value_returns_error_sentinel(self):
+        result = parse_pattern_metadata(42)
+        assert result.get("_parse_error") is True
+
+    def test_decoded_list_returns_error_sentinel(self):
+        result = parse_pattern_metadata([1, 2, 3])
+        assert result.get("_parse_error") is True
+
+    def test_decoded_bool_returns_error_sentinel(self):
+        result = parse_pattern_metadata(True)
+        assert result.get("_parse_error") is True
 
     def test_json_array_returns_error_sentinel(self):
         result = parse_pattern_metadata("[]")


### PR DESCRIPTION
## Summary

- Extract 6 pure functions from `pattern_report.py`: `format_age`, `parse_pattern_metadata`, `format_type_section`, `format_type_breakdown`, `_format_tags`, `_format_pattern_json`
- Add pure orchestrators: `generate_report_from_data`, `generate_summary_from_data` (no I/O)
- Thin async wrappers (`generate_report`, `generate_summary`) delegate to pure logic after fetching data
- Extract `_fetch_type_breakdown` query function from inline SQL in `generate_summary`
- Handle future timestamps in `format_age` (clock skew shows "in Xm" instead of false stale age)
- Guard `parse_pattern_metadata` against malformed JSON, non-object JSON (arrays, scalars), and non-string types
- Surface metadata parse errors in reports: human format shows "span: N/A", JSON includes `metadata_error: true` and `temporal_span_days: null`
- Fresh sentinel copies prevent shared-state mutation; `%r` log format escapes control characters

## Test Coverage

```
Name                             Stmts   Miss  Cover   Missing
--------------------------------------------------------------
scripts/core/pattern_report.py     177     13    93%   41-43, 54, 319, 467-490, 497
--------------------------------------------------------------
```

51 tests (up from 21). Uncovered: `_get_pool` (DB import), CLI `main()`, `_fetch_run_metadata` run_id branch.

## Adversarial Review Findings Addressed

1. **Round 1**: Future-dated timestamps produced misleading age strings (fixed: `format_age` handles negative deltas)
2. **Round 2**: Valid non-object JSONB (`[]`, `1`, `"text"`) crashed reports (fixed: `parse_pattern_metadata` validates parsed type)
3. **Round 3**: Malformed metadata silently rendered as `0 days` (fixed: `_parse_error` sentinel surfaces corruption)

## Security Review

0 critical, 0 high. 2 medium findings fixed:
- Shared mutable sentinel replaced with factory function
- Log injection mitigated with `%r` format

## Test plan

- [x] `uv run pytest tests/test_pattern_report.py -x` -- 51 pass
- [x] `uv run pytest tests/ -x` -- 1813 pass, no regressions
- [x] `uv run ruff check scripts/core/pattern_report.py` -- clean
- [x] 3 rounds of adversarial review completed
- [x] Security audit completed
