### PR TITLE
fix: sanitize DB/subprocess strings in memory_daemon logs (#104)

### DIFF
--- a/scripts/core/backfill_archive.py
+++ b/scripts/core/backfill_archive.py
@@ -219,7 +219,7 @@ def archive_jsonl(
             elif db_result == 0:
                 print(f"  Note: No DB row updated for {safe(session_id)} (not tracked or archived)")
 
-        print(f"  Archived {safe(session_id)} -> {s3_key}")
+        print(f"  Archived {safe(session_id)} -> {safe(s3_key)}")
         return True
 
     except subprocess.TimeoutExpired:

--- a/scripts/core/backfill_archive.py
+++ b/scripts/core/backfill_archive.py
@@ -28,6 +28,7 @@ if _repo_root not in sys.path:
     sys.path.insert(0, _repo_root)
 
 from scripts.core.config.models import ArchivalConfig  # noqa: E402
+from scripts.core.log_safety import safe  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Pure functions
@@ -170,11 +171,11 @@ def _safe_restore(zst_path: Path, timeout: int) -> bool:
     try:
         result = decompress_file(zst_path, timeout)
         if result.returncode != 0:
-            print(f"  WARNING: Failed to restore {zst_path} — file may be orphaned")
+            print(f"  WARNING: Failed to restore {safe(zst_path)} — file may be orphaned")
             return False
         return True
     except Exception as e:
-        print(f"  WARNING: Restore error for {zst_path}: {e}")
+        print(f"  WARNING: Restore error for {safe(zst_path)}: {safe(e)}")
         return False
 
 
@@ -199,12 +200,12 @@ def archive_jsonl(
     try:
         result = compress_file(jsonl_path, cfg.compress_timeout)
         if result.returncode != 0:
-            print(f"  zstd failed: {result.stderr.decode(errors='replace')}")
+            print(f"  zstd failed: {safe(result.stderr.decode(errors='replace'))}")
             return False
 
         result = upload_to_s3(zst_path, s3_key, cfg.upload_timeout)
         if result.returncode != 0:
-            print(f"  S3 upload failed: {result.stderr.decode(errors='replace')}")
+            print(f"  S3 upload failed: {safe(result.stderr.decode(errors='replace'))}")
             _safe_restore(zst_path, cfg.compress_timeout)
             return False
 
@@ -214,20 +215,20 @@ def archive_jsonl(
         if db_url:
             db_result = mark_archived_in_db(session_id, s3_key, db_url)
             if db_result is None:
-                print(f"  Warning: DB error for {session_id} (S3 upload succeeded)")
+                print(f"  Warning: DB error for {safe(session_id)} (S3 upload succeeded)")
             elif db_result == 0:
-                print(f"  Note: No DB row updated for {session_id} (not tracked or archived)")
+                print(f"  Note: No DB row updated for {safe(session_id)} (not tracked or archived)")
 
-        print(f"  Archived {session_id} -> {s3_key}")
+        print(f"  Archived {safe(session_id)} -> {s3_key}")
         return True
 
     except subprocess.TimeoutExpired:
-        print(f"  Timeout for {session_id}")
+        print(f"  Timeout for {safe(session_id)}")
         if zst_path.exists() and not jsonl_path.exists():
             _safe_restore(zst_path, cfg.compress_timeout)
         return False
     except Exception as e:
-        print(f"  Error: {e}")
+        print(f"  Error: {safe(e)}")
         return False
 
 

--- a/scripts/core/backfill_learnings.py
+++ b/scripts/core/backfill_learnings.py
@@ -28,6 +28,8 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
+from scripts.core.log_safety import safe
+
 # ---------------------------------------------------------------------------
 # Pure functions
 # ---------------------------------------------------------------------------
@@ -273,7 +275,7 @@ def list_s3_keys(bucket: str) -> str | None:
             timeout=60,
         )
         if result.returncode != 0:
-            _log(f"S3 list failed: {result.stderr}")
+            _log(f"S3 list failed: {safe(result.stderr)}")
             return None
         return result.stdout
     except subprocess.TimeoutExpired:
@@ -295,7 +297,7 @@ def _is_valid_uuid(value: str) -> bool:
 def lookup_session_id(uuid: str, conn) -> str | None:
     """Look up s-* session ID from DB using JSONL UUID from transcript_path."""
     if not _is_valid_uuid(uuid):
-        _log(f"Invalid UUID format, skipping lookup: {uuid[:40]}")
+        _log(f"Invalid UUID format, skipping lookup: {safe(uuid[:40])}")
         return None
     try:
         cur = conn.cursor()
@@ -306,7 +308,7 @@ def lookup_session_id(uuid: str, conn) -> str | None:
         row = cur.fetchone()
         return row[0] if row else None
     except Exception as e:
-        _log(f"DB lookup failed for {uuid}: {e}")
+        _log(f"DB lookup failed for {safe(uuid)}: {safe(e)}")
         conn.rollback()
         return None
 
@@ -353,7 +355,7 @@ def claim_session(uuid: str, session_id: str, project: str, conn) -> bool:
         return claimed
     except Exception as e:
         conn.rollback()
-        _log(f"WARNING: failed to claim {uuid}: {e}")
+        _log(f"WARNING: failed to claim {safe(uuid)}: {safe(e)}")
         return False
 
 
@@ -382,7 +384,7 @@ def log_extraction_result(result: dict, conn) -> None:
         conn.commit()
     except Exception as e:
         conn.rollback()
-        _log(f"WARNING: failed to log result for {result.get('uuid')}: {e}")
+        _log(f"WARNING: failed to log result for {safe(result.get('uuid'))}: {safe(e)}")
 
 
 def download_and_decompress(
@@ -398,7 +400,8 @@ def download_and_decompress(
         timeout=120,
     )
     if dl.returncode != 0:
-        _log(f"Download failed for {uuid}: {dl.stderr.decode()[:200]}")
+        err = safe(dl.stderr.decode(errors="replace")[:200])
+        _log(f"Download failed for {safe(uuid)}: {err}")
         return None
 
     dc = subprocess.run(
@@ -407,7 +410,8 @@ def download_and_decompress(
         timeout=60,
     )
     if dc.returncode != 0:
-        _log(f"Decompress failed for {uuid}: {dc.stderr.decode()[:200]}")
+        err = safe(dc.stderr.decode(errors="replace")[:200])
+        _log(f"Decompress failed for {safe(uuid)}: {err}")
         return None
 
     return jsonl_path
@@ -536,7 +540,7 @@ def main() -> int:
             conn = psycopg2.connect(pg_url)
             _log("Connected to PostgreSQL")
         except Exception as e:
-            _log(f"WARNING: PostgreSQL unavailable: {e}")
+            _log(f"WARNING: PostgreSQL unavailable: {safe(e)}")
 
     if not conn and not args.dry_run:
         _log("ERROR: PostgreSQL required for non-dry runs (session ID resolution + backfill_log)")
@@ -602,7 +606,10 @@ def main() -> int:
         timeout = 300
 
     if model not in allowed_models:
-        _log(f"ERROR: invalid extraction model '{model}', must be one of {sorted(allowed_models)}")
+        _log(
+            f"ERROR: invalid extraction model '{safe(model)}', "
+            f"must be one of {sorted(allowed_models)}"
+        )
         return 1
 
     agent_prompt = load_agent_prompt()

--- a/scripts/core/backfill_learnings.py
+++ b/scripts/core/backfill_learnings.py
@@ -271,7 +271,8 @@ def list_s3_keys(bucket: str) -> str | None:
         result = subprocess.run(
             ["aws", "s3", "ls", f"s3://{bucket}/sessions/", "--recursive"],
             capture_output=True,
-            text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=60,
         )
         if result.returncode != 0:
@@ -642,7 +643,7 @@ def main() -> int:
             except Exception as e:
                 result = {
                     "status": "exception",
-                    "error": str(e),
+                    "error": safe(e),
                     "uuid": s.get("uuid", "?"),
                     "session_id": s.get("session_id", "?"),
                     "project": s.get("project", "?"),
@@ -661,12 +662,12 @@ def main() -> int:
             if status != "ok":
                 errors += 1
                 _log(
-                    f"[{i}/{len(claimed_batch)}] FAIL {s.get('session_id', '?')} "
-                    f"status={status} error={result.get('error', '')[:100]}"
+                    f"[{i}/{len(claimed_batch)}] FAIL {safe(s.get('session_id', '?'))} "
+                    f"status={safe(status)} error={safe(result.get('error', '')[:100])}"
                 )
             else:
                 _log(
-                    f"[{i}/{len(claimed_batch)}] OK {s.get('session_id', '?')} "
+                    f"[{i}/{len(claimed_batch)}] OK {safe(s.get('session_id', '?'))} "
                     f"learnings={learned} dupes={dupes}"
                 )
 

--- a/scripts/core/log_safety.py
+++ b/scripts/core/log_safety.py
@@ -1,0 +1,89 @@
+"""Sanitize DB-sourced values for inclusion in log messages.
+
+Addresses GitHub issue #104: memory_daemon and its extractors interpolate
+DB-sourced strings (session IDs, project paths, transcript paths,
+subprocess stderr) into log messages via f-strings. An attacker who has
+DB write access can inject newlines (log forgery), ESC sequences (ANSI
+terminal manipulation on an admin's TTY), or other control characters.
+
+The ``safe()`` helper is the single black-box boundary where untrusted
+bytes become safe display text. One helper, one rule, one test suite.
+
+See ``thoughts/shared/plans/issue-104-log-injection-sanitization.md``.
+"""
+
+from __future__ import annotations
+
+__all__ = ["safe"]
+
+_DEFAULT_MAX_LEN = 500
+_NONE_MARKER = "<none>"
+_UNREPRESENTABLE = "<unrepresentable>"
+
+
+def _coerce(value: object) -> str:
+    """Best-effort ``str()`` conversion that never raises.
+
+    Hostile objects may raise from ``__str__`` or return a non-str. We
+    do not fall back to ``repr()`` because ``repr()`` can also raise on
+    hostile objects; a fixed sentinel is safer.
+    """
+    if value is None:
+        return _NONE_MARKER
+    if isinstance(value, str):
+        return value
+    try:
+        result = str(value)
+    except Exception:
+        return _UNREPRESENTABLE
+    if not isinstance(result, str):
+        return _UNREPRESENTABLE
+    return result
+
+
+def _escape_controls(s: str) -> str:
+    out: list[str] = []
+    for ch in s:
+        o = ord(ch)
+        if ch == "\t":
+            out.append(ch)
+        elif o < 0x20 or o == 0x7F:
+            out.append(f"\\x{o:02x}")
+        else:
+            out.append(ch)
+    return "".join(out)
+
+
+def safe(value: object, *, max_len: int = _DEFAULT_MAX_LEN) -> str:
+    """Render an arbitrary value as a single-line, control-char-free log field.
+
+    Contract (see ``tests/test_log_safety.py``):
+
+    - ``None`` → ``"<none>"`` (preserves field-was-null forensic signal)
+    - Empty string → ``""``
+    - Non-str values → ``str(value)`` first; if that raises or returns
+      non-str, the sentinel ``"<unrepresentable>"`` is used instead of
+      falling back to ``repr()`` (which can also raise on hostile
+      objects).
+    - ``\\n``, ``\\r``, ``\\x00``–``\\x08``, ``\\x0b``–``\\x1f``, ``\\x7f``
+      → replaced with ``\\xNN`` markers (lowercase hex, reversible for
+      forensics).
+    - ``\\t`` (``0x09``) preserved — tabs are common in real data and
+      harmless for log tailing.
+    - Inputs longer than ``max_len`` raw characters are truncated to
+      ``max_len`` then suffixed with the ASCII marker
+      ``"...[truncated N bytes]"``. Truncation happens on the raw input
+      length (not the escaped output length) to prevent a string of
+      newlines from ballooning the log line.
+
+    The return value is always a ``str`` containing only ``\\t`` (``0x09``)
+    or printable ASCII (``0x20``–``0x7e``). No other characters can leak
+    into the output.
+    """
+    coerced = _coerce(value)
+    raw_len = len(coerced)
+    if raw_len > max_len:
+        head = coerced[:max_len]
+        dropped = raw_len - max_len
+        return _escape_controls(head) + f"...[truncated {dropped} bytes]"
+    return _escape_controls(coerced)

--- a/scripts/core/log_safety.py
+++ b/scripts/core/log_safety.py
@@ -22,11 +22,15 @@ _UNREPRESENTABLE = "<unrepresentable>"
 
 
 def _coerce(value: object) -> str:
-    """Best-effort ``str()`` conversion that never raises.
+    """Best-effort ``str()`` conversion that never raises a non-system Exception.
 
     Hostile objects may raise from ``__str__`` or return a non-str. We
     do not fall back to ``repr()`` because ``repr()`` can also raise on
     hostile objects; a fixed sentinel is safer.
+
+    ``KeyboardInterrupt`` and ``SystemExit`` (``BaseException`` subclasses
+    outside the ``Exception`` hierarchy) are **not** suppressed — a user
+    hitting Ctrl-C during a log render should still abort the process.
     """
     if value is None:
         return _NONE_MARKER
@@ -34,7 +38,13 @@ def _coerce(value: object) -> str:
         return value
     try:
         result = str(value)
-    except Exception:
+    except Exception:  # noqa: BLE001
+        # Deliberately narrow to Exception, NOT BaseException. KeyboardInterrupt
+        # and SystemExit MUST propagate so Ctrl-C and sys.exit() still work
+        # when a log line is rendering. CodeRabbit cycle-1 suggested
+        # BaseException; ARCHITECT overruled — the "never raises" contract
+        # covers regular exceptions only. The docstring is updated to
+        # "Never raises a non-system Exception" to codify the invariant.
         return _UNREPRESENTABLE
     if not isinstance(result, str):
         return _UNREPRESENTABLE
@@ -62,8 +72,14 @@ def _escape_controls(s: str) -> str:
             out.append(ch)
         elif o <= 0xFF:
             out.append(f"\\x{o:02x}")
-        else:
+        elif o <= 0xFFFF:
             out.append(f"\\u{o:04x}")
+        else:
+            # Non-BMP (> U+FFFF) — emoji and supplementary-plane chars
+            # get the fixed-width \UNNNNNNNN form. Using \uNNNNNN here
+            # would break log parsers expecting 4-hex \u (cycle-1 Gemini
+            # + Copilot).
+            out.append(f"\\U{o:08x}")
     return "".join(out)
 
 
@@ -91,8 +107,12 @@ def safe(value: object, *, max_len: int = _DEFAULT_MAX_LEN) -> str:
       ``\\xNN`` markers. These look "innocent" but UTF-8 terminals
       interpret ``\\x9b`` as an ANSI escape, so allowing them through
       would reopen the injection vector.
-    - Non-ASCII characters ``\\u0100``+ (including emoji and Unicode
-      surrogates) → ``\\uNNNN`` markers.
+    - Non-ASCII BMP characters ``\\u0100``–``\\uffff`` (including most
+      Latin scripts, CJK, lone surrogates) → ``\\uNNNN`` (fixed 4 hex
+      digits).
+    - Non-BMP characters ``\\U00010000``+ (emoji, supplementary planes)
+      → ``\\UNNNNNNNN`` (fixed 8 hex digits). Using 4-digit ``\\u`` for
+      these would produce invalid 5+-digit output.
     - ``\\t`` (``0x09``) preserved — tabs are common in real data and
       harmless for log tailing.
     - Inputs longer than ``max_len`` raw characters are truncated to
@@ -131,6 +151,13 @@ def safe(value: object, *, max_len: int = _DEFAULT_MAX_LEN) -> str:
         stderr_text = result.stderr.decode(errors="replace")
         log(f"zstd failed: {safe(stderr_text)}")
     """
+    if max_len < 0:
+        # Raise on a developer error at call time — better to surface a
+        # misconfigured call site than to silently truncate in ways the
+        # caller didn't expect (cycle-1 Copilot; ARCHITECT: raise not clamp).
+        # A negative max_len is never meaningful and can only come from a
+        # coding mistake, not untrusted input.
+        raise ValueError(f"max_len must be >= 0 (got {max_len})")
     coerced = _coerce(value)
     raw_len = len(coerced)
     if raw_len > max_len:

--- a/scripts/core/log_safety.py
+++ b/scripts/core/log_safety.py
@@ -42,6 +42,7 @@ def _coerce(value: object) -> str:
 
 
 def _escape_controls(s: str) -> str:
+    """Replace C0 controls and DEL with ``\\xNN`` markers; keep ``\\t``."""
     out: list[str] = []
     for ch in s:
         o = ord(ch)
@@ -79,6 +80,20 @@ def safe(value: object, *, max_len: int = _DEFAULT_MAX_LEN) -> str:
     The return value is always a ``str`` containing only ``\\t`` (``0x09``)
     or printable ASCII (``0x20``–``0x7e``). No other characters can leak
     into the output.
+
+    Usage:
+
+        from scripts.core.log_safety import safe
+
+        log(f"Extracting session {safe(session_id)} "
+            f"(project={safe(project_dir)})")
+
+    For subprocess stderr, decode with ``errors='replace'`` before wrapping
+    so that non-UTF8 bytes become replacement characters rather than a
+    ``"b'...'"`` repr::
+
+        stderr_text = result.stderr.decode(errors="replace")
+        log(f"zstd failed: {safe(stderr_text)}")
     """
     coerced = _coerce(value)
     raw_len = len(coerced)

--- a/scripts/core/log_safety.py
+++ b/scripts/core/log_safety.py
@@ -70,6 +70,12 @@ def _escape_controls(s: str) -> str:
 def safe(value: object, *, max_len: int = _DEFAULT_MAX_LEN) -> str:
     """Render an arbitrary value as a single-line, control-char-free log field.
 
+    **Stability:** the behavioral contract below is covered by
+    ``tests/test_log_safety.py`` and is intended to remain stable so call
+    sites can rely on the output invariant. The escape format
+    (``\\xNN`` / ``\\uNNNN``) and truncation marker text are considered
+    part of the contract — log-parsing tools may grep for them.
+
     Contract (see ``tests/test_log_safety.py``):
 
     - ``None`` → ``"<none>"`` (preserves field-was-null forensic signal)

--- a/scripts/core/log_safety.py
+++ b/scripts/core/log_safety.py
@@ -108,6 +108,15 @@ def safe(value: object, *, max_len: int = _DEFAULT_MAX_LEN) -> str:
     or printable ASCII (``0x20``–``0x7e``). No other characters can leak
     into the output.
 
+    **Accepted trade-off — sentinel ambiguity:** a DB-stored value whose
+    literal text is ``"<none>"`` or ``"<unrepresentable>"`` renders
+    identically to the real sentinel. Operators cannot distinguish a
+    NULL column from an attacker-written literal on log inspection alone.
+    This was accepted during Aegis review (#104) because the alternative
+    — suppressing sentinel output entirely — would lose the forensic
+    field-was-null signal that motivated choosing a marker over empty
+    string in the first place.
+
     Usage:
 
         from scripts.core.log_safety import safe

--- a/scripts/core/log_safety.py
+++ b/scripts/core/log_safety.py
@@ -42,16 +42,28 @@ def _coerce(value: object) -> str:
 
 
 def _escape_controls(s: str) -> str:
-    """Replace C0 controls and DEL with ``\\xNN`` markers; keep ``\\t``."""
+    """Enforce printable-ASCII-only output; escape everything else.
+
+    The output contract is strict: only ``\\t`` or printable ASCII
+    (``0x20``–``0x7e``) is ever passed through unchanged. C0 controls,
+    DEL (``0x7f``), C1 controls (``0x80``–``0x9f``), and non-ASCII
+    characters (incl. Unicode surrogates and emoji) are all escaped.
+
+    C1 in particular matters for the threat model — a raw ``\\x9b``
+    (CSI) is treated as an ANSI escape by UTF-8 terminals, so allowing
+    it through would reopen the exact ANSI-injection vector this helper
+    exists to close. Allowlisting printable ASCII is simpler and safer
+    than chasing denylists across Unicode categories.
+    """
     out: list[str] = []
     for ch in s:
         o = ord(ch)
-        if ch == "\t":
+        if ch == "\t" or 0x20 <= o <= 0x7E:
             out.append(ch)
-        elif o < 0x20 or o == 0x7F:
+        elif o <= 0xFF:
             out.append(f"\\x{o:02x}")
         else:
-            out.append(ch)
+            out.append(f"\\u{o:04x}")
     return "".join(out)
 
 
@@ -69,13 +81,22 @@ def safe(value: object, *, max_len: int = _DEFAULT_MAX_LEN) -> str:
     - ``\\n``, ``\\r``, ``\\x00``–``\\x08``, ``\\x0b``–``\\x1f``, ``\\x7f``
       → replaced with ``\\xNN`` markers (lowercase hex, reversible for
       forensics).
+    - ``\\x80``–``\\xff`` (includes C1 controls like ``\\x9b`` CSI) →
+      ``\\xNN`` markers. These look "innocent" but UTF-8 terminals
+      interpret ``\\x9b`` as an ANSI escape, so allowing them through
+      would reopen the injection vector.
+    - Non-ASCII characters ``\\u0100``+ (including emoji and Unicode
+      surrogates) → ``\\uNNNN`` markers.
     - ``\\t`` (``0x09``) preserved — tabs are common in real data and
       harmless for log tailing.
     - Inputs longer than ``max_len`` raw characters are truncated to
       ``max_len`` then suffixed with the ASCII marker
-      ``"...[truncated N bytes]"``. Truncation happens on the raw input
-      length (not the escaped output length) to prevent a string of
-      newlines from ballooning the log line.
+      ``"...[truncated N characters]"``. Truncation happens on the raw
+      input length (Python string length = code points), not on the
+      escaped output length, to prevent a string of newlines from
+      ballooning the log line. The unit is characters (code points),
+      not bytes — a truncated 1000-codepoint emoji string would drop
+      far more than N bytes, and the suffix reflects the actual unit.
 
     The return value is always a ``str`` containing only ``\\t`` (``0x09``)
     or printable ASCII (``0x20``–``0x7e``). No other characters can leak
@@ -100,5 +121,5 @@ def safe(value: object, *, max_len: int = _DEFAULT_MAX_LEN) -> str:
     if raw_len > max_len:
         head = coerced[:max_len]
         dropped = raw_len - max_len
-        return _escape_controls(head) + f"...[truncated {dropped} bytes]"
+        return _escape_controls(head) + f"...[truncated {dropped} characters]"
     return _escape_controls(coerced)

--- a/scripts/core/memory_daemon.py
+++ b/scripts/core/memory_daemon.py
@@ -802,7 +802,11 @@ def _check_pattern_detection():
     if rc is not None:
         if rc == 0:
             stdout_stream = state.pattern_proc.stdout
-            stdout = stdout_stream.read().decode() if stdout_stream is not None else ""
+            stdout = (
+                stdout_stream.read().decode("utf-8", errors="replace")
+                if stdout_stream is not None
+                else ""
+            )
             try:
                 import json as _json
                 data = _json.loads(stdout)
@@ -832,7 +836,7 @@ def _check_pattern_detection():
             # hint was misleading under the DEVNULL fallback.)
             stderr_stream = state.pattern_proc.stderr
             if stderr_stream is not None:
-                stderr = stderr_stream.read().decode()[:200]
+                stderr = stderr_stream.read().decode("utf-8", errors="replace")[:200]
             else:
                 stashed_path = getattr(state.pattern_proc, "_debug_stderr_path", None)
                 if stashed_path:
@@ -953,7 +957,13 @@ def daemon_loop():
             if DEBUG:
                 import traceback
 
-                log(f"[DEBUG] traceback:\n{traceback.format_exc()}")
+                # Traceback may include exception messages that transit
+                # DB content (psycopg errors embed query parameters).
+                # Wrap to neutralize control chars — the resulting log
+                # line collapses the traceback to a single line with
+                # \x0a markers, which is noisier for humans but keeps
+                # the injection boundary closed (cycle-1 CodeRabbit).
+                log(f"[DEBUG] traceback: {safe(traceback.format_exc())}")
         time.sleep(_poll_interval())
 
 

--- a/scripts/core/memory_daemon.py
+++ b/scripts/core/memory_daemon.py
@@ -182,6 +182,9 @@ from scripts.core.memory_daemon_core import (  # noqa: E402
     strip_yaml_frontmatter,
 )
 
+# Log-field sanitizer for DB-sourced / subprocess-sourced strings (#104).
+from scripts.core.log_safety import safe  # noqa: E402
+
 # Re-exports from memory_daemon_db (D12: shims per step)
 from scripts.core.memory_daemon_db import (  # noqa: E402
     get_postgres_url,
@@ -581,8 +584,8 @@ def reap_completed_extractions():
             learnings_info = f", learnings={learnings_count}" if learnings_count is not None else ""
             rejections_count = _count_session_rejections(session_id) if exit_code == 0 else None
             rejections_info = f", rejections={rejections_count}" if rejections_count is not None else ""
-            log(f"Extraction completed for {session_id} "
-                f"(pid={pid}, project={project}, "
+            log(f"Extraction completed for {safe(session_id)} "
+                f"(pid={pid}, project={safe(project)}, "
                 f"exit={exit_code}, elapsed={elapsed}s{learnings_info}{rejections_info})")
             # Safe to read(): proc.poll() already returned, so child has exited
             # and the write end of the pipe is closed. No deadlock risk.
@@ -593,7 +596,7 @@ def reap_completed_extractions():
                         raw = proc.stderr.read(65536)  # bounded read, ~64KB max
                         stderr_text = raw.decode("utf-8", errors="replace").strip()[-500:]
                         if stderr_text:
-                            log(f"  stderr: {stderr_text}")
+                            log(f"  stderr: {safe(stderr_text)}")
                 finally:
                     proc.stderr.close()
 
@@ -626,13 +629,13 @@ def watchdog_stuck_extractions():
         if elapsed > _extraction_timeout():
             elapsed_min = int(elapsed / 60)
             log(f"Watchdog: killing stuck extraction "
-                f"{session_id} (pid={pid}, "
+                f"{safe(session_id)} (pid={pid}, "
                 f"running {elapsed_min}m)")
             try:
                 proc.kill()
                 proc.wait(timeout=5)
             except Exception as e:
-                log(f"Watchdog: failed to kill pid {pid}: {e}")
+                log(f"Watchdog: failed to kill pid {pid}: {safe(e)}")
             killed.append(pid)
             mark_extraction_failed(session_id)
 
@@ -654,7 +657,7 @@ def process_pending_queue():
         # Skip sessions already being extracted (avoids duplicates)
         if any(ex[0] == session_id for ex in ae.values()):
             continue
-        log(f"Dequeuing {session_id} (project={project or 'unknown'}, "
+        log(f"Dequeuing {safe(session_id)} (project={safe(project or 'unknown')}, "
             f"queue remaining: {len(pq)})")
         if extract_memories(session_id, project, transcript_path):
             mark_extracting(session_id)
@@ -679,7 +682,7 @@ def queue_or_extract(
 
     if len(ae) >= _max_concurrent():
         pq.append((session_id, project, transcript_path))
-        log(f"Queued {session_id} (active={len(ae)}, "
+        log(f"Queued {safe(session_id)} (active={len(ae)}, "
             f"queue={len(pq)})")
     else:
         if extract_memories(session_id, project, transcript_path):
@@ -740,7 +743,7 @@ def _run_pattern_detection_batch():
                 # If we cannot open the log file (symlink refused, fd
                 # exhaustion, permission denied), fall back to DEVNULL —
                 # discarding verbose output is safer than deadlocking.
-                log(f"Pattern detection verbose log open failed: {e}")
+                log(f"Pattern detection verbose log open failed: {safe(e)}")
                 pb_stderr = subprocess.DEVNULL
         # Round 3 Codex Finding 2: if Popen raises after debug_stderr_handle
         # is opened, the handle must be closed before the exception
@@ -784,7 +787,7 @@ def _run_pattern_detection_batch():
         if DEBUG:
             debug(f"pattern_batch spawned pid={state.pattern_proc.pid}")
     except Exception as e:
-        log(f"Pattern detection launch error: {e}")
+        log(f"Pattern detection launch error: {safe(e)}")
 
 
 def _check_pattern_detection():
@@ -812,7 +815,7 @@ def _check_pattern_detection():
                 log(f"Pattern detection completed: {total} patterns "
                     f"from {analyzed} learnings ({type_summary})")
             except (_json.JSONDecodeError, KeyError):
-                log(f"Pattern detection completed: {stdout[:200]}")
+                log(f"Pattern detection completed: {safe(stdout[:200])}")
         else:
             # stderr can be None in two cases:
             #   1. DEBUG mode successfully opened a verbose log file and
@@ -833,7 +836,7 @@ def _check_pattern_detection():
                     stderr = f"(see {stashed_path})"
                 else:
                     stderr = "(stderr not captured — output was discarded)"
-            log(f"Pattern detection failed (rc={rc}): {stderr}")
+            log(f"Pattern detection failed (rc={rc}): {safe(stderr)}")
         # Close the DEBUG-mode stderr log handle if we stashed one at spawn.
         debug_stderr = getattr(state.pattern_proc, "_debug_stderr_handle", None)
         if debug_stderr is not None:
@@ -881,18 +884,18 @@ def daemon_tick() -> None:
 
         # Log still-alive sessions — noisy per-iteration, gated to debug.
         for s in still_alive:
-            debug(f"Skipping {s.id}: process {s.pid} still alive")
+            debug(f"Skipping {safe(s.id)}: process {s.pid} still alive")
 
         # Mark newly-dead sessions (grace period starts)
         for sid in newly_dead_ids:
             mark_session_exited(sid)
-            log(f"Skipping {sid}: marked exited, "
+            log(f"Skipping {safe(sid)}: marked exited, "
                 f"grace period {_harvest_grace_period()}s")
 
         # Extract truly stale sessions
         if truly_stale:
             summary = ", ".join(
-                f"{s.id}({s.project or '?'})" for s in truly_stale
+                f"{safe(s.id)}({safe(s.project or '?')})" for s in truly_stale
             )
             log(f"Found {len(truly_stale)} stale sessions: "
                 f"{summary}")
@@ -943,7 +946,7 @@ def daemon_loop():
         try:
             daemon_tick()
         except Exception as e:
-            log(f"Error in daemon loop: {e}")
+            log(f"Error in daemon loop: {safe(e)}")
             if DEBUG:
                 import traceback
 

--- a/scripts/core/memory_daemon.py
+++ b/scripts/core/memory_daemon.py
@@ -809,11 +809,14 @@ def _check_pattern_detection():
                 total = data.get("patterns_detected", "?")
                 analyzed = data.get("learnings_analyzed", "?")
                 by_type = data.get("patterns_by_type", {})
+                # pattern_batch reads DB-sourced values (learning text, tag
+                # names) — its JSON output can contain attacker-influenced
+                # keys/values. Sanitize each field before interpolation.
                 type_summary = ", ".join(
-                    f"{k}={v}" for k, v in sorted(by_type.items())
+                    f"{safe(k)}={safe(v)}" for k, v in sorted(by_type.items())
                 )
-                log(f"Pattern detection completed: {total} patterns "
-                    f"from {analyzed} learnings ({type_summary})")
+                log(f"Pattern detection completed: {safe(total)} patterns "
+                    f"from {safe(analyzed)} learnings ({type_summary})")
             except (_json.JSONDecodeError, KeyError):
                 log(f"Pattern detection completed: {safe(stdout[:200])}")
         else:

--- a/scripts/core/memory_daemon_extractors.py
+++ b/scripts/core/memory_daemon_extractors.py
@@ -213,7 +213,7 @@ def archive_session_jsonl(
                 f"(file already in S3): {safe(e)}"
             )
 
-        log_fn(f"Archived {safe(session_id)} -> {s3_key}")
+        log_fn(f"Archived {safe(session_id)} -> {safe(s3_key)}")
 
     except subprocess.TimeoutExpired:
         log_fn(f"Archive timeout for {safe(session_id)}")

--- a/scripts/core/memory_daemon_extractors.py
+++ b/scripts/core/memory_daemon_extractors.py
@@ -245,10 +245,13 @@ def calibrate_session_confidence(session_id: str, log_fn: Callable[[str], None])
         result = asyncio.run(calibrate_session(session_id))
         stats = result["stats"]
         if stats["total"] > 0:
+            # stats values come from calibrate_session which ultimately reads
+            # DB-stored learning content; wrap for defense in depth even
+            # though happy-path values are ints.
             log_fn(
                 f"Confidence calibration for {safe(session_id)}: "
-                f"{stats['updated']} updated, "
-                f"{stats['unchanged']} unchanged"
+                f"{safe(stats['updated'])} updated, "
+                f"{safe(stats['unchanged'])} unchanged"
             )
     except Exception as e:
         log_fn(f"Confidence calibration failed for {safe(session_id)}: {safe(e)}")

--- a/scripts/core/memory_daemon_extractors.py
+++ b/scripts/core/memory_daemon_extractors.py
@@ -20,6 +20,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
+from scripts.core.log_safety import safe
 from scripts.core.memory_daemon_core import (
     build_extraction_command,
     build_extraction_env,
@@ -63,14 +64,14 @@ def extract_memories_impl(
     subprocess import is used only for subprocess.DEVNULL constants.
     """
     log_fn(
-        f"Extracting memories for session {session_id} "
-        f"(project={project_dir or 'unknown'})"
+        f"Extracting memories for session {safe(session_id)} "
+        f"(project={safe(project_dir or 'unknown')})"
     )
 
     if is_blocked_fn(project_dir):
         log_fn(
             f"Extraction blocked by .claude/no-extract sentinel "
-            f"(project={project_dir}), marking as extracted (skip)"
+            f"(project={safe(project_dir)}), marking as extracted (skip)"
         )
         mark_extracted_fn(session_id)
         return False
@@ -85,8 +86,8 @@ def extract_memories_impl(
     if not jsonl_path:
         reason = "no transcript_path in DB" if not transcript_path else "file missing from disk"
         log_fn(
-            f"No JSONL for session {session_id} "
-            f"(project={project_dir or 'unknown'}, {reason}), "
+            f"No JSONL for session {safe(session_id)} "
+            f"(project={safe(project_dir or 'unknown')}, {reason}), "
             f"marking as extracted (skip)"
         )
         mark_extracted_fn(session_id)
@@ -110,9 +111,9 @@ def extract_memories_impl(
 
         if daemon_cfg.extraction_model not in allowed_models:
             log_fn(
-                f"Invalid extraction_model '{daemon_cfg.extraction_model}', "
+                f"Invalid extraction_model '{safe(daemon_cfg.extraction_model)}', "
                 f"must be one of {sorted(allowed_models)}. "
-                f"Session {session_id} marked failed for retry."
+                f"Session {safe(session_id)} marked failed for retry."
             )
             mark_failed_fn(session_id)
             return False
@@ -141,13 +142,13 @@ def extract_memories_impl(
             time.time(),
         )
         log_fn(
-            f"Started extraction for {session_id} "
-            f"(pid={proc.pid}, file={jsonl_path.name}, "
+            f"Started extraction for {safe(session_id)} "
+            f"(pid={proc.pid}, file={safe(jsonl_path.name)}, "
             f"active={len(active_extractions)})"
         )
         return True
     except Exception as e:
-        log_fn(f"Failed to start extraction: {e}")
+        log_fn(f"Failed to start extraction: {safe(e)}")
         return False
 
 
@@ -169,7 +170,7 @@ def archive_session_jsonl(
         return
 
     if not jsonl_path or not jsonl_path.exists():
-        log_fn(f"Archive skipped for {session_id}: JSONL not found")
+        log_fn(f"Archive skipped for {safe(session_id)}: JSONL not found")
         return
 
     project_name = jsonl_path.parent.name
@@ -183,7 +184,8 @@ def archive_session_jsonl(
             timeout=300,
         )
         if result.returncode != 0:
-            log_fn(f"zstd failed for {session_id}: {result.stderr.decode()}")
+            err = safe(result.stderr.decode(errors="replace"))
+            log_fn(f"zstd failed for {safe(session_id)}: {err}")
             return
 
         result = subprocess.run(
@@ -192,7 +194,8 @@ def archive_session_jsonl(
             timeout=120,
         )
         if result.returncode != 0:
-            log_fn(f"S3 upload failed for {session_id}: {result.stderr.decode()}")
+            err = safe(result.stderr.decode(errors="replace"))
+            log_fn(f"S3 upload failed for {safe(session_id)}: {err}")
             subprocess.run(
                 ["zstd", "-d", "-q", "--rm", str(zst_path)],
                 capture_output=True,
@@ -205,12 +208,15 @@ def archive_session_jsonl(
         try:
             mark_archived_fn(session_id, s3_key)
         except Exception as e:
-            log_fn(f"Archive DB update failed for {session_id} (file already in S3): {e}")
+            log_fn(
+                f"Archive DB update failed for {safe(session_id)} "
+                f"(file already in S3): {safe(e)}"
+            )
 
-        log_fn(f"Archived {session_id} -> {s3_key}")
+        log_fn(f"Archived {safe(session_id)} -> {s3_key}")
 
     except subprocess.TimeoutExpired:
-        log_fn(f"Archive timeout for {session_id}")
+        log_fn(f"Archive timeout for {safe(session_id)}")
         if zst_path.exists() and not jsonl_path.exists():
             try:
                 subprocess.run(
@@ -219,9 +225,9 @@ def archive_session_jsonl(
                     timeout=300,
                 )
             except (subprocess.TimeoutExpired, OSError) as restore_err:
-                log_fn(f"Archive cleanup failed for {session_id}: {restore_err}")
+                log_fn(f"Archive cleanup failed for {safe(session_id)}: {safe(restore_err)}")
     except Exception as e:
-        log_fn(f"Archive error for {session_id}: {e}")
+        log_fn(f"Archive error for {safe(session_id)}: {safe(e)}")
 
 
 # ---------------------------------------------------------------------------
@@ -240,12 +246,12 @@ def calibrate_session_confidence(session_id: str, log_fn: Callable[[str], None])
         stats = result["stats"]
         if stats["total"] > 0:
             log_fn(
-                f"Confidence calibration for {session_id}: "
+                f"Confidence calibration for {safe(session_id)}: "
                 f"{stats['updated']} updated, "
                 f"{stats['unchanged']} unchanged"
             )
     except Exception as e:
-        log_fn(f"Confidence calibration failed for {session_id}: {e}")
+        log_fn(f"Confidence calibration failed for {safe(session_id)}: {safe(e)}")
 
 
 # ---------------------------------------------------------------------------
@@ -268,7 +274,7 @@ def extract_and_store_workflows(
             format_pattern_as_learning,
         )
     except ImportError as e:
-        log_fn(f"Workflow extraction unavailable: {e}")
+        log_fn(f"Workflow extraction unavailable: {safe(e)}")
         return
 
     try:
@@ -277,7 +283,7 @@ def extract_and_store_workflows(
         successful = [p for p in patterns if p.get("success") is True]
 
         if not successful:
-            log_fn(f"No successful workflow patterns for {session_id}")
+            log_fn(f"No successful workflow patterns for {safe(session_id)}")
             return
 
         from scripts.core.store_learning import store_learning_v2
@@ -303,11 +309,11 @@ def extract_and_store_workflows(
                 if result.get("success") and not result.get("skipped"):
                     stored += 1
             except Exception as e:
-                log_fn(f"Failed to store workflow learning: {e}")
+                log_fn(f"Failed to store workflow learning: {safe(e)}")
 
-        log_fn(f"Stored {stored} workflow patterns for {session_id}")
+        log_fn(f"Stored {stored} workflow patterns for {safe(session_id)}")
     except Exception as e:
-        log_fn(f"Workflow extraction failed for {session_id}: {e}")
+        log_fn(f"Workflow extraction failed for {safe(session_id)}: {safe(e)}")
 
 
 # ---------------------------------------------------------------------------
@@ -328,11 +334,11 @@ def generate_mini_handoff(
             write_handoff,
         )
     except ImportError as e:
-        log_fn(f"Mini-handoff generation unavailable: {e}")
+        log_fn(f"Mini-handoff generation unavailable: {safe(e)}")
         return
 
     if not project:
-        log_fn(f"Mini-handoff skipped for {session_id}: no project dir")
+        log_fn(f"Mini-handoff skipped for {safe(session_id)}: no project dir")
         return
 
     state_file = Path(project) / ".claude" / "cache" / "session-state" / f"{session_id}.jsonl"
@@ -347,16 +353,19 @@ def generate_mini_handoff(
         )
         output_path = write_handoff(handoff, Path(project), session_id)
         source = "state_file" if use_state_file else "jsonl"
-        log_fn(f"Mini-handoff written for {session_id} (source={source}): {output_path}")
+        log_fn(
+            f"Mini-handoff written for {safe(session_id)} "
+            f"(source={source}): {safe(output_path)}"
+        )
 
         if use_state_file:
             try:
                 state_file.unlink()
-                log_fn(f"State file cleaned up for {session_id}")
+                log_fn(f"State file cleaned up for {safe(session_id)}")
             except OSError as cleanup_err:
-                log_fn(f"State file cleanup failed for {session_id}: {cleanup_err}")
+                log_fn(f"State file cleanup failed for {safe(session_id)}: {safe(cleanup_err)}")
     except Exception as e:
-        log_fn(f"Mini-handoff generation failed for {session_id}: {e}")
+        log_fn(f"Mini-handoff generation failed for {safe(session_id)}: {safe(e)}")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_log_safety.py
+++ b/tests/test_log_safety.py
@@ -8,6 +8,7 @@ and GitHub issue #104.
 from __future__ import annotations
 
 import pytest
+
 from scripts.core.log_safety import safe
 
 # ---------------------------------------------------------------------------
@@ -88,6 +89,57 @@ def test_bell_replaced():
 
 
 # ---------------------------------------------------------------------------
+# C1 control sanitization (Gemini Round 1 HIGH)
+# ---------------------------------------------------------------------------
+
+
+def test_c1_csi_replaced():
+    # 0x9b is CSI — UTF-8 terminals interpret it as ESC [, reopening the
+    # ANSI-injection vector if allowed through.
+    assert safe("\x9b[31mRED") == "\\x9b[31mRED"
+
+
+def test_all_c1_controls_replaced():
+    # 0x80-0x9f must all be escaped.
+    for c in range(0x80, 0xA0):
+        raw = chr(c)
+        out = safe(raw)
+        assert raw not in out
+        assert f"\\x{c:02x}" in out
+
+
+def test_high_byte_latin1_replaced():
+    # 0xa0-0xff: e.g. \xa0 NBSP — not a control but not printable ASCII.
+    assert safe("a\xa0b") == "a\\xa0b"
+    assert safe("\xff") == "\\xff"
+
+
+def test_non_ascii_unicode_replaced():
+    # Emoji / non-Latin-1 chars must be escaped as \uNNNN.
+    out = safe("caf\u00e9")  # é
+    assert "\u00e9" not in out
+    assert "\\xe9" in out  # within 0xff, gets \xNN
+    out = safe("hi \u4e2d")  # Chinese char > 0xff
+    assert "\u4e2d" not in out
+    assert "\\u4e2d" in out
+
+
+def test_emoji_replaced():
+    # Emoji are typically > 0xffff (use surrogate pair when in BMP), but
+    # a BMP emoji like U+2600 ☀ is single code point > 0xff.
+    out = safe("\u2600 sunny")
+    assert "\u2600" not in out
+    assert "\\u2600" in out
+
+
+def test_unicode_surrogate_replaced():
+    # Lone surrogate (invalid Unicode but Python can hold it in a str).
+    out = safe("\ud83d")
+    assert "\ud83d" not in out
+    assert "\\ud83d" in out
+
+
+# ---------------------------------------------------------------------------
 # Non-string coercion
 # ---------------------------------------------------------------------------
 
@@ -160,32 +212,44 @@ def test_long_input_truncated_with_ascii_marker():
     s = "x" * 1000
     out = safe(s)
     assert out.startswith("x" * 500)
-    assert out.endswith("...[truncated 500 bytes]")
+    assert out.endswith("...[truncated 500 characters]")
     assert "\u2026" not in out  # ASCII-only per ARCHITECT
 
 
-def test_truncation_marker_reports_remaining_bytes():
+def test_truncation_marker_reports_remaining_characters():
     s = "a" * 750
     out = safe(s)
-    # Default max_len=500 → 250 bytes dropped.
-    assert out.endswith("...[truncated 250 bytes]")
+    # Default max_len=500 → 250 characters dropped.
+    assert out.endswith("...[truncated 250 characters]")
 
 
 def test_custom_max_len():
     out = safe("abcdefghij", max_len=4)
     assert out.startswith("abcd")
-    assert out.endswith("...[truncated 6 bytes]")
+    assert out.endswith("...[truncated 6 characters]")
 
 
 def test_truncation_happens_before_escaping_length():
     # 1000 newlines. Each expands to "\x0a" (4 chars) if escaped first,
-    # which would balloon the log. We must cap at the raw byte count first.
+    # which would balloon the log. We must cap at the raw code-point
+    # count first.
     s = "\n" * 1000
     out = safe(s)
-    # The truncation count refers to raw input bytes dropped, not escaped chars.
-    assert "[truncated 500 bytes]" in out
+    # The truncation count refers to raw input code points dropped,
+    # not escaped chars.
+    assert "[truncated 500 characters]" in out
     # And no raw newline leaked.
     assert "\n" not in out
+
+
+def test_truncation_unit_is_codepoints_not_bytes():
+    # 1000 emoji code points — each is 4 bytes in UTF-8. We truncate at
+    # 500 code points. The marker must say "characters" because that's
+    # the actual unit — saying "bytes" would be off by a factor of 4.
+    s = "\U0001f600" * 1000  # each codepoint is 1 len-unit in Python str
+    out = safe(s)
+    assert "[truncated 500 characters]" in out
+    assert "[truncated 2000 bytes]" not in out
 
 
 # ---------------------------------------------------------------------------
@@ -205,6 +269,16 @@ def test_truncation_happens_before_escaping_length():
         b"\x00\x01\x02",
         "x" * 2000,
         _RaisingStr(),
+        # Gemini Round 1 HIGH: extend coverage across Unicode space so
+        # the ASCII-only invariant is genuinely enforced, not coincidence.
+        "\x9b[31m",  # C1 CSI
+        "\x80\x81\x82\x9f",  # C1 block
+        "\xa0\xff",  # Latin-1 supplement (non-control but non-ASCII)
+        "caf\u00e9",  # accented Latin
+        "\u4e2d\u6587",  # CJK
+        "\u2600\u2b50",  # BMP symbols
+        "\U0001f600",  # supplementary-plane emoji
+        "\ud83d",  # lone surrogate
     ],
 )
 def test_output_has_no_raw_control_chars(value):

--- a/tests/test_log_safety.py
+++ b/tests/test_log_safety.py
@@ -125,11 +125,36 @@ def test_non_ascii_unicode_replaced():
 
 
 def test_emoji_replaced():
-    # Emoji are typically > 0xffff (use surrogate pair when in BMP), but
-    # a BMP emoji like U+2600 ☀ is single code point > 0xff.
+    # Many emoji are > 0xffff (and use surrogate pairs in UTF-16 because
+    # they are outside the BMP), but a BMP symbol like U+2600 ☀ is a
+    # single code point > 0xff.
     out = safe("\u2600 sunny")
     assert "\u2600" not in out
     assert "\\u2600" in out
+
+
+def test_non_bmp_uses_8_digit_escape():
+    # Code points > 0xFFFF must use \U with 8 hex digits (cycle-1 Gemini
+    # + Copilot). Using \u with 5+ digits is non-standard and breaks
+    # downstream JSON/Python parsers that expect fixed-width \uNNNN.
+    out = safe("\U0001f600")  # grinning face U+1F600
+    assert "\U0001f600" not in out
+    assert "\\U0001f600" in out
+    # And \u1f600 (5-digit \u) MUST NOT appear.
+    assert "\\u1f600" not in out
+
+
+def test_bmp_boundary_uses_4_digit_u():
+    # U+FFFF is the last BMP codepoint — must render as \uffff not \U.
+    out = safe("\uffff")
+    assert "\\uffff" in out
+    assert "\\U" not in out
+
+
+def test_supplementary_plane_boundary():
+    # U+10000 is the first non-BMP codepoint — must render as \U00010000.
+    out = safe("\U00010000")
+    assert "\\U00010000" in out
 
 
 def test_unicode_surrogate_replaced():
@@ -198,6 +223,29 @@ def test_str_returning_nonstr_falls_back_to_sentinel():
     assert safe(_StrReturnsNonStr()) == "<unrepresentable>"
 
 
+class _KeyboardInterruptOnStr:
+    def __str__(self) -> str:
+        raise KeyboardInterrupt("ctrl-c during log render")
+
+
+class _SystemExitOnStr:
+    def __str__(self) -> str:
+        raise SystemExit(0)
+
+
+def test_keyboard_interrupt_propagates():
+    # CodeRabbit cycle-1 suggested catching BaseException in _coerce — ARCHITECT
+    # overruled: KeyboardInterrupt MUST propagate so Ctrl-C still works mid-log.
+    with pytest.raises(KeyboardInterrupt):
+        safe(_KeyboardInterruptOnStr())
+
+
+def test_system_exit_propagates():
+    # Same rationale as KeyboardInterrupt — sys.exit() must not be swallowed.
+    with pytest.raises(SystemExit):
+        safe(_SystemExitOnStr())
+
+
 # ---------------------------------------------------------------------------
 # Truncation
 # ---------------------------------------------------------------------------
@@ -227,6 +275,18 @@ def test_custom_max_len():
     out = safe("abcdefghij", max_len=4)
     assert out.startswith("abcd")
     assert out.endswith("...[truncated 6 characters]")
+
+
+def test_max_len_zero_truncates_everything():
+    out = safe("abc", max_len=0)
+    assert out == "...[truncated 3 characters]"
+
+
+def test_negative_max_len_raises_valueerror():
+    # Cycle-1 Copilot: surfaces misconfigured call sites at the boundary.
+    # Only reachable via developer error — max_len is not user-supplied.
+    with pytest.raises(ValueError, match="max_len must be >= 0"):
+        safe("anything", max_len=-1)
 
 
 def test_truncation_happens_before_escaping_length():

--- a/tests/test_log_safety.py
+++ b/tests/test_log_safety.py
@@ -1,0 +1,221 @@
+"""Tests for scripts.core.log_safety.safe().
+
+Locks the sanitizer contract used to render DB-sourced fields into log
+messages. See thoughts/shared/plans/issue-104-log-injection-sanitization.md
+and GitHub issue #104.
+"""
+
+from __future__ import annotations
+
+import pytest
+from scripts.core.log_safety import safe
+
+# ---------------------------------------------------------------------------
+# None / empty
+# ---------------------------------------------------------------------------
+
+
+def test_none_renders_as_none_marker():
+    # Per ARCHITECT refinement: preserve field-was-null forensic signal.
+    assert safe(None) == "<none>"
+
+
+def test_empty_string_passes_through():
+    assert safe("") == ""
+
+
+# ---------------------------------------------------------------------------
+# Happy-path ASCII
+# ---------------------------------------------------------------------------
+
+
+def test_plain_ascii_unchanged():
+    assert safe("hello world") == "hello world"
+
+
+def test_printable_punctuation_unchanged():
+    s = "session-abc_123:/Users/x/project (foo)"
+    assert safe(s) == s
+
+
+def test_tab_preserved():
+    assert safe("a\tb") == "a\tb"
+
+
+# ---------------------------------------------------------------------------
+# Control-character sanitization
+# ---------------------------------------------------------------------------
+
+
+def test_newline_replaced():
+    assert safe("a\nb") == "a\\x0ab"
+
+
+def test_carriage_return_replaced():
+    assert safe("a\rb") == "a\\x0db"
+
+
+def test_crlf_both_replaced():
+    assert safe("a\r\nb") == "a\\x0d\\x0ab"
+
+
+def test_esc_replaced():
+    assert safe("\x1b[31mRED\x1b[0m") == "\\x1b[31mRED\\x1b[0m"
+
+
+def test_null_byte_replaced():
+    assert safe("a\x00b") == "a\\x00b"
+
+
+def test_all_c0_controls_replaced_except_tab():
+    # 0x00-0x1f minus 0x09 (tab); plus 0x7f (DEL).
+    raw = "".join(chr(c) for c in range(0x00, 0x20) if c != 0x09) + "\x7f"
+    out = safe(raw)
+    # No raw control chars should remain.
+    for c in raw:
+        assert c not in out, f"raw {hex(ord(c))} leaked into output"
+    # Every replaced char should appear as \xNN.
+    for c in raw:
+        assert f"\\x{ord(c):02x}" in out
+
+
+def test_del_byte_replaced():
+    assert safe("a\x7fb") == "a\\x7fb"
+
+
+def test_bell_replaced():
+    assert safe("beep\x07here") == "beep\\x07here"
+
+
+# ---------------------------------------------------------------------------
+# Non-string coercion
+# ---------------------------------------------------------------------------
+
+
+def test_int_coerced():
+    assert safe(42) == "42"
+
+
+def test_float_coerced():
+    assert safe(3.14) == "3.14"
+
+
+def test_list_coerced():
+    assert safe(["a", "b"]) == "['a', 'b']"
+
+
+def test_bytes_coerced_and_sanitized():
+    # bytes → str(bytes) yields "b'abc'" then sanitized (no control chars here).
+    assert safe(b"abc") == "b'abc'"
+
+
+def test_bytes_with_escape_sanitized():
+    # str(b"\x1b") -> "b'\\x1b'" — the ESC is already escaped by bytes' repr.
+    # But if a hostile bytes object contained a real ESC in its repr
+    # (impossible with stdlib bytes, but a subclass could), we still scrub.
+    out = safe(b"\x1b")
+    assert "\x1b" not in out
+
+
+# ---------------------------------------------------------------------------
+# Hostile __str__
+# ---------------------------------------------------------------------------
+
+
+class _RaisingStr:
+    def __str__(self) -> str:
+        raise RuntimeError("hostile __str__")
+
+    def __repr__(self) -> str:  # pragma: no cover - also hostile
+        raise RuntimeError("hostile __repr__")
+
+
+class _StrReturnsNonStr:
+    def __str__(self):  # type: ignore[override]
+        return 12345  # type: ignore[return-value]
+
+
+def test_hostile_str_falls_back_to_sentinel():
+    # Per ARCHITECT refinement: hardcode sentinel, do NOT fall back to repr()
+    # since repr() can also raise on hostile objects.
+    assert safe(_RaisingStr()) == "<unrepresentable>"
+
+
+def test_str_returning_nonstr_falls_back_to_sentinel():
+    # TypeError from str() on broken __str__ is also treated as unrepresentable.
+    assert safe(_StrReturnsNonStr()) == "<unrepresentable>"
+
+
+# ---------------------------------------------------------------------------
+# Truncation
+# ---------------------------------------------------------------------------
+
+
+def test_short_input_not_truncated():
+    s = "x" * 500
+    assert safe(s) == s
+
+
+def test_long_input_truncated_with_ascii_marker():
+    s = "x" * 1000
+    out = safe(s)
+    assert out.startswith("x" * 500)
+    assert out.endswith("...[truncated 500 bytes]")
+    assert "\u2026" not in out  # ASCII-only per ARCHITECT
+
+
+def test_truncation_marker_reports_remaining_bytes():
+    s = "a" * 750
+    out = safe(s)
+    # Default max_len=500 → 250 bytes dropped.
+    assert out.endswith("...[truncated 250 bytes]")
+
+
+def test_custom_max_len():
+    out = safe("abcdefghij", max_len=4)
+    assert out.startswith("abcd")
+    assert out.endswith("...[truncated 6 bytes]")
+
+
+def test_truncation_happens_before_escaping_length():
+    # 1000 newlines. Each expands to "\x0a" (4 chars) if escaped first,
+    # which would balloon the log. We must cap at the raw byte count first.
+    s = "\n" * 1000
+    out = safe(s)
+    # The truncation count refers to raw input bytes dropped, not escaped chars.
+    assert "[truncated 500 bytes]" in out
+    # And no raw newline leaked.
+    assert "\n" not in out
+
+
+# ---------------------------------------------------------------------------
+# Output invariants
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        None,
+        "",
+        "plain",
+        "a\nb\rc\x1bd\x00e",
+        42,
+        ["a", "\n", "b"],
+        b"\x00\x01\x02",
+        "x" * 2000,
+        _RaisingStr(),
+    ],
+)
+def test_output_has_no_raw_control_chars(value):
+    out = safe(value)
+    assert isinstance(out, str)
+    for c in out:
+        o = ord(c)
+        # Allow tab (0x09) and printable 0x20-0x7e. Nothing else.
+        assert c == "\t" or 0x20 <= o <= 0x7E, f"leaked control char {hex(o)} in {out!r}"
+
+
+@pytest.mark.parametrize("value", [None, "x", 1, ["a"], b"b"])
+def test_output_is_always_str(value):
+    assert isinstance(safe(value), str)


### PR DESCRIPTION
# Log injection sanitization for memory_daemon and backfill scripts

Fixes #104.

## Summary

`memory_daemon.py` and its extractors (plus the backfill CLI scripts)
interpolate DB-sourced strings — session IDs, project paths, transcript
paths, subprocess stderr — directly into log messages via f-strings. An
attacker with DB write access can inject newlines (log forgery), ESC
sequences (ANSI terminal manipulation on an admin's TTY), or other C0
control characters.

This PR introduces a single black-box sanitizer,
`scripts.core.log_safety.safe()`, and applies it at every identified
call site across `scripts/core/`.

## Design

One helper, one rule, one test suite. The `safe()` helper lives in a
new zero-dependency module (`scripts/core/log_safety.py`) so it can be
imported from anywhere without coupling to the daemon. It:

- Maps `None` → `"<none>"` (preserves field-was-null forensic signal —
  chosen over empty string because `project=` vs `project=<none>` is a
  meaningful distinction in logs).
- Replaces C0 controls and DEL with `\xNN` markers (lowercase hex,
  reversible for forensics). Preserves `\t`.
- Never raises: hostile objects with broken `__str__`/`__repr__` resolve
  to the sentinel `"<unrepresentable>"` rather than falling back to
  `repr()` (which can also raise).
- Truncates at 500 raw input chars with the ASCII marker
  `...[truncated N bytes]`. Raw-length truncation prevents a
  newline-flood from ballooning the log line.
- Output is always a `str` containing only `\t` or printable ASCII
  `0x20–0x7e`.

Subprocess stderr is decoded with `errors="replace"` before being passed
to `safe()` so non-UTF8 bytes become replacement characters rather than
an ugly `b'...'` repr.

## Commits

1. `test(log_safety): RED - add failing tests for safe() helper` — 39
   tests locking the contract.
2. `feat(log_safety): GREEN - implement safe() sanitizer` — pure
   function, 97% coverage.
3. `refactor(memory_daemon): apply safe() to DB/subprocess log fields` —
   13 call sites.
4. `refactor(extractors): apply safe() to DB/subprocess log fields` —
   25 call sites across 6 extractor functions.
5. `refactor(backfill_archive): apply safe() to DB/subprocess log fields` —
   7 call sites.
6. `refactor(backfill_learnings): apply safe() to DB/subprocess log fields` —
   8 call sites.
7. `docs(log_safety): add usage examples to safe() docstring` —
   shows both the basic pattern and the `decode(errors='replace')`
   pipeline for subprocess stderr.
8. `fix(log_safety): address Gemini Round 1 findings` — C1/non-ASCII
   allowlist, `s3_key` wrap, truncation unit, +15 tests.
9. `fix(log_safety): address Gemini Round 2 findings` — JSON
   subprocess output (pattern_detection + confidence calibration)
   no longer bypasses `safe()`.
10. `docs(log_safety): declare API stability of safe() contract` —
    escape format and truncation marker are part of the contract.
11. `fix(log_safety): address Aegis findings` — `backfill_learnings`
    main-loop bypass, `list_s3_keys` decode hardening, sentinel
    caveat documented.

## Test Coverage

All per-file coverage below was produced on this branch with:

```
uv run pytest \
  --cov=scripts.core.log_safety \
  --cov=scripts.core.memory_daemon \
  --cov=scripts.core.memory_daemon_extractors \
  --cov=scripts.core.backfill_archive \
  --cov=scripts.core.backfill_learnings \
  --cov-report=term-missing tests/
```

| File | Stmts | Miss | Cover |
|------|------:|-----:|------:|
| `scripts/core/log_safety.py` | 35 | 1 | **97%** |
| `scripts/core/backfill_learnings.py` | 317 | 31 | 90% |
| `scripts/core/backfill_archive.py` | 161 | 18 | 89% |
| `scripts/core/memory_daemon.py` | 501 | 186 | 63% |
| `scripts/core/memory_daemon_extractors.py` | 163 | 96 | 41% |

**Note for reviewers:** coverage on `memory_daemon.py` (63%) and
`memory_daemon_extractors.py` (41%) is the pre-existing project
baseline on `origin/main`. This PR only wraps existing log call sites
with `safe()`; it does not add new branches or change control flow, so
it cannot move the coverage number for those files. The new code in
this PR lives entirely in `scripts/core/log_safety.py` (97% covered).

Full suite: **2194 passed, 1 skipped, 2 deselected, 0 regressions.**

The two deselected failures are pre-existing on `origin/main` and
unrelated to this work:

- `TestPgEnsureColumn::test_adds_six_columns` — column-count drift
  (owned by another branch in the swarm).
- `TestMemoryBackendProtocol::test_protocol_is_a_protocol` — requires
  Python 3.13's `typing.is_protocol`; project runs 3.12.

## Non-Goals

- No new dependencies.
- No schema changes.
- No change to log destinations (rotating handler, faulthandler path).
- No change to what fields are logged.
- No refactor of the `log()` / `debug()` wrappers themselves.
- PR is scoped to `scripts/core/`. Any hits in `scripts/mcp/` or
  `src/runtime/` discovered during audit will be filed as separate
  follow-up issues per the deferred-fix rule.

## Pre-existing lint note

`ruff check scripts/core/memory_daemon.py` reports one `I001`
(import-block-un-sorted) error. This is pre-existing on `origin/main`
and not introduced by this PR — verified by running `ruff` against the
`origin/main` version of the file independently. Per the repo's
deferred-fix rule, it is not addressed here.

## Security Review

Reviewed with **Gemini-pro** (3 adversarial rounds — Codex plugin quota
was exhausted, so `gemini-mcp` was substituted per ARCHITECT direction)
and an **Aegis** security-specialist agent as the final pass.
Belt-and-suspenders: Gemini catches architectural/correctness issues,
Aegis catches security-specific patterns Gemini may miss.

Findings addressed across the 4 review passes:

| Pass | Severity | Finding | Commit |
|------|----------|---------|--------|
| Gemini R1 | HIGH | `_escape_controls` used a C0+DEL denylist — raw `\x9b` (CSI) and all non-ASCII passed through, reopening the ANSI-injection vector | 593cd8e |
| Gemini R1 | HIGH | Test suite didn't actually verify the ASCII-only contract (no C1 / Unicode inputs) | 593cd8e |
| Gemini R1 | HIGH | `s3_key` logged raw — derived from attacker-controlled `session_id` | 593cd8e |
| Gemini R1 | LOW | Truncation marker said "bytes" but Python `len(str)` counts code points | 593cd8e |
| Gemini R2 | HIGH | Pattern-detection JSON fields (`total`, `analyzed`, `type_summary` k/v pairs) interpolated raw from subprocess stdout | c657294 |
| Gemini R2 | HIGH | Confidence-calibration `stats['updated']` / `stats['unchanged']` interpolated raw | c657294 |
| Gemini R3 | — | Clean across all 5 axes — "Ready to merge" | — |
| Aegis | HIGH | `backfill_learnings.py:663-671` main results loop logged `session_id`, `status`, `result.error` unsanitized; `result.error` is from `claude -p` subprocess stderr reading untrusted transcript content | d0815b3 |
| Aegis | MEDIUM | `list_s3_keys` used `text=True` without `errors='replace'` — non-UTF8 `aws s3 ls` output could raise `UnicodeDecodeError` and bypass the `safe()` wrap | d0815b3 |
| Aegis | LOW | Sentinel `"<none>"` / `"<unrepresentable>"` forgeable by a DB value whose literal text matches — documented as an accepted trade-off in the `safe()` docstring | d0815b3 |
| Aegis | LOW | Narrow `except (JSONDecodeError, KeyError)` in `_check_pattern_detection` — filed as follow-up issue #114 per deferred-fix rule | deferred |
| AI cycle 1 | MEDIUM | `_escape_controls` emitted `\uNNNN` with 5+ hex digits for non-BMP code points (e.g. emoji U+1F600 → `\u1f600`) — non-standard, breaks JSON/Python parsers. Class of bug **Aegis missed** on the final pass. Now `\UNNNNNNNN` (8 hex) for > 0xFFFF. | 0aeb39b |
| AI cycle 1 | MEDIUM | Strict UTF-8 decode of `pattern_batch` stdout/stderr in `memory_daemon.py` — `UnicodeDecodeError` would leave `state.pattern_proc` stuck. Now `errors='replace'`. | 0aeb39b |
| AI cycle 1 | MEDIUM | DEBUG traceback at `memory_daemon.py:956` logged raw — `traceback.format_exc()` includes exception messages that embed DB values via psycopg. Now wrapped via `safe()`. | 0aeb39b |
| AI cycle 1 | MEDIUM | `safe()` didn't validate `max_len` — negative values produced nonsense truncation. Now raises `ValueError`. | 0aeb39b |
| AI cycle 1 | LOW | `_coerce` `except Exception` clarified as intentional — `KeyboardInterrupt` / `SystemExit` must propagate so Ctrl-C / `sys.exit()` still work during log render. Docstring now says "never raises a non-system Exception"; tests added for propagation. | 0aeb39b |
| AI cycle 1 | deferred | psycopg tracebacks retain embedded DB values even after `safe()` sanitization — filed as follow-up issue #117. | deferred |

Full Aegis verdict: `Aegis verdict: ready for PR` (after the HIGH + MEDIUM fixes landed).

**Deferred follow-up issues:** #114 (narrow except tuple), #117 (psycopg traceback scrubbing at raise-site).

## Workflow Compliance

- Branch: `fix/issue-104-log-injection`, created from `origin/main`.
- Developed in worktree `.worktrees/issue-104-log-injection`.
- TDD cycle (RED → GREEN → refactor) followed.
- Plan tracked at
  `thoughts/shared/plans/issue-104-log-injection-sanitization.md` on
  `main`.
