### PR TITLE
test(memory_daemon_db): fix stale pg_ensure_column assertion (#101)

### DIFF
--- a/tests/test_memory_daemon_db.py
+++ b/tests/test_memory_daemon_db.py
@@ -175,7 +175,8 @@ class TestPgEnsureColumn:
         pg_ensure_column()
 
         sql_calls = [c.args[0] for c in mock_cur.execute.call_args_list]
-        combined = " ".join(sql_calls)
+        sessions_sql = " ".join(s for s in sql_calls if "sessions" in s)
+        archival_sql = " ".join(s for s in sql_calls if "archival_memory" in s)
         for col in [
             "memory_extracted_at",
             "extraction_status",
@@ -184,10 +185,10 @@ class TestPgEnsureColumn:
             "archived_at",
             "archive_path",
             "last_error",
-            "push_count",
-            "last_pushed_at",
         ]:
-            assert col in combined
+            assert col in sessions_sql, f"{col} must be ALTERed on sessions"
+        for col in ["push_count", "last_pushed_at"]:
+            assert col in archival_sql, f"{col} must be ALTERed on archival_memory"
 
 
 class TestSqliteEnsureTable:

--- a/tests/test_memory_daemon_db.py
+++ b/tests/test_memory_daemon_db.py
@@ -144,7 +144,7 @@ class TestGetSqlitePath:
 
 
 class TestPgEnsureColumn:
-    """pg_ensure_column adds extraction columns to sessions table."""
+    """pg_ensure_column adds extraction columns to sessions and push-tracking columns to archival_memory."""  # noqa: E501
 
     @patch("scripts.core.memory_daemon_db.pg_connect")
     def test_adds_all_extraction_and_push_columns(self, mock_pg_connect):
@@ -175,8 +175,8 @@ class TestPgEnsureColumn:
         pg_ensure_column()
 
         sql_calls = [c.args[0] for c in mock_cur.execute.call_args_list]
-        sessions_sql = " ".join(s for s in sql_calls if "sessions" in s)
-        archival_sql = " ".join(s for s in sql_calls if "archival_memory" in s)
+        sessions_sql = " ".join(s for s in sql_calls if "ALTER TABLE sessions" in s)
+        archival_sql = " ".join(s for s in sql_calls if "ALTER TABLE archival_memory" in s)
         for col in [
             "memory_extracted_at",
             "extraction_status",

--- a/tests/test_memory_daemon_db.py
+++ b/tests/test_memory_daemon_db.py
@@ -147,7 +147,7 @@ class TestPgEnsureColumn:
     """pg_ensure_column adds extraction columns to sessions table."""
 
     @patch("scripts.core.memory_daemon_db.pg_connect")
-    def test_adds_six_columns(self, mock_pg_connect):
+    def test_adds_all_extraction_and_push_columns(self, mock_pg_connect):
         mock_conn = MagicMock()
         mock_cur = MagicMock()
         mock_conn.cursor.return_value = mock_cur
@@ -157,7 +157,9 @@ class TestPgEnsureColumn:
 
         pg_ensure_column()
 
-        assert mock_cur.execute.call_count == 7
+        # 7 ALTER TABLE on sessions (extraction columns) +
+        # 2 ALTER TABLE on archival_memory (push tracking columns) = 9
+        assert mock_cur.execute.call_count == 9
         mock_conn.commit.assert_called_once()
         mock_conn.close.assert_called_once()
 
@@ -182,6 +184,8 @@ class TestPgEnsureColumn:
             "archived_at",
             "archive_path",
             "last_error",
+            "push_count",
+            "last_pushed_at",
         ]:
             assert col in combined
 


### PR DESCRIPTION
## Summary

Fixes #101. Closes #111 (duplicate, closed separately).

`tests/test_memory_daemon_db.py::TestPgEnsureColumn::test_adds_six_columns` was failing on `main` because `pg_ensure_column()` now issues **9** `cur.execute()` calls, not 7:

- 7 `ALTER TABLE sessions ADD COLUMN IF NOT EXISTS ...` (extraction tracking)
- 2 `ALTER TABLE archival_memory ADD COLUMN IF NOT EXISTS ...` (push tracking: `push_count`, `last_pushed_at`)

The test was stale in two ways — its name said "six columns" and its assertion said `== 7`. Both now reflect reality.

## Changes

- Rename `test_adds_six_columns` → `test_adds_all_extraction_and_push_columns`
- Update `mock_cur.execute.call_count` assertion from `7` → `9`
- Extend `test_adds_expected_column_names` to cover `push_count` and `last_pushed_at`, and **bind each column name to its expected table** (`sessions` vs `archival_memory`) so a regression that adds the columns to the wrong table is caught (adversarial-review finding)

## Before / After

```
# before (on main)
AssertionError: assert 9 == 7
tests/test_memory_daemon_db.py:160

# after
tests/test_memory_daemon_db.py ................................................... [100%]
51 passed in 0.24s
```

## Coverage

```
scripts/core/memory_daemon_db.py   241  13  95%
```

(unchanged — test-only edit)

## Verification

- Confirmed the 9 `execute` calls by reading `scripts/core/memory_daemon_db.py:78-105` — all 9 ALTER TABLEs are legitimate (7 sessions extraction columns + 2 archival_memory push tracking columns)
- `uv run pytest tests/test_memory_daemon_db.py` → 51/51 green
- One adversarial review round (codex) addressed: tightened column-to-table binding
- Full suite: 2156 passed, 1 pre-existing failure unrelated to this change (`tests/test_memory_protocol.py::test_protocol_is_a_protocol` — imports `typing.is_protocol` which requires Python 3.13+; env runs 3.12.13; present on `main` prior to this PR)

## Notes

- **No deselect entry to remove.** Grep of `pyproject.toml` (no `addopts`), `conftest.py` (none present), `.github/workflows/`, and `Makefile` turned up nothing referencing `test_adds_six_columns` or `deselect`. The test was simply failing on `main`, not deselected. Noting here since the task prompt suggested a deselect might exist.
- Task category: QA / test-hygiene; security review not required (test-only change).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated PostgreSQL schema column test assertions to reflect additional database operations and correct validation for session extraction and archival memory tracking columns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->