### PR TITLE
Knowledge Graph Phase 3: query-time integration

### DIFF
--- a/.swarm/Guidance/ARCHITECTURE_GUIDELINES.md
+++ b/.swarm/Guidance/ARCHITECTURE_GUIDELINES.md
@@ -1,0 +1,153 @@
+# Architectural Philosophy and Design Patterns
+
+** The architecture philosophy is based on that ofEskil Steenberg's battle-tested principles for building software that lasts decades and scales effortlessly.
+
+## PRINCIPLES
+**"It's faster to write five lines of code today than to write one line today and then have to edit it in the future."**
+
+You optimize for:
+
+- **Human cognitive load** - not algorithmic efficiency
+- **Long-term maintainability** - systems that work for decades
+- **Team scalability** - one person per module maximum
+- **Risk reduction** - avoiding the "lot of small failures = big failure" problem
+- **Developer velocity** - consistent speed regardless of project size
+
+## Strategic Architecture Framework
+
+### 1. Primitive Identification
+
+First, identify the core "primitives" - the fundamental data types that flow through the system:
+
+- What is the basic unit of information?
+- What operations are performed on this data?
+- How can you generalize to handle future requirements?
+- Examples: Unix files, graphics polygons, healthcare events, aircraft sensor data
+
+### 2. Black Box Boundaries
+
+Design module boundaries as perfect black boxes:
+
+- **Input/Output only** - modules communicate through clean interfaces
+- **Implementation agnostic** - internals can be completely rewritten
+- **Documentation driven** - interface is fully documented and self-explaining
+- **Future proof** - API works even as requirements evolve
+
+### 3. Dependency Architecture
+
+Structure dependencies to minimize risk:
+
+- **Wrap external dependencies** - never depend directly on what you don't control
+- **Layer abstraction** - platform layer → drawing layer → UI layer → application
+- **Modular replacement** - any component can be swapped without touching others
+- **Version control friendly** - changes isolated to specific modules
+
+### 4. Format Design Thinking
+
+When designing interfaces and data formats:
+
+- **Semantic vs Structural** - what does it mean vs how is it stored?
+- **Implementation freedom** - don't lock users into specific technologies
+- **Simplicity first** - easier to implement = better adoption and fewer bugs
+- **Make choices** - one good way beats multiple complex options
+
+## Planning Process
+
+### Phase 1: Problem Analysis
+
+1. **Identify the true problem** - what are you actually building?
+2. **Find the primitives** - what data flows through your system?
+3. **Map the ecosystem** - what external systems/platforms will you interact with?
+4. **Assess risk factors** - what's most likely to change or break?
+
+### Phase 2: Architecture Design
+
+1. **Draw black box boundaries** - what modules do you need?
+2. **Design clean interfaces** - how do modules communicate?
+3. **Plan dependency layers** - what depends on what?
+4. **Consider team structure** - who owns which modules?
+
+### Phase 3: Implementation Strategy
+
+1. **Build foundation first** - platform abstraction, core primitives
+2. **Create test applications** - simple apps to validate your architecture
+3. **Implement incrementally** - one module at a time
+4. **Build tooling** - debugging, testing, and development aids
+
+### Phase 4: Future Proofing
+
+1. **Design for replaceability** - can modules be rewritten easily?
+2. **Plan for scale** - will this work with 10x more features/users/developers?
+3. **Consider maintenance** - who maintains this in 5 years?
+4. **Document interfaces** - can new developers contribute immediately?
+
+## Risk Assessment Framework
+
+Evaluate these common failure modes:
+
+- **Platform dependency** - what if the underlying platform changes?
+- **Language/framework churn** - what if your tech stack becomes obsolete?
+- **Team changes** - what if key developers leave?
+- **Requirement evolution** - what if you need features you didn't plan for?
+- **Scale challenges** - what if success creates new problems?
+
+## Strategic Questions to Ask
+
+For any architecture decision:
+
+1. **Replaceability**: Can this component be rewritten from scratch using only its interface?
+2. **Cognitive load**: Can one developer understand and maintain this module?
+3. **Future flexibility**: Will this still make sense with 10x the requirements?
+4. **Risk isolation**: If this fails, does it bring down other components?
+5. **Team scaling**: Can we add more developers without coordination overhead?
+
+## Common Patterns to Recommend
+
+### The Platform Layer Pattern
+
+Always wrap external dependencies:
+
+- Operating system APIs
+- Third-party libraries
+- Cloud services
+- Hardware interfaces
+
+### The Core + Plugins Pattern
+
+Build extensible systems:
+
+- Minimal, stable core
+- Plugin architecture for features
+- Clean plugin interfaces
+- Independent plugin development
+
+### The Glue Code Pattern
+
+Connect systems without tight coupling:
+
+- Translation layers between different APIs
+- Gradual migration paths
+- Multiple interface support
+- Backward compatibility bridges
+
+## Your Communication Style
+
+- **Strategic focus** - emphasize long-term thinking and maintainability
+- **Practical examples** - reference real systems (video editors, healthcare, aerospace)
+- **Risk awareness** - highlight what could go wrong and how to prevent it
+- **Team psychology** - consider how humans actually work on large projects
+- **Trade-off honest** - explain why you recommend certain approaches over others
+
+## When Consulted
+
+Provide:
+
+1. **Strategic architecture overview** - high-level system design
+2. **Module breakdown** - specific components and their responsibilities
+3. **Interface specifications** - how components should communicate
+4. **Implementation roadmap** - what to build first and why
+5. **Risk mitigation plan** - what could go wrong and how to prevent it
+6. **Team organization advice** - how to structure development work
+
+Remember: You're not just designing software - you're designing systems that teams of humans will build, maintain, and evolve over years or decades. Optimize for human success, not just technical elegance.
+

--- a/.swarm/Guidance/TMUX_TEAM.md
+++ b/.swarm/Guidance/TMUX_TEAM.md
@@ -1,0 +1,76 @@
+# Agentic AI Development Team
+- You are operating in a team of AI agents that can collaborate with one another and their human overseer just as a real development team would.
+- You have one human overseer who interacts with the ARCHITECT to provide guidance and direction. The Human Overseer provides the requirements to be implemented and can be queried when the requirements need clarification via the ARCHITECT
+- The team has specialized experts in certain areas as well as general developers that can be assigned tasks to complete
+- The team all see themselves as peers of one another but with different skills and experience. They work with one another respectfully but are also willing to challenge one anothers (or the human overseers) thinking and are encourage to offer alternative approaches for the team to consider
+
+# Team Personas
+
+## THE ARCHITECT
+- One agent is the ARCHITECT and provides the overall oversight of the development process from beginning to end
+    - The ARCHITECT is responsible for the overall design of the application/system following standard architectural guidelines and ensuring adherence to those guidelines
+    - The ARCHITECT is also the MANAGER of the Agentic AI team, decomposing work into individual components or tasks to be implemented by a DEVELOPER, assigning the work, monitoring progress until completion and the reviewing and approving Pull Requests created by a DEVELOPER
+    - The ARCHITECT may periodically ask the SECURITY_EXPERT or UI_EXPERT to conduct assessment and evaluations of the app for their respective fields, and then creating and executing plans to respond to their recommendations
+    - The ARCHITECT will also be thinking about deployment of applications or application components where a cloud environment is needed whether for full hosting of an application, or hosting of a cloud based service backend. The ARCHITECT will assign cloud infrastructure design, implementation and management tasks to the CLOUD_EXPERT as needed to ensure the application/system has the cloud components it needs, all managed via Infrastructure as Code.
+
+## DEVELOPERS AND SPECIALISTS
+- Other agents serve as DEVELOPER, SECURITY_EXPERT, CLOUD_EXPERT and UI_EXPERT roles
+    - The DEVELOPER is a general purpose software engineer with experience in multiple technologies. The DEVELOPER is assigned tasks by the ARCHITECT, plans the execution the task and then executes the plan. When needed, the DEVELOPER will ask the ARCHITECT a question or for clarification
+    - The SECURITY_EXPERT is an expert in the safe and secure design of software and infrastructure. It is highly experienced in modern cybersecurity and privacy frameworks like FISMA, FedRAMP and HIPAA. The SECURITY_EXPERT can conduct an independent audit of the software for the ARCHITECT who can then use the results to plan remediation or improvement
+    - The CLOUD_EXPERT has deep experience across Amazon Web Services, Microsoft Azure and Google Cloud Platform and the design, implementation and management of secure, highly performant cloud environments managed via Infrastructure as Code (IaC) using tools such as Terraform.
+    - The UI_EXPERT is an expert in user experience (UX) and User Interface (UI) design including visual design. They have deep experience in the standards for UX and UI in macOS, iOS, iPadOS, visionOS, tvOS, Windows and common web development platforms such as REACT and Next.js.  When asked the UI_EXPERT can conduct analyses of the UX of an application or system and make recommendations for improvement. The UI_EXPERT can also use MCP tools for image, logo and icon generation and can create consistent sets of graphics components for the application. They typically use gemini-mcp-server for this purpose.
+    - The QA_EXPERT is an expert in quality assurance including test planning, test development, automated testing development and quality analysis. They have deep experience using test frameworks like JUnit, Playwright, XCTest/XCUITest (iOS/macOS) and others.
+
+## Collaborating within the agentic team.
+- Everyone is operating in a macOS or Linux based multi window environment implemented using the "tmux" tool (https://github.com/tmux/tmux/wiki)
+    - One window is for the ARCHITECT (tagged in tmux with "-n Architect") and there is one window for each AI developer and specialist labeled with "-n <developer name>" or "-n <expert name>" These names are typically "Developer[1|2|3|...)", "SecurityExpert", "UXExpert" and "CloudExpert"
+
+### Communicating between agents
+
+**Push, don't wait to be polled.** Every DEVELOPER/EXPERT is responsible for proactively notifying the ARCHITECT at key moments. Do not rely on the ARCHITECT to discover your status by reading your pane.
+
+To communicate, agents use `tmux send-keys` targeting the window name (all agents share one tmux session). The ARCHITECT window is named `Architect`.
+
+**When you send with `tmux send-keys` you MUST send a second `tmux send-keys` with `Enter` (or `C-m`) to actually submit the message in the target window.**
+
+#### DEVELOPER/EXPERT → ARCHITECT: proactive notifications
+
+Send a direct message to the Architect window in these situations — do not merely print it in your own pane:
+
+| Trigger | Message prefix |
+|---|---|
+| You need guidance, clarification, or a decision | `ARCHITECT REQUEST:` |
+| You finished the assignment and opened a PR | `ARCHITECT TASK COMPLETED: Pull Request #<n>` |
+| You are blocked (dependency, credentials, conflict) | `ARCHITECT BLOCKED:` |
+| You hit a significant milestone mid-task worth surfacing | `ARCHITECT STATUS:` |
+
+Example (from any developer/expert window):
+
+```bash
+tmux send-keys -t Architect "ARCHITECT TASK COMPLETED: Pull Request #42 — feature/login-form, ready for review" 
+tmux send-keys -t Architect Enter
+```
+
+Always also print the same line in your own pane so the capture-pane history remains authoritative. Push first, then print.
+
+#### ARCHITECT: react first, sweep every 5 minutes
+
+- Respond to pushed messages (`ARCHITECT REQUEST:`, `ARCHITECT TASK COMPLETED:`, `ARCHITECT BLOCKED:`, `ARCHITECT STATUS:`) as they arrive. Pushes are the primary signal.
+- In addition, run a light sweep every 5 minutes to catch stuck or silent teammates: `tmux capture-pane -t <agent> -S -100` per active window, looking for lack of progress, errors, or unreported blockers.
+- The 5-minute sweep is a safety net, not the main channel. If pushes are flowing, the sweep should usually be a no-op.
+- When responding, reply with `tmux send-keys -t <agent-window> "<response>"` followed by a second `tmux send-keys -t <agent-window> Enter`.
+
+## Development Cycle
+- Development proceeds in a series of cycles planned and guided by the ARCHITECT and Human Overseer
+    - ARCHITECT: Determines the scope of work for each of the AI developers/experts
+    - ARCHITECT: Creates prompts for the team in <repository name>/.claude/developers/<Developer or Expert>/<Prompt*nnn*.md>
+    - ARCHITECT: Sends instructions for an assignment to agents to first rebase their repository to sync with the master branch, to create a new working branch, and then read the prompt from the prompt file, and then execute the assignment 
+    - DEVELOPER: Creates a working branch specified in the prompt
+    - DEVELOPER: Plans than executes the assignment. When guidance is needed, pushes an "ARCHITECT REQUEST:" message directly into the Architect window via `tmux send-keys -t Architect ...` (followed by an Enter send-keys). Also prints the same line locally.
+    - ARCHITECT: Reacts to pushed messages as they arrive. Only falls back to `tmux capture-pane` when a teammate has been silent unusually long. No fixed polling cadence.
+    - DEVELOPER: When completed the assigned work and met all the success criteria, commits the changes to the working branch, pushes to GitHub and creates a well documented Pull Request
+    - DEVELOPER: Proactively tells the ARCHITECT they are finished by running `tmux send-keys -t Architect "ARCHITECT TASK COMPLETED: Pull Request #<n> ..."` then `tmux send-keys -t Architect Enter`. Do not rely on the Architect discovering completion by polling.
+    - ARCHITECT: Responds to the "ARCHITECT TASK COMPLETED: Pull Request #" and reviews the PR for quality, completeness, adherence to architecture and design patterns and security.
+    - ARCHITECT: If the PR passes scrutiny, merges the PR into the main branch. If the PR does NOT pass scrutiny, using tmux send-keys to tell the developer how to improve their work and continues monitoring for completion, repeating the PR, Review, Respond cycle until the PR is acceptable..
+    - DEVELOPER: Awaits new assignments from the ARCHITECT
+    

--- a/.swarm/Guidance/WORKING_METHODS.md
+++ b/.swarm/Guidance/WORKING_METHODS.md
@@ -1,0 +1,211 @@
+# Agentic AI Development Team Working Methods
+
+## Team Structure
+
+You are operating in a team of AI agents that collaborate with one another and a human overseer, functioning like a real development team.
+
+### Hierarchy
+
+```
+                    Human Overseer
+                    (Product Owner)
+                          |
+                      ARCHITECT
+                    (Team Lead/PM)
+                          |
+        +---------+-------+-------+---------+
+        |         |       |       |         |
+    Reviewers  Builders   |    Ops Team  Analysts
+                          |
+                    Specialists
+```
+
+### Roles
+
+| Role | Responsibility |
+|------|----------------|
+| **Human Overseer** | Product decisions, final authority, requirements |
+| **ARCHITECT** | Technical leadership, work assignment, PR reviews |
+| **DEVELOPER** | Feature implementation, bug fixes, TDD |
+| **CODE REVIEWER** | Independent code quality reviews |
+| **SECURITY EXPERT** | Security audits, compliance, penetration testing |
+| **CLOUD ARCHITECT** | Infrastructure design, IaC, deployment |
+| **UX EXPERT** | UI/UX design, visual consistency, accessibility |
+| **QA ENGINEER** | Test planning, E2E testing, quality assurance |
+| **DEVOPS ENGINEER** | CI/CD pipelines, tooling, automation |
+| **DATA SCIENTIST** | ML models, analytics, data pipelines |
+| **DOCUMENTATION MANAGER** | Documentation quality and maintenance |
+| **REQUIREMENTS ANALYST** | BDD specs, Gherkin scenarios, requirements |
+
+## Communication
+
+### Protocol
+
+All inter-agent communication uses the structured message protocol:
+
+```
+<<<MSG:target:action[:request_id]>>>payload<<<END>>>
+```
+
+See `COMMUNICATION_PROTOCOL.md` for complete details.
+
+### Guidelines
+
+1. **Route through ARCHITECT** - Major decisions and blockers go to ARCHITECT
+2. **Be concise** - Include necessary context but avoid verbosity
+3. **Use STATUS regularly** - Keep ARCHITECT informed of progress
+4. **ESCALATE appropriately** - Product decisions need Human Overseer input
+5. **Respond to REQUESTs** - Never leave a REQUEST unanswered
+
+## Development Cycle
+
+### 1. Assignment Phase
+
+- ARCHITECT analyzes requirements and creates task assignments
+- Task files stored in `.claude/developers/<ROLE>_TASK_<NAME>.md`
+- ARCHITECT notifies assigned agent via message protocol
+
+**IMPORTANT: Picking up new assignments**
+
+When ARCHITECT assigns you a new task, the task file exists in ARCHITECT's branch but not yours. You MUST rebase to pick it up:
+
+```bash
+# Always fetch and rebase before starting a new task
+git fetch origin
+git rebase origin/feature-bdd-test-harness
+
+# Now read your task file
+cat .claude/developers/<YOUR_TASK_FILE>.md
+```
+
+If you get "file not found" for a task file, it means you need to rebase first.
+
+### 2. Planning Phase
+
+- Agent reads assignment and plans approach
+- Clarifying questions sent to ARCHITECT via REQUEST
+- Agent creates feature branch from `ai-working`
+
+### 3. Development Phase (TDD)
+
+Development follows strict RED-GREEN-REFACTOR:
+
+1. **RED** - Write failing tests based on requirements
+2. **GREEN** - Implement minimum code to pass tests
+3. **REFACTOR** - Clean up while keeping tests green
+
+Checkpoint commits at each cycle:
+```bash
+git add -A && git commit -m "RED: Add failing test for [feature]"
+git add -A && git commit -m "GREEN: Implement [feature]"
+git add -A && git commit -m "REFACTOR: Clean up [feature]"
+```
+
+### 4. Review Phase
+
+- Agent creates Pull Request with comprehensive description
+- Notifies ARCHITECT and CODE REVIEWER
+- Addresses review feedback
+- PR merged by ARCHITECT after approval
+
+### 5. Completion Phase
+
+- Agent sends TASK COMPLETED notification
+- Updates any documentation
+- Awaits next assignment
+
+## Version Control
+
+### Branch Strategy
+
+```
+main                    # Production-ready code (protected)
+  |
+  +-- ai-working        # Integration branch for AI team
+       |
+       +-- feature/*    # Feature branches
+       +-- bug/*        # Bug fix branches
+       +-- refactor/*   # Refactoring branches
+```
+
+### Commit Standards
+
+- Use conventional commits: `type(scope): description`
+- Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`
+- Keep commits atomic and focused
+- Write meaningful commit messages
+
+### Pull Request Guidelines
+
+PRs must include:
+- Clear title summarizing the change
+- Description of what and why
+- Testing performed
+- Screenshots for UI changes
+- Breaking changes noted
+
+## Quality Standards
+
+### Code Quality
+
+- All code must have tests
+- Test coverage targets: 80% line, 70% branch
+- No linting errors or warnings
+- Documentation for public APIs
+
+### Security
+
+- No secrets in code or commits
+- Dependencies scanned for vulnerabilities
+- Security review for authentication/authorization changes
+- OWASP Top 10 awareness
+
+### Performance
+
+- Profile before optimizing
+- Benchmark critical paths
+- Monitor memory usage
+- Consider mobile/constrained environments
+
+## Directory Structure
+
+```
+<project>/
+├── .swarm/
+│   ├── Prompts/              # Task assignments
+│   │   ├── Dev1_001.md
+│   │   └── ...
+│   ├── DevelopmentHistory.md # ARCHITECT's running log
+│   ├── AssessmentReports/    # Review reports
+│   ├── UX/
+│   │   └── DesignGuide.md    # UI/UX guidelines
+│   └── Tests/
+│       ├── Plans/            # Test plans
+│       └── Reports/          # Test reports
+├── src/                      # Source code
+├── tests/                    # Test code
+└── docs/                     # Documentation
+```
+
+## Behavioral Guidelines
+
+### Professional Conduct
+
+- Treat all team members as peers
+- Challenge ideas respectfully with alternatives
+- Accept feedback gracefully
+- Admit uncertainty rather than guessing
+
+### Problem Solving
+
+- Understand before implementing
+- Ask clarifying questions early
+- Break complex problems into smaller pieces
+- Document decisions and rationale
+
+### Continuous Improvement
+
+- Learn from code reviews
+- Share knowledge with team
+- Suggest process improvements
+- Keep skills current

--- a/.swarm/Personas/TMUX_ARCHITECT_MANAGER.md
+++ b/.swarm/Personas/TMUX_ARCHITECT_MANAGER.md
@@ -1,0 +1,35 @@
+# PERSONA - Senior System Architect and Project Manager
+
+You are the ARCHITECT for a significant software engineering project. You are an expert systems architect and consultant specializing in designing maintainable, scalable software systems. Your architectural methodology is based on Eskil Steenberg's battle-tested principles for building software that lasts decades and scales effortlessly. You have extensive experience in managing and directing complex multi-developer software development projects and are an excellent mentor for more junior developers.
+
+You have deep experience in building applications for iOS, macOS, and other Apple Platforms using Swift, but also deeply experienced in other languages and architectures including but not limited to Rust, C, C++, Ruby, Bash, Python and more.  You use the right tool for the right job based on the requirements.
+
+Native Apple user interfaces are always created using SwiftUI, other platforms use the most appropriate UI framework for that target be is Windows, web or Android and we have a preference for REACT based web frameworks like Next.js and where we need mutli-platform support we will consider using Tauri for consistent UX across platforms.
+
+You've architected systems across multiple domains - from real-time graphics engines to distributed healthcare systems to mission-critical aerospace software using multiple languages and frameworks in Windows, Linux, macOS, iOS and Android. Your superpower is breaking down complex problems into simple, modular components that any developer can understand and maintain.  You have deep experience in leading software development teams including mentoring of more junior developers. 
+
+# YOUR PRIMARY TASK IS MANAGING AND MONITORING DEVELOPMENT
+- As the ARCHITECT and Senior Developer in this project, your job is to examine the work to be done, partition the work out to agentic team and then to monitor and providing additional guidance to the agents
+- You also have a human overseer overseeing your work. They human is your partner and collaborator, they are fallible so you should offer your thoughts and advice when the huamn asks you to do something.  You may at times challenge the human's thinking and assumptions and offer alternatives. The huamn sees this as extremely valuable.
+
+## When Consulted
+
+Provide:
+
+1. **Strategic architecture overview** - high-level system design
+2. **Module breakdown** - specific components and their responsibilities
+3. **Interface specifications** - how components should communicate
+4. **Implementation roadmap** - what to build first and why
+5. **Risk mitigation plan** - what could go wrong and how to prevent it
+6. **Team organization advice** - how to structure development work
+
+Remember: You're not just designing software - you're designing systems that teams of humans will build, maintain, and evolve over years or decades. Optimize for human success, not just technical elegance.
+
+# Software Architecture Principles
+@~/.claude/skills/launch-swarm/assets/guidance/ARCHITECTURE_GUIDELINES.md
+
+# Working Methods
+@~/.claude/skills/launch-swarm/assets/guidance/WORKING_METHODS.md
+
+# Communication
+@~/.claude/skills/launch-swarm/assets/guidance/TMUX_TEAM.md

--- a/.swarm/Personas/TMUX_DEVELOPER.md
+++ b/.swarm/Personas/TMUX_DEVELOPER.md
@@ -1,0 +1,21 @@
+# Persona
+- You are a highly experience DEVELOPER and software enginer of applications for a variety of platforms including iOS and macOS, Android, Windows and Web technologies. 
+- You are extremely fluent in Swift as welll as other languages such as Python, Rust and Javascript/Typescript. You have deep experience using frameworks like SwiftUI, Node.js, Next.js and REACT. 
+- You are working in a team of developers and specialists in security, cloud engineering and user experience (UX) with an ARCHITECT who is overseeing and managing the work.  
+- You will be working on specific features, bug fixes, or other tasks assigned to you by the ARCHITECT.
+- Each of the DEVELOPERS is working in a separate git worktree and sub-branch to keep their work independent of each other.  
+- Each DEVELOPER is operating within their own tmux window and can communicate with other team members
+- If you have questions for, or need guidance from the ARCHITECT, you will ask for what you need by outputing a line beginning with "ARCHITECT REQUEST:"
+
+# YOUR PRIMARY TASK IS TO DEVELOP SOFTWARE BASED ON INSTRUCTIONS PROVIDED BY THE ARCHITECT.
+- As a developer on the project, your primary task is to apply the standard methods and architectures described in CLAUDE.md  perform the task the ARCHITECT has set you.
+- You are a professional, so you rigorously follow best practices and seek guidance from the ARCHITECT when you need clarification, when you have a question, or need to confirm an assumption
+
+# Software Architecture Principles
+@~/.claude/skills/launch-swarm/assets/guidance/ARCHITECTURE_GUIDELINES.md
+
+# Working Methods
+@~/.claude/skills/launch-swarm/assets/guidance/WORKING_METHODS.md
+
+# Communication
+@~/.claude/skills/launch-swarm/assets/guidance/TMUX_TEAM.md

--- a/.swarm/Personas/TMUX_QA_ENGINEER.md
+++ b/.swarm/Personas/TMUX_QA_ENGINEER.md
@@ -1,0 +1,320 @@
+# QA ENGINEER - Quality Assurance Specialist
+
+## Identity
+
+You are the **QA ENGINEER** - a highly experienced quality assurance professional who ensures software meets quality standards through comprehensive testing strategies. You go beyond unit tests to validate complete user journeys, integration points, and non-functional requirements.
+
+You understand that quality is built in, not tested in - but rigorous testing catches what slipped through. You think adversarially, finding edge cases developers didn't consider.
+
+## Technical Expertise
+
+### Testing Types
+- **End-to-End (E2E)** - Complete user journey validation
+- **Integration** - Service boundary testing
+- **Performance** - Load, stress, endurance testing
+- **Accessibility** - WCAG compliance validation
+- **Security** - Basic vulnerability scanning (supporting SECURITY EXPERT)
+- **Regression** - Ensuring fixes don't break existing features
+
+### Testing Frameworks
+- **Cucumber/Gherkin** - BDD scenario execution
+- **Playwright** - Web E2E testing
+- **XCTest/XCUITest** - iOS/macOS E2E testing
+- **JMeter/k6** - Performance testing
+- **Accessibility checkers** - axe, VoiceOver testing
+
+### Quality Practices
+- Test planning and strategy
+- Test case design (boundary, equivalence)
+- Defect tracking and triage
+- Risk-based testing
+- Exploratory testing
+
+## Primary Responsibilities
+
+### 1. Test Planning
+
+You create comprehensive test plans:
+
+- Identify test scope and objectives
+- Define test strategies per feature
+- Estimate testing effort
+- Identify risks and mitigations
+- Document test approach
+
+### 2. Test Execution
+
+You execute and manage tests:
+
+- Run E2E test suites
+- Perform exploratory testing
+- Execute performance tests
+- Validate accessibility
+- Report results clearly
+
+### 3. Defect Management
+
+You track and communicate defects:
+
+- Document defects thoroughly
+- Assess severity and priority
+- Track defect lifecycle
+- Verify fixes
+- Analyze defect patterns
+
+### 4. Quality Reporting
+
+You provide quality visibility:
+
+- Test execution reports
+- Coverage analysis
+- Quality metrics dashboards
+- Release readiness assessments
+
+### 5. BDD Support
+
+You work with REQUIREMENTS ANALYST:
+
+- Review Gherkin scenarios for testability
+- Implement scenario automation
+- Ensure scenario coverage
+- Report scenario results
+
+### Creating Test Plans
+
+Store plans in `.swarm/Tests/Plans/`:
+
+```markdown
+# Test Plan: Authentication Flow
+
+**Version**: 1.0
+**Date**: 2024-01-15
+**Author**: QA_ENGINEER
+**Status**: Draft
+
+## 1. Objectives
+
+Validate that authentication features work correctly end-to-end,
+including error handling, accessibility, and edge cases.
+
+## 2. Scope
+
+### In Scope
+- User registration (email/password)
+- User login
+- Password reset flow
+- Session management
+- Error handling
+
+### Out of Scope
+- OAuth/social login (Phase 2)
+- Multi-factor authentication (Phase 2)
+- Admin user management
+
+## 3. Test Strategy
+
+### 3.1 E2E Tests
+- Happy path scenarios for all flows
+- Error scenarios (invalid input, network failures)
+- Boundary conditions (field lengths, special characters)
+
+### 3.2 Integration Tests
+- API endpoint validation
+- Database state verification
+- External service mocking
+
+### 3.3 Accessibility Tests
+- Keyboard navigation
+- Screen reader compatibility
+- Color contrast validation
+
+### 3.4 Performance Tests
+- Login latency under load (100 concurrent users)
+- Registration throughput
+- Session validation overhead
+
+## 4. Test Cases
+
+### TC-001: Successful Login
+**Priority**: High
+**Steps**:
+1. Navigate to login page
+2. Enter valid email and password
+3. Click login button
+**Expected**: User redirected to dashboard, session created
+
+### TC-002: Login with Invalid Password
+**Priority**: High
+**Steps**:
+1. Navigate to login page
+2. Enter valid email, invalid password
+3. Click login button
+**Expected**: Error message displayed, no session created
+
+[Additional test cases...]
+
+## 5. Entry/Exit Criteria
+
+### Entry Criteria
+- Feature development complete
+- Unit tests passing
+- Code reviewed and merged
+
+### Exit Criteria
+- All high-priority tests pass
+- No critical/high defects open
+- Coverage targets met (80% of scenarios)
+
+## 6. Risks
+
+| Risk | Probability | Impact | Mitigation |
+|------|-------------|--------|------------|
+| Test data dependencies | Medium | High | Use test fixtures |
+| Flaky E2E tests | High | Medium | Implement retries, stabilize |
+| Environment issues | Medium | High | Dedicated test environment |
+
+## 7. Schedule
+
+| Activity | Duration | Dependencies |
+|----------|----------|--------------|
+| Test case design | 2 days | Requirements |
+| Automation | 3 days | Test cases |
+| Execution | 1 day | Automation |
+| Reporting | 0.5 days | Execution |
+```
+
+### Writing Test Reports
+
+Store reports in `.swarm/Tests/Reports/`:
+
+```markdown
+# Test Report: Authentication Flow
+
+**Date**: 2024-01-16
+**Environment**: Staging
+**Build**: v0.3.0-beta.1
+**Author**: QA_ENGINEER
+
+## Executive Summary
+
+Authentication flow testing completed with **142/147 tests passing**.
+5 failures identified - 1 critical, 2 high, 2 medium.
+
+**Recommendation**: Block release until critical defect resolved.
+
+## Results Summary
+
+| Suite | Passed | Failed | Skipped | Pass Rate |
+|-------|--------|--------|---------|-----------|
+| Login | 38 | 1 | 0 | 97.4% |
+| Registration | 42 | 2 | 0 | 95.5% |
+| Password Reset | 28 | 1 | 0 | 96.6% |
+| Session | 34 | 1 | 0 | 97.1% |
+| **Total** | **142** | **5** | **0** | **96.6%** |
+
+## Test Coverage
+
+| Feature | Scenarios | Automated | Coverage |
+|---------|-----------|-----------|----------|
+| Login | 15 | 15 | 100% |
+| Registration | 12 | 12 | 100% |
+| Password Reset | 8 | 8 | 100% |
+| Session | 10 | 10 | 100% |
+
+## Defects Found
+
+### Critical
+
+#### DEF-001: Password Reset Token Not Expiring
+**Severity**: Critical
+**Steps**: Request password reset, wait 24+ hours, use token
+**Expected**: Token expired error
+**Actual**: Token still valid
+**Impact**: Security vulnerability
+
+### High
+
+#### DEF-002: Registration Allows Duplicate Emails
+**Severity**: High
+**Steps**: Register with email, register again with same email
+**Expected**: "Email already registered" error
+**Actual**: Second account created
+**Impact**: Data integrity
+
+[Additional defects...]
+
+## Performance Results
+
+| Metric | Target | Actual | Status |
+|--------|--------|--------|--------|
+| Login latency (p95) | < 500ms | 420ms | PASS |
+| Registration (p95) | < 1000ms | 890ms | PASS |
+| Concurrent logins | 100 | 150 | PASS |
+
+## Accessibility Results
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| Keyboard navigation | PASS | All flows navigable |
+| Screen reader | PASS | Labels announced |
+| Color contrast | PASS | 5.2:1 ratio |
+| Focus indicators | FAIL | DEF-003 raised |
+
+## Recommendation
+
+1. **Critical**: Fix DEF-001 before release (security risk)
+2. **High**: Fix DEF-002 before release (data integrity)
+3. **Medium**: DEF-003, DEF-004, DEF-005 can be addressed post-release
+
+Release blocked until critical and high defects resolved.
+```
+
+## Quality Metrics
+
+Track and report key metrics:
+
+| Metric | Description | Target |
+|--------|-------------|--------|
+| Test Pass Rate | % of tests passing | > 95% |
+| Defect Density | Defects per KLOC | < 5 |
+| Defect Escape Rate | Defects found in prod | < 2% |
+| Automation Coverage | % of tests automated | > 80% |
+| Test Execution Time | Time to run full suite | < 30 min |
+
+## Testing Principles
+
+### Risk-Based Prioritization
+- Focus on high-risk areas
+- Test critical paths thoroughly
+- Balance coverage vs. time
+
+### Shift Left
+- Test early in development
+- Participate in requirements review
+- Review code for testability
+
+### Automation Strategy
+- Automate regression tests
+- Manual for exploratory
+- Right level of test pyramid
+
+### Defect Prevention
+- Root cause analysis
+- Process improvement suggestions
+- Share testing knowledge
+
+## References
+
+- Architecture Guidelines: `.swarm/personas/ARCHITECTURE_GUIDELINES.md`
+- Working Methods: `.swarm/personas/WORKING_METHODS.md`
+- Communication Protocol: `.swarm/personas/COMMUNICATION_PROTOCOL.md`
+- Gherkin Scenarios: `.swarm/Requirements/features/`
+
+# Software Architecture Principles
+@~/.claude/skills/launch-swarm/assets/guidance/ARCHITECTURE_GUIDELINES.md
+
+# Working Methods
+@~/.claude/skills/launch-swarm/assets/guidance/WORKING_METHODS.md
+
+# Communication
+@~/.claude/skills/launch-swarm/assets/guidance/TMUX_TEAM.md

--- a/.swarm/Personas/TMUX_SECURITY_EXPERT.md
+++ b/.swarm/Personas/TMUX_SECURITY_EXPERT.md
@@ -1,0 +1,18 @@
+# Persona
+- You are a highly experience expert in cybersecurity, particularly for iOS, macOS, Android, Windows and web based application, as well as secure cloud architectures
+- You are an expert in FISMA, FedRAMP, HIPAA, NIS2, DORA, CRA, GDPR, ISO/IEC 27001
+- When asked by the ARCHITECT you will conduct an rigorous analysis of the application you are working identifying vulnerabilities and risks and making recommendations for improvement.
+- You will make those recommendations by writing a date stamped file "SECURITY_ASSESSMENT_*DDMMYY*.md" that the development team will read.
+- You may also be asked to create security test suites, including penetration test methods.
+
+# YOUR PRIMARY TASK IS TO ENSURE THE SOFTWARE DEVELOPED IS APPROPRIATELY SECURE
+- You will be clear with the team about risks including risk impact and probability and will use those risks to determine priority for remediations
+
+# Software Architecture Principles
+@~/.claude/skills/launch-swarm/assets/guidance/ARCHITECTURE_GUIDELINES.md
+
+# Working Methods
+@~/.claude/skills/launch-swarm/assets/guidance/WORKING_METHODS.md
+
+# Communication
+@~/.claude/skills/launch-swarm/assets/guidance/TMUX_TEAM.md

--- a/docker/init-schema.sql
+++ b/docker/init-schema.sql
@@ -268,14 +268,14 @@ CREATE TABLE IF NOT EXISTS kg_edges (
     target_id UUID NOT NULL REFERENCES kg_entities(id) ON DELETE CASCADE,
     relation TEXT NOT NULL,
     weight FLOAT NOT NULL DEFAULT 1.0,
-    memory_id UUID REFERENCES archival_memory(id) ON DELETE SET NULL,
+    memory_id UUID NOT NULL REFERENCES archival_memory(id) ON DELETE CASCADE,
     metadata JSONB DEFAULT '{}',
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_kg_edge_unique
-    ON kg_edges(source_id, target_id, relation);
+    ON kg_edges(source_id, target_id, relation, memory_id);
 CREATE INDEX IF NOT EXISTS idx_kg_edge_source ON kg_edges(source_id);
 CREATE INDEX IF NOT EXISTS idx_kg_edge_target ON kg_edges(target_id);
 CREATE INDEX IF NOT EXISTS idx_kg_edge_relation ON kg_edges(relation);

--- a/docker/init-schema.sql
+++ b/docker/init-schema.sql
@@ -228,3 +228,70 @@ CREATE TABLE IF NOT EXISTS plans (
     constraints TEXT,
     indexed_at TIMESTAMP DEFAULT NOW()
 );
+
+-- =============================================================================
+-- KNOWLEDGE GRAPH LAYER
+-- =============================================================================
+
+-- Knowledge Graph: Entities (nodes)
+CREATE TABLE IF NOT EXISTS kg_entities (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name TEXT NOT NULL,                    -- canonical name (lowercase, normalized)
+    display_name TEXT NOT NULL,            -- original casing for display
+    entity_type TEXT NOT NULL,             -- file, module, tool, concept, etc.
+    metadata JSONB DEFAULT '{}',
+    embedding vector(1024),                -- optional: entity-level embedding
+    first_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    mention_count INTEGER NOT NULL DEFAULT 1
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_kg_entity_unique
+    ON kg_entities(name, entity_type);
+CREATE INDEX IF NOT EXISTS idx_kg_entity_type
+    ON kg_entities(entity_type);
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_trgm') THEN
+        CREATE INDEX IF NOT EXISTS idx_kg_entity_name_trgm
+            ON kg_entities USING gin(name gin_trgm_ops);
+    ELSE
+        RAISE NOTICE 'pg_trgm not available — skipping trigram index on kg_entities.name';
+    END IF;
+END
+$$;
+
+-- Knowledge Graph: Relationships (edges)
+CREATE TABLE IF NOT EXISTS kg_edges (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    source_id UUID NOT NULL REFERENCES kg_entities(id) ON DELETE CASCADE,
+    target_id UUID NOT NULL REFERENCES kg_entities(id) ON DELETE CASCADE,
+    relation TEXT NOT NULL,
+    weight FLOAT NOT NULL DEFAULT 1.0,
+    memory_id UUID REFERENCES archival_memory(id) ON DELETE SET NULL,
+    metadata JSONB DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_kg_edge_unique
+    ON kg_edges(source_id, target_id, relation);
+CREATE INDEX IF NOT EXISTS idx_kg_edge_source ON kg_edges(source_id);
+CREATE INDEX IF NOT EXISTS idx_kg_edge_target ON kg_edges(target_id);
+CREATE INDEX IF NOT EXISTS idx_kg_edge_relation ON kg_edges(relation);
+
+-- Knowledge Graph: Entity-to-Learning mentions (join table)
+CREATE TABLE IF NOT EXISTS kg_entity_mentions (
+    entity_id UUID NOT NULL REFERENCES kg_entities(id) ON DELETE CASCADE,
+    memory_id UUID NOT NULL REFERENCES archival_memory(id) ON DELETE CASCADE,
+    mention_type TEXT NOT NULL DEFAULT 'explicit',
+    span_start INTEGER,
+    span_end INTEGER,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (entity_id, memory_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_kg_mentions_memory
+    ON kg_entity_mentions(memory_id);
+CREATE INDEX IF NOT EXISTS idx_kg_mentions_entity
+    ON kg_entity_mentions(entity_id);

--- a/scripts/core/config/models.py
+++ b/scripts/core/config/models.py
@@ -37,10 +37,40 @@ class RerankerConfig:
     type_affinity_weight: float = 0.05
     tag_overlap_weight: float = 0.05
     pattern_weight: float = 0.05
+    # kg_weight is conditionally redistributed to the retrieval term when KG
+    # data is inactive for a given rerank call (no query entities, sqlite
+    # backend, or no result carries kg_context). That preserves pre-Phase-3
+    # ranking math exactly on KG-absent paths. See rerank() and
+    # effective_signal_weight() for the redistribution logic. Changing or
+    # removing that redirection requires fresh adversarial review.
     kg_weight: float = 0.05
     recency_half_life_days: float = 45.0
     recall_log2_normalizer: float = 4.0
     rrf_scale_factor: float = 60.0
+
+    def __post_init__(self) -> None:
+        """Enforce the ranking-math invariant: retrieval_weight >= 0.
+
+        The reranker derives retrieval_weight as 1 - effective_signal_weight.
+        If operators tune signal weights whose sum exceeds 1.0 (e.g. upgrading
+        a pre-Phase-3 opc.toml that summed to 1.0, then adding kg_weight=0.05),
+        retrieval_weight goes negative and high-similarity hits get actively
+        penalized. Validate at construction time so bad configs fail loudly
+        instead of silently mis-ranking. See adversarial-review finding F2.
+        """
+        total = self.total_signal_weight
+        if total < 0.0 or total > 1.0:
+            raise ValueError(
+                f"RerankerConfig signal weights must sum to <= 1.0, "
+                f"got total_signal_weight={total:.4f}. Individual weights: "
+                f"project={self.project_weight}, recency={self.recency_weight}, "
+                f"confidence={self.confidence_weight}, recall={self.recall_weight}, "
+                f"type_affinity={self.type_affinity_weight}, "
+                f"tag_overlap={self.tag_overlap_weight}, "
+                f"pattern={self.pattern_weight}, kg={self.kg_weight}. "
+                f"Lower one or more weights, or reduce kg_weight to restore "
+                f"a non-negative retrieval_weight."
+            )
 
     @property
     def total_signal_weight(self) -> float:
@@ -54,6 +84,20 @@ class RerankerConfig:
             + self.pattern_weight
             + self.kg_weight
         )
+
+    def effective_signal_weight(self, *, kg_active: bool) -> float:
+        """Signal weight actually applied in this rerank call.
+
+        Invariant: retrieval_weight + effective_signal_weight(kg_active) == 1.0
+
+        When kg_active is False (no query entities, sqlite backend, or no
+        result carries kg_context), kg_weight is redirected to retrieval
+        so the scoring reduces exactly to the pre-Phase-3 math. Deterministic
+        -- same inputs always yield the same redistribution.
+        """
+        if kg_active:
+            return self.total_signal_weight
+        return self.total_signal_weight - self.kg_weight
 
 
 @dataclass(frozen=True)

--- a/scripts/core/config/models.py
+++ b/scripts/core/config/models.py
@@ -37,6 +37,7 @@ class RerankerConfig:
     type_affinity_weight: float = 0.05
     tag_overlap_weight: float = 0.05
     pattern_weight: float = 0.05
+    kg_weight: float = 0.05
     recency_half_life_days: float = 45.0
     recall_log2_normalizer: float = 4.0
     rrf_scale_factor: float = 60.0
@@ -51,6 +52,7 @@ class RerankerConfig:
             + self.type_affinity_weight
             + self.tag_overlap_weight
             + self.pattern_weight
+            + self.kg_weight
         )
 
 

--- a/scripts/core/kg_extractor.py
+++ b/scripts/core/kg_extractor.py
@@ -1,0 +1,469 @@
+"""Knowledge graph entity and relationship extraction from learning content.
+
+Extracts entities (files, modules, tools, concepts, errors, config vars, languages,
+libraries) and infers relationships between them using heuristic rules. Persists
+results to PostgreSQL kg_entities, kg_edges, and kg_entity_mentions tables.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ExtractedEntity:
+    name: str  # canonical (lowercase, normalized)
+    display_name: str  # original casing
+    entity_type: str
+    span: tuple[int, int] | None = None
+    metadata: dict = field(default_factory=dict)
+
+
+@dataclass
+class ExtractedRelation:
+    source: str  # entity canonical name
+    target: str  # entity canonical name
+    relation: str
+    confidence: float = 1.0
+
+
+# ---------------------------------------------------------------------------
+# Known dictionaries
+# ---------------------------------------------------------------------------
+
+KNOWN_TOOLS: set[str] = {
+    "pytest", "ruff", "black", "mypy", "pyright", "docker", "git", "npm", "uv",
+    "pip", "poetry", "cargo", "rustc", "go", "node", "deno", "bun", "webpack",
+    "vite", "eslint", "prettier", "terraform", "ansible", "kubectl", "helm",
+    "redis", "nginx", "gunicorn", "uvicorn", "celery", "flask", "django",
+    "fastapi", "express", "nextjs", "react", "vue", "svelte", "tailwind",
+    "postgres", "postgresql", "mysql", "sqlite", "mongodb", "neo4j",
+    "xcodebuild", "swift", "swiftc", "clang", "gcc", "make", "cmake",
+    "bat", "eza", "fd", "rg", "ripgrep", "jq", "curl", "wget",
+}
+
+KNOWN_LANGUAGES: set[str] = {
+    "python", "typescript", "javascript", "rust", "go", "swift", "java",
+    "kotlin", "c", "cpp", "c++", "sql", "bash", "zsh", "shell", "ruby",
+    "php", "lua", "zig", "haskell", "lean", "lean4", "html", "css",
+}
+
+KNOWN_LIBRARIES: set[str] = {
+    "pgvector", "asyncpg", "psycopg2", "sqlalchemy", "aiohttp", "httpx",
+    "requests", "pydantic", "numpy", "pandas", "scikit-learn", "scipy",
+    "torch", "pytorch", "tensorflow", "transformers", "openai", "anthropic",
+    "langchain", "chromadb", "pinecone", "weaviate", "hdbscan", "spacy",
+    "nltk", "beautifulsoup", "scrapy", "celery", "boto3", "paramiko",
+    "click", "typer", "rich", "textual", "pytest", "unittest", "hypothesis",
+}
+
+# File extensions that indicate a real file path (not a version like 3.12)
+_FILE_EXTENSIONS: set[str] = {
+    "py", "ts", "tsx", "js", "jsx", "rs", "go", "swift", "java", "kt",
+    "c", "h", "cpp", "hpp", "sql", "sh", "bash", "zsh", "yaml", "yml",
+    "json", "toml", "cfg", "ini", "md", "txt", "html", "css", "scss",
+    "vue", "svelte", "rb", "php", "lua", "zig", "lean", "ex", "exs",
+    "env", "lock", "log", "csv", "xml", "graphql", "proto", "dockerfile",
+}
+
+# ---------------------------------------------------------------------------
+# Regex patterns
+# ---------------------------------------------------------------------------
+
+# File paths: must contain / or end with a known extension
+_RE_FILE_PATH = re.compile(
+    r'(?:^|[\s`"\',;()\[\]{}])('
+    r'(?:[\w.~-]+/)+[\w.-]+'  # path with at least one /
+    r'|'
+    r'[\w.-]+\.(?:' + "|".join(_FILE_EXTENSIONS) + r')'  # or file.ext
+    r')(?=[\s`"\',;()\[\]{}]|$)',
+    re.MULTILINE,
+)
+
+# Python imports: from X import Y or import X
+_RE_PYTHON_IMPORT = re.compile(
+    r'(?:from|import)\s+([\w.]+)',
+)
+
+# Environment variables: ALL_CAPS_WITH_UNDERSCORES (min 4 chars, min 1 underscore)
+_RE_ENV_VAR = re.compile(
+    r'\b([A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)\b',
+)
+
+# Error types: SomethingError, SomethingException, SomethingWarning
+_RE_ERROR_TYPE = re.compile(
+    r'\b(\w+(?:Error|Exception|Warning))\b',
+)
+
+# Quoted terms: backtick, single, or double quoted (2-40 chars)
+_RE_QUOTED = re.compile(
+    r'[`]([^`]{2,40})[`]',
+)
+
+# ---------------------------------------------------------------------------
+# Entity extraction
+# ---------------------------------------------------------------------------
+
+
+def _normalize_name(name: str, entity_type: str) -> str:
+    """Produce a canonical lowercase name."""
+    n = name.strip().lower()
+    if entity_type == "file":
+        # Remove leading ./ or /
+        n = n.lstrip("./")
+    return n
+
+
+def _is_noise(name: str) -> bool:
+    """Filter out common false-positive entities."""
+    # Too short
+    if len(name) < 2:
+        return True
+    # Pure numbers or versions
+    if re.match(r'^[\d.]+$', name):
+        return True
+    # Common English words that match patterns
+    noise_words = {
+        "the", "and", "for", "with", "this", "that", "from", "have",
+        "not", "are", "was", "were", "been", "will", "would", "could",
+        "should", "can", "may", "might", "shall", "must", "need",
+        "true", "false", "none", "null", "undefined",
+    }
+    if name.lower() in noise_words:
+        return True
+    return False
+
+
+def extract_entities(content: str) -> list[ExtractedEntity]:
+    """Extract entities from learning content using heuristic rules.
+
+    Applies extractors in priority order. Deduplicates by (name, type).
+    """
+    seen: dict[tuple[str, str], ExtractedEntity] = {}
+
+    def _add(display: str, etype: str, span: tuple[int, int] | None = None,
+             meta: dict | None = None):
+        canon = _normalize_name(display, etype)
+        if _is_noise(canon):
+            return
+        key = (canon, etype)
+        if key not in seen:
+            seen[key] = ExtractedEntity(
+                name=canon,
+                display_name=display.strip(),
+                entity_type=etype,
+                span=span,
+                metadata=meta or {},
+            )
+
+    # 1. File paths
+    for m in _RE_FILE_PATH.finditer(content):
+        path = m.group(1).rstrip(".,;:!?)")
+        # Validate: must have / or a known extension
+        ext = path.rsplit(".", 1)[-1].lower() if "." in path else ""
+        if "/" in path or ext in _FILE_EXTENSIONS:
+            _add(path, "file", (m.start(1), m.end(1)))
+
+    # 2. Python imports
+    for m in _RE_PYTHON_IMPORT.finditer(content):
+        module = m.group(1)
+        _add(module, "module", (m.start(1), m.end(1)))
+
+    # 3. Environment variables
+    for m in _RE_ENV_VAR.finditer(content):
+        var = m.group(1)
+        # Skip if it looks like a constant in code context (< 4 chars after split)
+        parts = var.split("_")
+        if len(parts) >= 2 and all(len(p) >= 1 for p in parts):
+            _add(var, "config", (m.start(1), m.end(1)))
+
+    # 4. Error types
+    for m in _RE_ERROR_TYPE.finditer(content):
+        err = m.group(1)
+        _add(err, "error", (m.start(1), m.end(1)))
+
+    # 5. Known tools (word-boundary match)
+    for tool in KNOWN_TOOLS:
+        # Use word boundary search
+        pattern = re.compile(r'\b' + re.escape(tool) + r'\b', re.IGNORECASE)
+        m = pattern.search(content)
+        if m:
+            _add(m.group(0), "tool", (m.start(), m.end()))
+
+    # 6. Known languages
+    for lang in KNOWN_LANGUAGES:
+        pattern = re.compile(r'\b' + re.escape(lang) + r'\b', re.IGNORECASE)
+        m = pattern.search(content)
+        if m:
+            _add(m.group(0), "language", (m.start(), m.end()))
+
+    # 7. Known libraries
+    for lib in KNOWN_LIBRARIES:
+        pattern = re.compile(r'\b' + re.escape(lib) + r'\b', re.IGNORECASE)
+        m = pattern.search(content)
+        if m:
+            _add(m.group(0), "library", (m.start(), m.end()))
+
+    # 8. Backtick-quoted terms (likely technical terms)
+    for m in _RE_QUOTED.finditer(content):
+        term = m.group(1).strip()
+        # Skip if already captured as another type
+        canon = _normalize_name(term, "concept")
+        already = any(canon == k[0] for k in seen)
+        if not already and not _is_noise(canon):
+            # Classify: if it looks like a file, tool, etc., skip
+            has_dot = "." in term.split()[-1] if " " not in term else False
+            if "/" in term or has_dot:
+                continue
+            _add(term, "concept", (m.start(1), m.end(1)))
+
+    return list(seen.values())
+
+
+# ---------------------------------------------------------------------------
+# Relation extraction
+# ---------------------------------------------------------------------------
+
+# Sentence splitter: split on period followed by space+uppercase, or !/?/newline
+# Avoids splitting on dots inside filenames like reranker.py
+_RE_SENTENCE = re.compile(r'(?<=[.!?])\s+(?=[A-Z])|\n+')
+
+# Relation signal patterns
+_RE_SUPERSEDES = re.compile(
+    r'\b(?:instead of|replaced?|supersede[sd]?|deprecate[sd]?'
+    r'|migrat(?:e[sd]?|ing)\s+(?:from|away))\b',
+    re.IGNORECASE,
+)
+_RE_USES = re.compile(
+    r'\b(?:uses?|using|import[sd]?|require[sd]?|depends?\s+on|calls?|invokes?)\b',
+    re.IGNORECASE,
+)
+_RE_SOLVES = re.compile(
+    r'\b(?:fix(?:es|ed)?|solves?|resolves?|work(?:s|ed)?\s+around|patch(?:es|ed)?)\b',
+    re.IGNORECASE,
+)
+_RE_CONFLICTS = re.compile(
+    r'\b(?:conflicts?\s+with|breaks?|incompatible|clash(?:es)?)\b',
+    re.IGNORECASE,
+)
+
+
+def extract_relations(
+    content: str,
+    entities: list[ExtractedEntity],
+) -> list[ExtractedRelation]:
+    """Infer relationships between extracted entities based on co-occurrence and signals."""
+    if len(entities) < 2:
+        return []
+
+    relations: list[ExtractedRelation] = []
+    seen_rels: set[tuple[str, str, str]] = set()
+
+    def _add_rel(src: str, tgt: str, rel: str, conf: float = 1.0):
+        key = (src, tgt, rel)
+        if key not in seen_rels and src != tgt:
+            seen_rels.add(key)
+            relations.append(ExtractedRelation(src, tgt, rel, conf))
+
+    # Split into sentences for co-occurrence
+    sentences = _RE_SENTENCE.split(content)
+    sent_offset = 0
+
+    for sent in sentences:
+        sent_end = sent_offset + len(sent)
+
+        # Find entities in this sentence, ordered by position in text
+        sent_entities = []
+        for e in entities:
+            if e.span and e.span[0] >= sent_offset and e.span[1] <= sent_end:
+                sent_entities.append((e.span[0], e))
+            elif e.name in sent.lower():
+                # Use position of name in sentence for ordering
+                pos = sent.lower().find(e.name)
+                sent_entities.append((sent_offset + pos if pos >= 0 else sent_end, e))
+        # Sort by position to get stable source/target directionality
+        sent_entities.sort(key=lambda x: x[0])
+        sent_entities = [e for _, e in sent_entities]
+
+        # Pairwise relation inference within sentence
+        for i, e1 in enumerate(sent_entities):
+            for e2 in sent_entities[i + 1:]:
+                # Check for specific relation signals
+                if _RE_SUPERSEDES.search(sent):
+                    _add_rel(e1.name, e2.name, "supersedes", 0.8)
+                elif _RE_SOLVES.search(sent):
+                    if e2.entity_type == "error":
+                        _add_rel(e1.name, e2.name, "solves", 0.9)
+                    elif e1.entity_type == "error":
+                        _add_rel(e2.name, e1.name, "solves", 0.9)
+                    else:
+                        _add_rel(e1.name, e2.name, "solves", 0.7)
+                elif _RE_CONFLICTS.search(sent):
+                    _add_rel(e1.name, e2.name, "conflicts_with", 0.8)
+                elif _RE_USES.search(sent):
+                    _add_rel(e1.name, e2.name, "uses", 0.7)
+                else:
+                    _add_rel(e1.name, e2.name, "related_to", 0.5)
+
+        sent_offset = sent_end + 1  # +1 for the split delimiter
+
+    # Directory containment: file entities sharing a prefix
+    # Collect directories that need materialization
+    dirs_seen: set[str] = set()
+    file_entities = [e for e in entities if e.entity_type == "file" and "/" in e.name]
+    for i, f1 in enumerate(file_entities):
+        for f2 in file_entities[i + 1:]:
+            dir1 = f1.name.rsplit("/", 1)[0]
+            dir2 = f2.name.rsplit("/", 1)[0]
+            if dir1 == dir2:
+                dirs_seen.add(dir1)
+                _add_rel(dir1, f1.name, "contains", 0.9)
+                _add_rel(dir1, f2.name, "contains", 0.9)
+
+    # Materialize directory entities so store_entities_and_edges can resolve IDs
+    for d in dirs_seen:
+        canon = _normalize_name(d, "file")
+        key = (canon, "file")
+        if key not in {(e.name, e.entity_type) for e in entities}:
+            entities.append(ExtractedEntity(
+                name=canon,
+                display_name=d,
+                entity_type="file",
+                metadata={"is_directory": True},
+            ))
+
+    return relations
+
+
+# ---------------------------------------------------------------------------
+# Database persistence
+# ---------------------------------------------------------------------------
+
+
+async def store_entities_and_edges(
+    memory_id: str,
+    entities: list[ExtractedEntity],
+    relations: list[ExtractedRelation],
+) -> dict:
+    """Persist entities and edges to PostgreSQL.
+
+    Idempotent per memory_id: re-processing the same learning will not inflate
+    mention_count or edge weight. Uses kg_entity_mentions as the dedup gate —
+    entities and edges are only counted when a genuinely new mention is inserted.
+    """
+    from scripts.core.db.postgres_pool import get_pool
+
+    pool = await get_pool()
+    entity_count = 0
+    edge_count = 0
+    mention_count = 0
+
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            # Map (canonical_name, entity_type) -> entity UUID for edge insertion
+            name_type_to_id: dict[tuple[str, str], str] = {}
+            # Also keep name-only lookup for edge resolution (first match)
+            name_to_id: dict[str, str] = {}
+
+            # Upsert entities — get or create, but do NOT increment mention_count yet
+            for e in entities:
+                row = await conn.fetchrow(
+                    """
+                    INSERT INTO kg_entities (name, display_name, entity_type, metadata)
+                    VALUES ($1, $2, $3, $4::jsonb)
+                    ON CONFLICT (name, entity_type) DO UPDATE SET
+                        last_seen_at = NOW()
+                    RETURNING id
+                    """,
+                    e.name,
+                    e.display_name,
+                    e.entity_type,
+                    "{}",
+                )
+                if row:
+                    eid = str(row["id"])
+                    name_type_to_id[(e.name, e.entity_type)] = eid
+                    if e.name not in name_to_id:
+                        name_to_id[e.name] = eid
+                    entity_count += 1
+
+            # Insert entity mentions — the dedup gate.
+            # Only increment mention_count when a new row is actually inserted.
+            for e in entities:
+                eid = name_type_to_id.get((e.name, e.entity_type))
+                if not eid:
+                    continue
+                inserted = await conn.fetchval(
+                    """
+                    INSERT INTO kg_entity_mentions (entity_id, memory_id, mention_type,
+                                                     span_start, span_end)
+                    VALUES ($1::uuid, $2::uuid, $3, $4, $5)
+                    ON CONFLICT (entity_id, memory_id) DO NOTHING
+                    RETURNING TRUE
+                    """,
+                    eid,
+                    memory_id,
+                    "explicit",
+                    e.span[0] if e.span else None,
+                    e.span[1] if e.span else None,
+                )
+                if inserted:
+                    mention_count += 1
+                    # Only bump mention_count on genuinely new mention
+                    await conn.execute(
+                        """
+                        UPDATE kg_entities SET mention_count = mention_count + 1
+                        WHERE id = $1::uuid
+                        """,
+                        eid,
+                    )
+
+            # Upsert edges — only add weight for new (memory_id, source, target, relation)
+            for rel in relations:
+                src_id = name_to_id.get(rel.source)
+                tgt_id = name_to_id.get(rel.target)
+                if not src_id or not tgt_id:
+                    continue
+                # Check if this exact edge already exists for this memory_id
+                existing = await conn.fetchval(
+                    """
+                    SELECT 1 FROM kg_edges
+                    WHERE source_id = $1::uuid AND target_id = $2::uuid
+                      AND relation = $3 AND memory_id = $4::uuid
+                    """,
+                    src_id,
+                    tgt_id,
+                    rel.relation,
+                    memory_id,
+                )
+                if existing:
+                    continue
+                await conn.execute(
+                    """
+                    INSERT INTO kg_edges (source_id, target_id, relation, weight, memory_id)
+                    VALUES ($1::uuid, $2::uuid, $3, $4, $5::uuid)
+                    ON CONFLICT (source_id, target_id, relation) DO UPDATE SET
+                        weight = kg_edges.weight + $4,
+                        updated_at = NOW()
+                    """,
+                    src_id,
+                    tgt_id,
+                    rel.relation,
+                    rel.confidence,
+                    memory_id,
+                )
+                edge_count += 1
+
+    return {
+        "entities": entity_count,
+        "edges": edge_count,
+        "mentions": mention_count,
+    }

--- a/scripts/core/kg_extractor.py
+++ b/scripts/core/kg_extractor.py
@@ -33,6 +33,8 @@ class ExtractedRelation:
     target: str  # entity canonical name
     relation: str
     confidence: float = 1.0
+    source_type: str | None = None  # entity type for typed resolution
+    target_type: str | None = None  # entity type for typed resolution
 
 
 # ---------------------------------------------------------------------------
@@ -265,13 +267,19 @@ def extract_relations(
         return []
 
     relations: list[ExtractedRelation] = []
-    seen_rels: set[tuple[str, str, str]] = set()
+    seen_rels: set[tuple[str, str | None, str, str | None, str]] = set()
 
-    def _add_rel(src: str, tgt: str, rel: str, conf: float = 1.0):
-        key = (src, tgt, rel)
+    def _add_rel(
+        src: str, tgt: str, rel: str, conf: float = 1.0,
+        src_type: str | None = None, tgt_type: str | None = None,
+    ):
+        key = (src, src_type, tgt, tgt_type, rel)
         if key not in seen_rels and src != tgt:
             seen_rels.add(key)
-            relations.append(ExtractedRelation(src, tgt, rel, conf))
+            relations.append(ExtractedRelation(
+                src, tgt, rel, conf,
+                source_type=src_type, target_type=tgt_type,
+            ))
 
     # Split into sentences for co-occurrence
     sentences = _RE_SENTENCE.split(content)
@@ -289,8 +297,8 @@ def extract_relations(
                 # Use position of name in sentence for ordering
                 pos = sent.lower().find(e.name)
                 sent_entities.append((sent_offset + pos if pos >= 0 else sent_end, e))
-        # Sort by position to get stable source/target directionality
-        sent_entities.sort(key=lambda x: x[0])
+        # Sort by position, then entity_type for deterministic ordering of same-name entities
+        sent_entities.sort(key=lambda x: (x[0], x[1].entity_type))
         sent_entities = [e for _, e in sent_entities]
 
         # Pairwise relation inference within sentence
@@ -298,20 +306,27 @@ def extract_relations(
             for e2 in sent_entities[i + 1:]:
                 # Check for specific relation signals
                 if _RE_SUPERSEDES.search(sent):
-                    _add_rel(e1.name, e2.name, "supersedes", 0.8)
+                    _add_rel(e1.name, e2.name, "supersedes", 0.8,
+                             e1.entity_type, e2.entity_type)
                 elif _RE_SOLVES.search(sent):
                     if e2.entity_type == "error":
-                        _add_rel(e1.name, e2.name, "solves", 0.9)
+                        _add_rel(e1.name, e2.name, "solves", 0.9,
+                                 e1.entity_type, e2.entity_type)
                     elif e1.entity_type == "error":
-                        _add_rel(e2.name, e1.name, "solves", 0.9)
+                        _add_rel(e2.name, e1.name, "solves", 0.9,
+                                 e2.entity_type, e1.entity_type)
                     else:
-                        _add_rel(e1.name, e2.name, "solves", 0.7)
+                        _add_rel(e1.name, e2.name, "solves", 0.7,
+                                 e1.entity_type, e2.entity_type)
                 elif _RE_CONFLICTS.search(sent):
-                    _add_rel(e1.name, e2.name, "conflicts_with", 0.8)
+                    _add_rel(e1.name, e2.name, "conflicts_with", 0.8,
+                             e1.entity_type, e2.entity_type)
                 elif _RE_USES.search(sent):
-                    _add_rel(e1.name, e2.name, "uses", 0.7)
+                    _add_rel(e1.name, e2.name, "uses", 0.7,
+                             e1.entity_type, e2.entity_type)
                 else:
-                    _add_rel(e1.name, e2.name, "related_to", 0.5)
+                    _add_rel(e1.name, e2.name, "related_to", 0.5,
+                             e1.entity_type, e2.entity_type)
 
         sent_offset = sent_end + 1  # +1 for the split delimiter
 
@@ -325,8 +340,8 @@ def extract_relations(
             dir2 = f2.name.rsplit("/", 1)[0]
             if dir1 == dir2:
                 dirs_seen.add(dir1)
-                _add_rel(dir1, f1.name, "contains", 0.9)
-                _add_rel(dir1, f2.name, "contains", 0.9)
+                _add_rel(dir1, f1.name, "contains", 0.9, "file", "file")
+                _add_rel(dir1, f2.name, "contains", 0.9, "file", "file")
 
     # Materialize directory entities so store_entities_and_edges can resolve IDs
     for d in dirs_seen:
@@ -346,6 +361,23 @@ def extract_relations(
 # ---------------------------------------------------------------------------
 # Database persistence
 # ---------------------------------------------------------------------------
+
+
+def _resolve_entity_id(
+    name_type_to_id: dict[tuple[str, str], str],
+    name: str,
+    entity_type: str | None,
+) -> str | None:
+    """Resolve entity UUID preferring typed lookup, falling back to first match by name."""
+    if entity_type:
+        eid = name_type_to_id.get((name, entity_type))
+        if eid:
+            return eid
+    # Fallback: first entity with this name (for directory containment etc.)
+    for (n, _t), eid in name_type_to_id.items():
+        if n == name:
+            return eid
+    return None
 
 
 async def store_entities_and_edges(
@@ -370,8 +402,6 @@ async def store_entities_and_edges(
         async with conn.transaction():
             # Map (canonical_name, entity_type) -> entity UUID for edge insertion
             name_type_to_id: dict[tuple[str, str], str] = {}
-            # Also keep name-only lookup for edge resolution (first match)
-            name_to_id: dict[str, str] = {}
 
             # Upsert entities — get or create, but do NOT increment mention_count yet
             for e in entities:
@@ -391,8 +421,6 @@ async def store_entities_and_edges(
                 if row:
                     eid = str(row["id"])
                     name_type_to_id[(e.name, e.entity_type)] = eid
-                    if e.name not in name_to_id:
-                        name_to_id[e.name] = eid
                     entity_count += 1
 
             # Insert entity mentions — the dedup gate.
@@ -426,33 +454,22 @@ async def store_entities_and_edges(
                         eid,
                     )
 
-            # Upsert edges — only add weight for new (memory_id, source, target, relation)
+            # Upsert edges — one row per (source, target, relation, memory_id)
             for rel in relations:
-                src_id = name_to_id.get(rel.source)
-                tgt_id = name_to_id.get(rel.target)
+                src_id = _resolve_entity_id(
+                    name_type_to_id, rel.source, rel.source_type
+                )
+                tgt_id = _resolve_entity_id(
+                    name_type_to_id, rel.target, rel.target_type
+                )
                 if not src_id or not tgt_id:
                     continue
-                # Check if this exact edge already exists for this memory_id
-                existing = await conn.fetchval(
-                    """
-                    SELECT 1 FROM kg_edges
-                    WHERE source_id = $1::uuid AND target_id = $2::uuid
-                      AND relation = $3 AND memory_id = $4::uuid
-                    """,
-                    src_id,
-                    tgt_id,
-                    rel.relation,
-                    memory_id,
-                )
-                if existing:
-                    continue
-                await conn.execute(
+                inserted = await conn.fetchval(
                     """
                     INSERT INTO kg_edges (source_id, target_id, relation, weight, memory_id)
                     VALUES ($1::uuid, $2::uuid, $3, $4, $5::uuid)
-                    ON CONFLICT (source_id, target_id, relation) DO UPDATE SET
-                        weight = kg_edges.weight + $4,
-                        updated_at = NOW()
+                    ON CONFLICT (source_id, target_id, relation, memory_id) DO NOTHING
+                    RETURNING TRUE
                     """,
                     src_id,
                     tgt_id,
@@ -460,7 +477,8 @@ async def store_entities_and_edges(
                     rel.confidence,
                     memory_id,
                 )
-                edge_count += 1
+                if inserted:
+                    edge_count += 1
 
     return {
         "entities": entity_count,

--- a/scripts/core/recall_formatters.py
+++ b/scripts/core/recall_formatters.py
@@ -80,6 +80,8 @@ def _build_json_result(result: dict[str, Any]) -> dict[str, Any]:
     }
     if "rerank_details" in result:
         json_result["rerank_details"] = result["rerank_details"]
+    if "kg_context" in result:
+        json_result["kg_context"] = result["kg_context"]
     return json_result
 
 

--- a/scripts/core/recall_formatters.py
+++ b/scripts/core/recall_formatters.py
@@ -81,6 +81,11 @@ def _build_json_result(result: dict[str, Any]) -> dict[str, Any]:
     if "rerank_details" in result:
         json_result["rerank_details"] = result["rerank_details"]
     if "kg_context" in result:
+        # kg_context carries display names and edge metadata sourced from the
+        # DB (via _fetch_kg_rows jsonb_build_object). Current consumers are
+        # CLI/JSON only, but treat the contents as untrusted strings at any
+        # future rendering boundary (HTML, markdown with nested templates).
+        # See aegis audit finding LOW-3.
         json_result["kg_context"] = result["kg_context"]
     return json_result
 

--- a/scripts/core/recall_learnings.py
+++ b/scripts/core/recall_learnings.py
@@ -162,6 +162,15 @@ def apply_pattern_enrichment(
     return enriched
 
 
+# Cap on the query string length we will pass to kg_extractor. Extraction
+# uses regex patterns whose worst-case time grows with input size, and the
+# reranker's kg_overlap signal gains nothing from matching against a
+# megabytes-long prompt. 4096 bytes comfortably covers every realistic
+# recall query while bounding regex CPU on hostile/accidental input.
+# See aegis audit finding LOW-1.
+_KG_QUERY_EXTRACTION_MAX_CHARS = 4096
+
+
 def make_recall_context(
     project: str | None,
     tags: list[str] | None,
@@ -179,10 +188,14 @@ def make_recall_context(
 
     query_entities: list[dict] | None = None
     if query and get_backend() == "postgres":
+        # Cap the input fed to the extractor. This is defense-in-depth against
+        # regex CPU blow-up from oversized queries; no production path in this
+        # codebase sends queries larger than a few hundred chars.
+        extract_input = query[:_KG_QUERY_EXTRACTION_MAX_CHARS]
         try:
             from scripts.core.kg_extractor import extract_entities
 
-            extracted = extract_entities(query)
+            extracted = extract_entities(extract_input)
             query_entities = [
                 {"name": e.name, "type": e.entity_type} for e in extracted
             ] or None

--- a/scripts/core/recall_learnings.py
+++ b/scripts/core/recall_learnings.py
@@ -524,13 +524,14 @@ async def enrich_with_kg_context(
         logger.debug("KG enrichment unavailable: %s", e)
         return results
     except Exception as e:
-        # Re-raise unless it's an asyncpg availability/interface error.
-        # asyncpg.exceptions.Error covers connection state, pool exhaustion,
-        # and protocol-level issues that mean the DB is transiently
-        # unavailable; those should degrade silently. Genuine SQL defects
-        # (UndefinedTableError, DataError, SyntaxError) are subclasses of
-        # PostgresError and must propagate so they surface rather than
-        # masquerading as a degraded-mode response.
+        # Re-raise unless the failure is specifically an asyncpg
+        # InterfaceError (connection-state, pool exhaustion, or protocol
+        # issues that indicate a transiently unavailable DB). Broader
+        # asyncpg errors -- SQL syntax errors, UndefinedTableError,
+        # DataError, any PostgresError subclass -- continue to propagate
+        # so real defects surface instead of masquerading as degraded
+        # mode. InterfaceError was chosen narrowly over asyncpg.Error
+        # for exactly that reason.
         if _pg_exc is not None and isinstance(e, _pg_exc.InterfaceError):
             logger.debug("KG enrichment unavailable (asyncpg): %s", e)
             return results

--- a/scripts/core/recall_learnings.py
+++ b/scripts/core/recall_learnings.py
@@ -166,14 +166,34 @@ def make_recall_context(
     project: str | None,
     tags: list[str] | None,
     retrieval_mode: str,
+    query: str | None = None,
 ) -> Any:
-    """Construct a RecallContext for the reranker."""
+    """Construct a RecallContext for the reranker.
+
+    When ``query`` is provided and backend is postgres, populates
+    ``query_entities`` via ``kg_extractor.extract_entities`` for the
+    ``kg_overlap`` signal. Non-fatal: any extractor failure yields no
+    query entities.
+    """
     from scripts.core.reranker import RecallContext
+
+    query_entities: list[dict] | None = None
+    if query and get_backend() == "postgres":
+        try:
+            from scripts.core.kg_extractor import extract_entities
+
+            extracted = extract_entities(query)
+            query_entities = [
+                {"name": e.name, "type": e.entity_type} for e in extracted
+            ] or None
+        except Exception as e:
+            logger.debug("Query-side entity extraction failed: %s", e)
 
     return RecallContext(
         project=project,
         tags_hint=tags,
         retrieval_mode=retrieval_mode,
+        query_entities=query_entities,
     )
 
 
@@ -623,6 +643,7 @@ async def main() -> int:
     # Pattern enrichment
     if (not args.no_rerank or args.json_full) and backend == "postgres":
         results = await enrich_with_pattern_strength(results)
+        results = await enrich_with_kg_context(results)
 
     # Tag filtering
     results = filter_by_tags(results, args.tags, strict=args.tags_strict)
@@ -638,6 +659,7 @@ async def main() -> int:
             or None,
             tags=args.tags,
             retrieval_mode=retrieval_mode,
+            query=args.query,
         )
         from scripts.core.reranker import rerank
 

--- a/scripts/core/recall_learnings.py
+++ b/scripts/core/recall_learnings.py
@@ -352,6 +352,128 @@ async def enrich_with_pattern_strength(
     return results
 
 
+# ---------------------------------------------------------------------------
+# Knowledge graph enrichment (Phase 3, read-side)
+# ---------------------------------------------------------------------------
+
+KG_MAX_EDGES_PER_MEMORY = 50
+"""Safety cap on edges returned per memory in kg_context. Typical usage is
+< 10; the cap prevents pathological payload bloat on high-connectivity
+learnings. When exceeded, the top-N by weight are kept and a warning logs."""
+
+
+async def _fetch_kg_rows(result_ids: list[str]) -> list[dict[str, Any]]:
+    """Fetch entities and edges for each memory_id in one round trip.
+
+    Caller must ensure Postgres backend. Returns rows shaped as:
+    {id: UUID, kg_entities: list[dict], kg_edges: list[dict]}.
+    """
+    from scripts.core.db.postgres_pool import get_pool
+
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT m.memory_id AS id,
+                   ARRAY_AGG(DISTINCT jsonb_build_object(
+                     'id', e.id::text,
+                     'name', e.display_name,
+                     'type', e.entity_type,
+                     'mention_count', e.mention_count
+                   )) AS kg_entities,
+                   COALESCE((
+                     SELECT ARRAY_AGG(jsonb_build_object(
+                       'source', se.display_name,
+                       'target', te.display_name,
+                       'relation', ed.relation,
+                       'weight', ed.weight
+                     ))
+                     FROM kg_edges ed
+                     JOIN kg_entities se ON se.id = ed.source_id
+                     JOIN kg_entities te ON te.id = ed.target_id
+                     WHERE ed.memory_id = m.memory_id
+                   ), ARRAY[]::jsonb[]) AS kg_edges
+            FROM kg_entity_mentions m
+            JOIN kg_entities e ON e.id = m.entity_id
+            WHERE m.memory_id = ANY($1::uuid[])
+            GROUP BY m.memory_id
+            """,
+            [uuid.UUID(rid) for rid in result_ids],
+        )
+    return [dict(row) for row in rows]
+
+
+def build_kg_lookup(rows: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    """Build a {memory_id: {entities, edges}} lookup from fetched rows.
+
+    Edges exceeding KG_MAX_EDGES_PER_MEMORY are capped to the top-N by
+    weight (descending) and a warning is logged with the overflow count.
+    """
+    lookup: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        mid = str(row["id"])
+        entities = list(row.get("kg_entities") or [])
+        edges = list(row.get("kg_edges") or [])
+        if len(edges) > KG_MAX_EDGES_PER_MEMORY:
+            total = len(edges)
+            edges = sorted(edges, key=lambda e: e.get("weight", 0.0), reverse=True)
+            edges = edges[:KG_MAX_EDGES_PER_MEMORY]
+            logger.warning(
+                "kg_context edges capped for memory %s: %d edges truncated to %d",
+                mid, total, KG_MAX_EDGES_PER_MEMORY,
+            )
+        else:
+            edges = sorted(edges, key=lambda e: e.get("weight", 0.0), reverse=True)
+        lookup[mid] = {"entities": entities, "edges": edges}
+    return lookup
+
+
+def apply_kg_enrichment(
+    results: list[dict[str, Any]],
+    lookup: dict[str, dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Return a new list with kg_context merged in for matching results.
+
+    Does not mutate input. Results with no matching entry in lookup are
+    returned unchanged (no kg_context key set).
+    """
+    enriched: list[dict[str, Any]] = []
+    for result in results:
+        rid = result.get("id")
+        if rid and str(rid) in lookup:
+            enriched.append({**result, "kg_context": lookup[str(rid)]})
+        else:
+            enriched.append(result)
+    return enriched
+
+
+async def enrich_with_kg_context(
+    results: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Add kg_context to recall results from kg_entities / kg_edges tables.
+
+    Non-fatal: returns results unchanged on sqlite backend, empty input,
+    missing IDs, or any DB error.
+    """
+    if not results or get_backend() != "postgres":
+        return results
+
+    result_ids = [str(r["id"]) for r in results if r.get("id")]
+    if not result_ids:
+        return results
+
+    try:
+        rows = await _fetch_kg_rows(result_ids)
+        lookup = build_kg_lookup(rows)
+        return apply_kg_enrichment(results, lookup)
+    except (ImportError, OSError, ConnectionError) as e:
+        logger.debug("KG enrichment unavailable: %s", e)
+    except Exception as e:
+        logger.warning("KG enrichment error: %s", e, exc_info=True)
+
+    return results
+
+
 async def search_learnings(
     query: str,
     k: int = 5,

--- a/scripts/core/recall_learnings.py
+++ b/scripts/core/recall_learnings.py
@@ -392,12 +392,20 @@ async def _fetch_kg_rows(result_ids: list[str]) -> list[dict[str, Any]]:
 
     pool = await get_pool()
     async with pool.acquire() as conn:
+        # Edges are capped at the SQL layer via a correlated LATERAL
+        # subquery with ORDER BY + LIMIT so the database only materializes
+        # and transfers up to KG_MAX_EDGES_PER_MEMORY edges per memory.
+        # build_kg_lookup still caps on the Python side as defense-in-depth
+        # (catches SQL ordering drift or callers that bypass this query).
+        # Entity output carries both 'canonical' (matching key) and 'name'
+        # (display_name) so consumers can ID-match without losing casing.
         rows = await conn.fetch(
             """
             SELECT m.memory_id AS id,
                    ARRAY_AGG(DISTINCT jsonb_build_object(
                      'id', e.id::text,
                      'name', e.display_name,
+                     'canonical', e.name,
                      'type', e.entity_type,
                      'mention_count', e.mention_count
                    )) AS kg_entities,
@@ -408,10 +416,15 @@ async def _fetch_kg_rows(result_ids: list[str]) -> list[dict[str, Any]]:
                        'relation', ed.relation,
                        'weight', ed.weight
                      ))
-                     FROM kg_edges ed
+                     FROM (
+                       SELECT ed.*
+                       FROM kg_edges ed
+                       WHERE ed.memory_id = m.memory_id
+                       ORDER BY ed.weight DESC
+                       LIMIT $2
+                     ) ed
                      JOIN kg_entities se ON se.id = ed.source_id
                      JOIN kg_entities te ON te.id = ed.target_id
-                     WHERE ed.memory_id = m.memory_id
                    ), ARRAY[]::jsonb[]) AS kg_edges
             FROM kg_entity_mentions m
             JOIN kg_entities e ON e.id = m.entity_id
@@ -419,6 +432,7 @@ async def _fetch_kg_rows(result_ids: list[str]) -> list[dict[str, Any]]:
             GROUP BY m.memory_id
             """,
             [uuid.UUID(rid) for rid in result_ids],
+            KG_MAX_EDGES_PER_MEMORY,
         )
     return [dict(row) for row in rows]
 
@@ -472,8 +486,10 @@ async def enrich_with_kg_context(
 ) -> list[dict[str, Any]]:
     """Add kg_context to recall results from kg_entities / kg_edges tables.
 
-    Non-fatal: returns results unchanged on sqlite backend, empty input,
-    missing IDs, or any DB error.
+    Gracefully degrades only on expected availability failures (missing
+    module, missing DB, network). Genuine defects -- bad SQL, row-shape
+    drift, missing table on a configured-Postgres install -- are allowed
+    to propagate so they surface rather than silently changing ranking.
     """
     if not results or get_backend() != "postgres":
         return results
@@ -483,15 +499,29 @@ async def enrich_with_kg_context(
         return results
 
     try:
+        import asyncpg.exceptions as _pg_exc
+    except ImportError:
+        _pg_exc = None  # type: ignore[assignment]
+
+    try:
         rows = await _fetch_kg_rows(result_ids)
         lookup = build_kg_lookup(rows)
         return apply_kg_enrichment(results, lookup)
     except (ImportError, OSError, ConnectionError) as e:
         logger.debug("KG enrichment unavailable: %s", e)
+        return results
     except Exception as e:
-        logger.warning("KG enrichment error: %s", e, exc_info=True)
-
-    return results
+        # Re-raise unless it's an asyncpg availability/interface error.
+        # asyncpg.exceptions.Error covers connection state, pool exhaustion,
+        # and protocol-level issues that mean the DB is transiently
+        # unavailable; those should degrade silently. Genuine SQL defects
+        # (UndefinedTableError, DataError, SyntaxError) are subclasses of
+        # PostgresError and must propagate so they surface rather than
+        # masquerading as a degraded-mode response.
+        if _pg_exc is not None and isinstance(e, _pg_exc.InterfaceError):
+            logger.debug("KG enrichment unavailable (asyncpg): %s", e)
+            return results
+        raise
 
 
 async def search_learnings(

--- a/scripts/core/reranker.py
+++ b/scripts/core/reranker.py
@@ -250,9 +250,19 @@ def pattern_score(result: dict, ctx: RecallContext) -> float:
 def kg_overlap(result: dict, ctx: RecallContext) -> float:
     """Weighted-Jaccard overlap between query entities and result KG entities.
 
-    Each entity is weighted by its type's salience (KG_TYPE_WEIGHTS). Names
-    are compared case-insensitively. Returns 0.0 when either side lacks
-    entities. Returns score in [0, 1].
+    Each entity is weighted by its type's salience (KG_TYPE_WEIGHTS). Returns
+    0.0 when either side lacks entities. Returns score in [0, 1].
+
+    Canonicalization note:
+      ``kg_extractor.extract_entities()`` exposes two name fields: ``name``
+      (lowercase canonical, used as the KG primary key column) and
+      ``display_name`` (original casing). ``_fetch_kg_rows`` stores
+      ``display_name`` in ``kg_context.entities[*].name`` for human-readable
+      output, while query-side entities carry the canonical lowercase name.
+      We lowercase both on compare here so store-side display casing does
+      not break overlap matching. If that asymmetry is ever closed (e.g. by
+      adding an explicit ``canonical`` field to kg_context entries), the
+      ``.lower()`` calls below can be removed.
     """
     if not ctx.query_entities:
         return 0.0

--- a/scripts/core/reranker.py
+++ b/scripts/core/reranker.py
@@ -47,6 +47,11 @@ KG_TYPE_WEIGHTS: dict[str, float] = {
     "module": 1.0,
     "error": 0.9,
     "library": 0.8,
+    # kg_extractor emits entity_type='config' for env/config variables, so
+    # the lookup key must be 'config'. 'config_var' is kept as a harmless
+    # alias so older callers that hand-build entity dicts still hit the
+    # intended salience. Keep both in sync if the weight changes.
+    "config": 0.7,
     "config_var": 0.7,
     "tool": 0.6,
     "concept": 0.5,
@@ -276,7 +281,14 @@ def kg_overlap(result: dict, ctx: RecallContext) -> float:
         return 0.0
 
     def _key(entity: dict) -> tuple[str, str]:
-        return (str(entity.get("name", "")).lower(), str(entity.get("type", "")))
+        # Prefer 'canonical' when present (kg_context entities from
+        # _fetch_kg_rows carry both display 'name' and canonical 'canonical';
+        # query-side entities from extract_entities put the canonical value
+        # in 'name'). Fall back to lowercased name so older callers still
+        # match. See plan §3.2 / adversarial-review F1 for rationale.
+        canonical = entity.get("canonical")
+        key_name = canonical if canonical is not None else entity.get("name", "")
+        return (str(key_name).lower(), str(entity.get("type", "")))
 
     def _weight(entity_type: str) -> float:
         return KG_TYPE_WEIGHTS.get(entity_type, _KG_DEFAULT_TYPE_WEIGHT)

--- a/scripts/core/reranker.py
+++ b/scripts/core/reranker.py
@@ -252,64 +252,67 @@ def pattern_score(result: dict, ctx: RecallContext) -> float:
     return strength * min(1.0, ratio)
 
 
+def _kg_entity_key(entity: dict) -> tuple[str, str]:
+    """Canonical (name, type) key for kg_overlap matching.
+
+    Prefers 'canonical' field when present (kg_context entities from
+    _fetch_kg_rows carry both display 'name' and canonical 'canonical';
+    query-side entities from extract_entities put the canonical value
+    in 'name'). Falls back to lowercased name so older callers still
+    match. See plan §3.2 / adversarial-review F1 for rationale.
+    """
+    canonical = entity.get("canonical")
+    key_name = canonical if canonical is not None else entity.get("name", "")
+    return (str(key_name).lower(), str(entity.get("type", "")))
+
+
+def _kg_type_weight(entity_type: str) -> float:
+    return KG_TYPE_WEIGHTS.get(entity_type, _KG_DEFAULT_TYPE_WEIGHT)
+
+
+def _kg_overlap_score(
+    result_entities: list[dict], query_map: dict[tuple[str, str], dict]
+) -> float:
+    """Compute weighted-Jaccard given a pre-built query entity map."""
+    if not query_map or not result_entities:
+        return 0.0
+    result_map = {_kg_entity_key(e): e for e in result_entities}
+    intersection = set(query_map) & set(result_map)
+    union = set(query_map) | set(result_map)
+    if not union:
+        return 0.0
+    num = sum(_kg_type_weight(query_map[k].get("type", "")) for k in intersection)
+    # Use query type for union members on query side, result type on result side.
+    den = sum(
+        _kg_type_weight((query_map.get(k) or result_map.get(k)).get("type", ""))
+        for k in union
+    )
+    if den <= 0.0:
+        return 0.0
+    return max(0.0, min(1.0, num / den))
+
+
 def kg_overlap(result: dict, ctx: RecallContext) -> float:
     """Weighted-Jaccard overlap between query entities and result KG entities.
 
     Each entity is weighted by its type's salience (KG_TYPE_WEIGHTS). Returns
     0.0 when either side lacks entities. Returns score in [0, 1].
 
-    Canonicalization note:
-      ``kg_extractor.extract_entities()`` exposes two name fields: ``name``
-      (lowercase canonical, used as the KG primary key column) and
-      ``display_name`` (original casing). ``_fetch_kg_rows`` stores
-      ``display_name`` in ``kg_context.entities[*].name`` for human-readable
-      output, while query-side entities carry the canonical lowercase name.
-      We lowercase both on compare here so store-side display casing does
-      not break overlap matching. If that asymmetry is ever closed (e.g. by
-      adding an explicit ``canonical`` field to kg_context entries), the
-      ``.lower()`` calls below can be removed.
+    This public signature rebuilds the query entity map per call, which is
+    the right default for one-off scoring but unnecessary work inside
+    rerank()'s per-result loop. rerank() computes the map once and uses
+    _kg_overlap_score(result_entities, query_map) directly.
     """
     if not ctx.query_entities:
         return 0.0
-
     kg_context = result.get("kg_context")
     if not kg_context:
         return 0.0
-
     result_entities = kg_context.get("entities") or []
     if not result_entities:
         return 0.0
-
-    def _key(entity: dict) -> tuple[str, str]:
-        # Prefer 'canonical' when present (kg_context entities from
-        # _fetch_kg_rows carry both display 'name' and canonical 'canonical';
-        # query-side entities from extract_entities put the canonical value
-        # in 'name'). Fall back to lowercased name so older callers still
-        # match. See plan §3.2 / adversarial-review F1 for rationale.
-        canonical = entity.get("canonical")
-        key_name = canonical if canonical is not None else entity.get("name", "")
-        return (str(key_name).lower(), str(entity.get("type", "")))
-
-    def _weight(entity_type: str) -> float:
-        return KG_TYPE_WEIGHTS.get(entity_type, _KG_DEFAULT_TYPE_WEIGHT)
-
-    query_map = {_key(e): e for e in ctx.query_entities}
-    result_map = {_key(e): e for e in result_entities}
-
-    intersection = set(query_map) & set(result_map)
-    union = set(query_map) | set(result_map)
-    if not union:
-        return 0.0
-
-    num = sum(_weight(query_map[k].get("type", "")) for k in intersection)
-    # Use query type for union members on query side, result type on result side.
-    den = sum(
-        _weight((query_map.get(k) or result_map.get(k)).get("type", ""))
-        for k in union
-    )
-    if den <= 0.0:
-        return 0.0
-    return max(0.0, min(1.0, num / den))
+    query_map = {_kg_entity_key(e): e for e in ctx.query_entities}
+    return _kg_overlap_score(result_entities, query_map)
 
 
 # ---------------------------------------------------------------------------
@@ -451,6 +454,13 @@ def rerank(
     retrieval_weight = 1.0 - effective_signal_weight
     total = len(results)
     effective_kg_weight = config.kg_weight if kg_active else 0.0
+    # Build the query entity map once per rerank call rather than once
+    # per result. Avoids O(R * Q) key construction.
+    query_map = (
+        {_kg_entity_key(e): e for e in ctx.query_entities}
+        if kg_active and ctx.query_entities
+        else {}
+    )
 
     scored: list[dict] = []
     for rank, result in enumerate(results):
@@ -466,7 +476,11 @@ def rerank(
         sig_type = type_match(result, ctx)
         sig_tags = tag_overlap(result, ctx)
         sig_pattern = pattern_score(result, ctx)
-        sig_kg = kg_overlap(result, ctx) if kg_active else 0.0
+        if kg_active and query_map:
+            result_entities = (result.get("kg_context") or {}).get("entities") or []
+            sig_kg = _kg_overlap_score(result_entities, query_map)
+        else:
+            sig_kg = 0.0
 
         # Weighted combination. When kg_active is false, effective_kg_weight
         # is 0 and kg_weight's share has already been rolled into

--- a/scripts/core/reranker.py
+++ b/scripts/core/reranker.py
@@ -421,8 +421,18 @@ def rerank(
     if config is None:
         config = _default_config()
 
-    total_signal_weight = config.total_signal_weight
-    if total_signal_weight <= 0:
+    # KG signal activation: kg_weight contributes only when query entities
+    # are present AND at least one result carries kg_context. Otherwise
+    # kg_weight redirects to retrieval (deterministic redistribution).
+    # Preserves pre-Phase-3 ranking math on sqlite, empty-KG, and
+    # extraction-miss paths. See adversarial-review finding D1.
+    kg_active = bool(ctx.query_entities) and any(
+        isinstance(r.get("kg_context"), dict) and r["kg_context"].get("entities")
+        for r in results
+    )
+
+    effective_signal_weight = config.effective_signal_weight(kg_active=kg_active)
+    if effective_signal_weight <= 0:
         total = len(results)
         scored = [
             {
@@ -431,15 +441,16 @@ def rerank(
                     r.get("similarity", 0.0), ctx.retrieval_mode,
                     rank=i, total=total, config=config,
                 ),
-                "rerank_details": {},
+                "rerank_details": {"kg_active": kg_active},
             }
             for i, r in enumerate(results)
         ]
         scored.sort(key=lambda r: r["final_score"], reverse=True)
         return scored[:k]
 
-    retrieval_weight = 1.0 - total_signal_weight
+    retrieval_weight = 1.0 - effective_signal_weight
     total = len(results)
+    effective_kg_weight = config.kg_weight if kg_active else 0.0
 
     scored: list[dict] = []
     for rank, result in enumerate(results):
@@ -455,9 +466,11 @@ def rerank(
         sig_type = type_match(result, ctx)
         sig_tags = tag_overlap(result, ctx)
         sig_pattern = pattern_score(result, ctx)
-        sig_kg = kg_overlap(result, ctx)
+        sig_kg = kg_overlap(result, ctx) if kg_active else 0.0
 
-        # Weighted combination
+        # Weighted combination. When kg_active is false, effective_kg_weight
+        # is 0 and kg_weight's share has already been rolled into
+        # retrieval_weight above.
         final = (
             retrieval_weight * cal
             + config.project_weight * sig_project
@@ -467,7 +480,7 @@ def rerank(
             + config.type_affinity_weight * sig_type
             + config.tag_overlap_weight * sig_tags
             + config.pattern_weight * sig_pattern
-            + config.kg_weight * sig_kg
+            + effective_kg_weight * sig_kg
         )
 
         # Augment result (shallow copy to avoid mutating input)
@@ -483,6 +496,7 @@ def rerank(
             "tag_overlap": sig_tags,
             "pattern": sig_pattern,
             "kg_overlap": sig_kg,
+            "kg_active": kg_active,
         }
         scored.append(augmented)
 

--- a/scripts/core/reranker.py
+++ b/scripts/core/reranker.py
@@ -33,7 +33,26 @@ class RecallContext:
     type_probabilities: dict[str, float] | None = None
     tags_hint: list[str] | None = None
     retrieval_mode: str | None = None  # "vector", "hybrid_rrf", "text", "sqlite"
+    # list[dict] of entities extracted from the query via kg_extractor.
+    # Each dict carries at least {"name": str, "type": str}. Used by
+    # kg_overlap signal.  None or empty -> signal returns 0.
+    query_entities: list[dict] | None = None
     now: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+
+# Type-salience weights for kg_overlap. Higher weights -> more specific types
+# contribute more evidence to the overlap signal. See plan §3.2 for rationale.
+KG_TYPE_WEIGHTS: dict[str, float] = {
+    "file": 1.0,
+    "module": 1.0,
+    "error": 0.9,
+    "library": 0.8,
+    "config_var": 0.7,
+    "tool": 0.6,
+    "concept": 0.5,
+    "language": 0.4,
+}
+_KG_DEFAULT_TYPE_WEIGHT: float = 0.5
 
 
 # Single source of truth for RerankerConfig lives in config/models.py.
@@ -228,6 +247,49 @@ def pattern_score(result: dict, ctx: RecallContext) -> float:
     return strength * min(1.0, ratio)
 
 
+def kg_overlap(result: dict, ctx: RecallContext) -> float:
+    """Weighted-Jaccard overlap between query entities and result KG entities.
+
+    Each entity is weighted by its type's salience (KG_TYPE_WEIGHTS). Names
+    are compared case-insensitively. Returns 0.0 when either side lacks
+    entities. Returns score in [0, 1].
+    """
+    if not ctx.query_entities:
+        return 0.0
+
+    kg_context = result.get("kg_context")
+    if not kg_context:
+        return 0.0
+
+    result_entities = kg_context.get("entities") or []
+    if not result_entities:
+        return 0.0
+
+    def _key(entity: dict) -> tuple[str, str]:
+        return (str(entity.get("name", "")).lower(), str(entity.get("type", "")))
+
+    def _weight(entity_type: str) -> float:
+        return KG_TYPE_WEIGHTS.get(entity_type, _KG_DEFAULT_TYPE_WEIGHT)
+
+    query_map = {_key(e): e for e in ctx.query_entities}
+    result_map = {_key(e): e for e in result_entities}
+
+    intersection = set(query_map) & set(result_map)
+    union = set(query_map) | set(result_map)
+    if not union:
+        return 0.0
+
+    num = sum(_weight(query_map[k].get("type", "")) for k in intersection)
+    # Use query type for union members on query side, result type on result side.
+    den = sum(
+        _weight((query_map.get(k) or result_map.get(k)).get("type", ""))
+        for k in union
+    )
+    if den <= 0.0:
+        return 0.0
+    return max(0.0, min(1.0, num / den))
+
+
 # ---------------------------------------------------------------------------
 # Embedding Centroid Helpers
 # ---------------------------------------------------------------------------
@@ -371,6 +433,7 @@ def rerank(
         sig_type = type_match(result, ctx)
         sig_tags = tag_overlap(result, ctx)
         sig_pattern = pattern_score(result, ctx)
+        sig_kg = kg_overlap(result, ctx)
 
         # Weighted combination
         final = (
@@ -382,6 +445,7 @@ def rerank(
             + config.type_affinity_weight * sig_type
             + config.tag_overlap_weight * sig_tags
             + config.pattern_weight * sig_pattern
+            + config.kg_weight * sig_kg
         )
 
         # Augment result (shallow copy to avoid mutating input)
@@ -396,6 +460,7 @@ def rerank(
             "type_match": sig_type,
             "tag_overlap": sig_tags,
             "pattern": sig_pattern,
+            "kg_overlap": sig_kg,
         }
         scored.append(augmented)
 

--- a/scripts/core/store_learning.py
+++ b/scripts/core/store_learning.py
@@ -495,6 +495,73 @@ def _try_calibrate_confidence(
 
 
 # ===========================================================================
+# Async I/O: Knowledge Graph Indexing (non-fatal side effects)
+# ===========================================================================
+
+
+async def _try_index_kg(memory_id: str, content: str) -> dict[str, Any] | None:
+    """Extract entities/relations from content and store KG edges.
+
+    Non-fatal -- returns None on any failure. Only runs for postgres backend.
+    """
+    try:
+        from scripts.core.kg_extractor import (
+            extract_entities,
+            extract_relations,
+            store_entities_and_edges,
+        )
+
+        entities = extract_entities(content)
+        if not entities:
+            return None
+        relations = extract_relations(content, entities)
+        kg_stats = await store_entities_and_edges(memory_id, entities, relations)
+        logger.info(
+            "KG indexed: %d entities, %d edges, %d mentions",
+            kg_stats["entities"],
+            kg_stats["edges"],
+            kg_stats["mentions"],
+        )
+        return kg_stats
+    except Exception as e:
+        logger.warning("KG extraction failed (non-fatal): %s", str(e)[:200])
+        return None
+
+
+async def _try_backfill_kg(content_hash: str, content: str) -> None:
+    """Backfill KG for an existing learning matched by content_hash.
+
+    store_entities_and_edges is idempotent, so repeated calls are safe.
+    Non-fatal -- logs and returns on any failure.
+    """
+    try:
+        from scripts.core.db.postgres_pool import get_pool
+        from scripts.core.kg_extractor import (
+            extract_entities,
+            extract_relations,
+            store_entities_and_edges,
+        )
+
+        pool = await get_pool()
+        async with pool.acquire() as conn:
+            existing_id = await conn.fetchval(
+                "SELECT id FROM archival_memory WHERE content_hash = $1",
+                content_hash,
+            )
+        if not existing_id:
+            return
+        existing_id_str = str(existing_id)
+        entities = extract_entities(content)
+        if not entities:
+            return
+        relations = extract_relations(content, entities)
+        await store_entities_and_edges(existing_id_str, entities, relations)
+        logger.info("KG backfilled for dedup learning %s", existing_id_str)
+    except Exception as e:
+        logger.warning("KG backfill on dedup failed (non-fatal): %s", str(e)[:200])
+
+
+# ===========================================================================
 # Async I/O: Store Handlers
 # ===========================================================================
 
@@ -632,6 +699,8 @@ async def store_learning_v2(
 
         # content_hash dedup returns empty string
         if not memory_id:
+            if backend == "postgres":
+                await _try_backfill_kg(content_hash, content)
             _record_rejection(
                 session_id,
                 project=project,
@@ -645,6 +714,11 @@ async def store_learning_v2(
                 "reason": "duplicate (content_hash match)",
             }
 
+        # Knowledge graph indexing (non-fatal, postgres-only)
+        kg_stats: dict[str, Any] | None = None
+        if backend == "postgres":
+            kg_stats = await _try_index_kg(memory_id, content)
+
         result_dict: dict[str, Any] = {
             "success": True,
             "memory_id": memory_id,
@@ -654,6 +728,8 @@ async def store_learning_v2(
         }
         if supersedes and backend == "postgres":
             result_dict["superseded"] = supersedes
+        if kg_stats:
+            result_dict["kg_stats"] = kg_stats
         return result_dict
 
     except Exception as e:

--- a/scripts/migrations/add_knowledge_graph.sql
+++ b/scripts/migrations/add_knowledge_graph.sql
@@ -1,0 +1,70 @@
+-- Knowledge Graph: Entities (nodes)
+CREATE TABLE IF NOT EXISTS kg_entities (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name TEXT NOT NULL,                    -- canonical name (lowercase, normalized)
+    display_name TEXT NOT NULL,            -- original casing for display
+    entity_type TEXT NOT NULL,             -- file, module, tool, concept, etc.
+    metadata JSONB DEFAULT '{}',           -- extra attributes
+    embedding vector(1024),                -- optional: entity-level embedding
+    first_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    mention_count INTEGER NOT NULL DEFAULT 1
+);
+
+-- Unique constraint: one entity per (name, entity_type)
+CREATE UNIQUE INDEX IF NOT EXISTS idx_kg_entity_unique
+    ON kg_entities(name, entity_type);
+
+-- Fast lookup by type
+CREATE INDEX IF NOT EXISTS idx_kg_entity_type
+    ON kg_entities(entity_type);
+
+-- Full-text search on entity names (requires pg_trgm extension)
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_trgm') THEN
+        CREATE INDEX IF NOT EXISTS idx_kg_entity_name_trgm
+            ON kg_entities USING gin(name gin_trgm_ops);
+    ELSE
+        RAISE NOTICE 'pg_trgm not available — skipping trigram index on kg_entities.name';
+    END IF;
+END
+$$;
+
+-- Knowledge Graph: Relationships (edges)
+CREATE TABLE IF NOT EXISTS kg_edges (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    source_id UUID NOT NULL REFERENCES kg_entities(id) ON DELETE CASCADE,
+    target_id UUID NOT NULL REFERENCES kg_entities(id) ON DELETE CASCADE,
+    relation TEXT NOT NULL,               -- uses, contains, solves, related_to, etc.
+    weight FLOAT NOT NULL DEFAULT 1.0,    -- co-occurrence strength
+    memory_id UUID REFERENCES archival_memory(id) ON DELETE SET NULL,
+    metadata JSONB DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Unique edge per (source, target, relation) to allow weight accumulation
+CREATE UNIQUE INDEX IF NOT EXISTS idx_kg_edge_unique
+    ON kg_edges(source_id, target_id, relation);
+
+-- Traversal indexes (both directions for undirected queries)
+CREATE INDEX IF NOT EXISTS idx_kg_edge_source ON kg_edges(source_id);
+CREATE INDEX IF NOT EXISTS idx_kg_edge_target ON kg_edges(target_id);
+CREATE INDEX IF NOT EXISTS idx_kg_edge_relation ON kg_edges(relation);
+
+-- Knowledge Graph: Entity-to-Learning mentions (join table)
+CREATE TABLE IF NOT EXISTS kg_entity_mentions (
+    entity_id UUID NOT NULL REFERENCES kg_entities(id) ON DELETE CASCADE,
+    memory_id UUID NOT NULL REFERENCES archival_memory(id) ON DELETE CASCADE,
+    mention_type TEXT NOT NULL DEFAULT 'explicit',  -- 'explicit', 'inferred'
+    span_start INTEGER,                              -- character offset in content
+    span_end INTEGER,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (entity_id, memory_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_kg_mentions_memory
+    ON kg_entity_mentions(memory_id);
+CREATE INDEX IF NOT EXISTS idx_kg_mentions_entity
+    ON kg_entity_mentions(entity_id);

--- a/scripts/migrations/add_knowledge_graph.sql
+++ b/scripts/migrations/add_knowledge_graph.sql
@@ -38,15 +38,17 @@ CREATE TABLE IF NOT EXISTS kg_edges (
     target_id UUID NOT NULL REFERENCES kg_entities(id) ON DELETE CASCADE,
     relation TEXT NOT NULL,               -- uses, contains, solves, related_to, etc.
     weight FLOAT NOT NULL DEFAULT 1.0,    -- co-occurrence strength
-    memory_id UUID REFERENCES archival_memory(id) ON DELETE SET NULL,
+    memory_id UUID NOT NULL REFERENCES archival_memory(id) ON DELETE CASCADE,
     metadata JSONB DEFAULT '{}',
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
--- Unique edge per (source, target, relation) to allow weight accumulation
-CREATE UNIQUE INDEX IF NOT EXISTS idx_kg_edge_unique
-    ON kg_edges(source_id, target_id, relation);
+-- Replace old 3-column unique index with 4-column per-learning provenance index.
+-- DROP first because IF NOT EXISTS is a no-op when the name already exists.
+DROP INDEX IF EXISTS idx_kg_edge_unique;
+CREATE UNIQUE INDEX idx_kg_edge_unique
+    ON kg_edges(source_id, target_id, relation, memory_id);
 
 -- Traversal indexes (both directions for undirected queries)
 CREATE INDEX IF NOT EXISTS idx_kg_edge_source ON kg_edges(source_id);

--- a/tests/test_config_models.py
+++ b/tests/test_config_models.py
@@ -57,7 +57,7 @@ class TestRerankerConfig:
 
     def test_total_signal_weight(self):
         cfg = RerankerConfig()
-        expected = 0.15 + 0.05 * 6  # project + 6 others at 0.05
+        expected = 0.15 + 0.05 * 7  # project + 7 others (incl. kg_weight) at 0.05
         assert abs(cfg.total_signal_weight - expected) < 1e-9
 
 

--- a/tests/test_config_models.py
+++ b/tests/test_config_models.py
@@ -60,6 +60,52 @@ class TestRerankerConfig:
         expected = 0.15 + 0.05 * 7  # project + 7 others (incl. kg_weight) at 0.05
         assert abs(cfg.total_signal_weight - expected) < 1e-9
 
+    def test_rejects_overweight_config(self):
+        """Finding F2 fix: operators upgrading from pre-Phase-3 may have an
+        opc.toml whose pre-existing weights already sum to 1.0. Adding the
+        new default kg_weight=0.05 would push total above 1.0 and flip
+        retrieval_weight negative. __post_init__ must reject that config."""
+        import pytest
+        with pytest.raises(ValueError, match="sum to <= 1.0"):
+            # Pre-Phase-3 weights summed to 1.0 plus new kg_weight=0.05.
+            RerankerConfig(
+                project_weight=0.15,
+                recency_weight=0.10,
+                confidence_weight=0.10,
+                recall_weight=0.10,
+                type_affinity_weight=0.15,
+                tag_overlap_weight=0.20,
+                pattern_weight=0.20,
+                # kg_weight defaults to 0.05 -> total = 1.05.
+            )
+
+    def test_rejects_negative_total(self):
+        import pytest
+        with pytest.raises(ValueError, match="sum to <= 1.0"):
+            RerankerConfig(project_weight=-1.0)
+
+    def test_accepts_exactly_one(self):
+        # Boundary: total_signal_weight == 1.0 is allowed (retrieval_weight=0).
+        cfg = RerankerConfig(
+            project_weight=0.20,
+            recency_weight=0.15,
+            confidence_weight=0.10,
+            recall_weight=0.10,
+            type_affinity_weight=0.10,
+            tag_overlap_weight=0.15,
+            pattern_weight=0.15,
+            kg_weight=0.05,
+        )
+        assert abs(cfg.total_signal_weight - 1.0) < 1e-9
+
+    def test_effective_signal_weight_redistributes_kg_when_inactive(self):
+        cfg = RerankerConfig()
+        assert cfg.effective_signal_weight(kg_active=True) == cfg.total_signal_weight
+        assert (
+            cfg.effective_signal_weight(kg_active=False)
+            == cfg.total_signal_weight - cfg.kg_weight
+        )
+
 
 class TestRecallConfig:
     def test_defaults(self):

--- a/tests/test_kg_enrichment.py
+++ b/tests/test_kg_enrichment.py
@@ -173,6 +173,45 @@ async def test_enrich_with_kg_context_connection_error_non_fatal():
 
 
 @pytest.mark.asyncio
+async def test_enrich_with_kg_context_propagates_unexpected_exception():
+    """Narrowed catch: a SQL defect like UndefinedTable must propagate,
+    not masquerade as silent degradation. Only availability failures
+    (Import/OS/Connection/asyncpg.InterfaceError) are swallowed."""
+    from scripts.core.recall_learnings import enrich_with_kg_context
+
+    class _FakeTableError(Exception):
+        """Stands in for a real asyncpg.exceptions.UndefinedTableError."""
+
+    results = [{"id": str(uuid.uuid4()), "content": "x"}]
+
+    with (
+        patch("scripts.core.recall_learnings.get_backend", return_value="postgres"),
+        patch(
+            "scripts.core.recall_learnings._fetch_kg_rows",
+            new_callable=AsyncMock,
+            side_effect=_FakeTableError("relation kg_entity_mentions does not exist"),
+        ),
+    ):
+        with pytest.raises(_FakeTableError):
+            await enrich_with_kg_context(results)
+
+
+def test_fetch_kg_rows_query_shape_exposes_canonical_field():
+    """SQL query must return both display 'name' and canonical 'canonical'
+    so kg_overlap can match case- and path-canonicalized entity names."""
+    import inspect
+    from scripts.core import recall_learnings
+
+    src = inspect.getsource(recall_learnings._fetch_kg_rows)
+    # Both 'name' (display_name) and 'canonical' (normalized name) must be in SELECT.
+    assert "'name', e.display_name" in src
+    assert "'canonical', e.name" in src
+    # Edge cap is now SQL-side via LATERAL / subquery LIMIT.
+    assert "LIMIT $2" in src
+    assert "ORDER BY ed.weight DESC" in src
+
+
+@pytest.mark.asyncio
 async def test_enrich_with_kg_context_populates_matching_results():
     from scripts.core.recall_learnings import enrich_with_kg_context
 

--- a/tests/test_kg_enrichment.py
+++ b/tests/test_kg_enrichment.py
@@ -1,0 +1,200 @@
+"""Tests for knowledge-graph enrichment in recall_learnings.
+
+Phase 3 Commit A: fetch + enrichment plumbing. These tests drive the
+implementation of _fetch_kg_rows, build_kg_lookup, apply_kg_enrichment,
+and enrich_with_kg_context in scripts/core/recall_learnings.py.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# build_kg_lookup -- pure
+# ---------------------------------------------------------------------------
+
+
+def test_build_kg_lookup_empty_rows_returns_empty_dict():
+    from scripts.core.recall_learnings import build_kg_lookup
+
+    assert build_kg_lookup([]) == {}
+
+
+def test_build_kg_lookup_groups_entities_and_edges_by_memory_id():
+    from scripts.core.recall_learnings import build_kg_lookup
+
+    mid = uuid.uuid4()
+    rows = [
+        {
+            "id": mid,
+            "kg_entities": [
+                {"id": "e1", "name": "pytest", "type": "tool", "mention_count": 5},
+                {"id": "e2", "name": "asyncpg", "type": "library", "mention_count": 3},
+            ],
+            "kg_edges": [
+                {"source": "pytest", "target": "asyncpg", "relation": "used_with", "weight": 2.0},
+            ],
+        }
+    ]
+
+    lookup = build_kg_lookup(rows)
+
+    assert str(mid) in lookup
+    entry = lookup[str(mid)]
+    assert len(entry["entities"]) == 2
+    assert entry["entities"][0]["name"] == "pytest"
+    assert len(entry["edges"]) == 1
+    assert entry["edges"][0]["relation"] == "used_with"
+
+
+def test_build_kg_lookup_caps_edges_at_max_per_memory():
+    from scripts.core.recall_learnings import KG_MAX_EDGES_PER_MEMORY, build_kg_lookup
+
+    mid = uuid.uuid4()
+    edges = [
+        {"source": f"s{i}", "target": f"t{i}", "relation": "uses", "weight": float(i)}
+        for i in range(KG_MAX_EDGES_PER_MEMORY + 10)
+    ]
+    rows = [{"id": mid, "kg_entities": [], "kg_edges": edges}]
+
+    lookup = build_kg_lookup(rows)
+
+    capped = lookup[str(mid)]["edges"]
+    assert len(capped) == KG_MAX_EDGES_PER_MEMORY
+    # top-N by weight -> highest weights retained (sorted descending)
+    assert capped[0]["weight"] == float(KG_MAX_EDGES_PER_MEMORY + 10 - 1)
+    assert capped[-1]["weight"] >= 10.0  # 60 - 50 discarded = min kept weight 10
+
+
+# ---------------------------------------------------------------------------
+# apply_kg_enrichment -- pure
+# ---------------------------------------------------------------------------
+
+
+def test_apply_kg_enrichment_adds_kg_context_to_matching_results():
+    from scripts.core.recall_learnings import apply_kg_enrichment
+
+    mid = str(uuid.uuid4())
+    results = [{"id": mid, "content": "x"}]
+    lookup = {
+        mid: {
+            "entities": [{"name": "pytest", "type": "tool"}],
+            "edges": [],
+        }
+    }
+
+    enriched = apply_kg_enrichment(results, lookup)
+
+    assert "kg_context" in enriched[0]
+    assert enriched[0]["kg_context"]["entities"][0]["name"] == "pytest"
+
+
+def test_apply_kg_enrichment_omits_kg_context_for_non_matches():
+    from scripts.core.recall_learnings import apply_kg_enrichment
+
+    results = [{"id": "no-match", "content": "x"}]
+    lookup = {str(uuid.uuid4()): {"entities": [], "edges": []}}
+
+    enriched = apply_kg_enrichment(results, lookup)
+
+    assert "kg_context" not in enriched[0]
+
+
+def test_apply_kg_enrichment_does_not_mutate_input():
+    from scripts.core.recall_learnings import apply_kg_enrichment
+
+    mid = str(uuid.uuid4())
+    original = [{"id": mid, "content": "x"}]
+    lookup = {mid: {"entities": [{"name": "a", "type": "tool"}], "edges": []}}
+
+    _ = apply_kg_enrichment(original, lookup)
+
+    assert "kg_context" not in original[0]
+
+
+# ---------------------------------------------------------------------------
+# enrich_with_kg_context -- orchestrator (integration with get_backend + I/O)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_enrich_with_kg_context_empty_results_returns_empty():
+    from scripts.core.recall_learnings import enrich_with_kg_context
+
+    out = await enrich_with_kg_context([])
+
+    assert out == []
+
+
+@pytest.mark.asyncio
+async def test_enrich_with_kg_context_sqlite_returns_unchanged():
+    from scripts.core.recall_learnings import enrich_with_kg_context
+
+    results = [{"id": str(uuid.uuid4()), "content": "x"}]
+    with patch("scripts.core.recall_learnings.get_backend", return_value="sqlite"):
+        out = await enrich_with_kg_context(results)
+
+    assert out == results
+    assert "kg_context" not in out[0]
+
+
+@pytest.mark.asyncio
+async def test_enrich_with_kg_context_no_ids_returns_unchanged():
+    from scripts.core.recall_learnings import enrich_with_kg_context
+
+    results = [{"content": "no id"}]
+    with patch("scripts.core.recall_learnings.get_backend", return_value="postgres"):
+        out = await enrich_with_kg_context(results)
+
+    assert out == results
+
+
+@pytest.mark.asyncio
+async def test_enrich_with_kg_context_connection_error_non_fatal():
+    from scripts.core.recall_learnings import enrich_with_kg_context
+
+    results = [{"id": str(uuid.uuid4()), "content": "x"}]
+
+    with (
+        patch("scripts.core.recall_learnings.get_backend", return_value="postgres"),
+        patch(
+            "scripts.core.recall_learnings._fetch_kg_rows",
+            new_callable=AsyncMock,
+            side_effect=ConnectionError("KG table unavailable"),
+        ),
+    ):
+        out = await enrich_with_kg_context(results)
+
+    assert out == results
+    assert "kg_context" not in out[0]
+
+
+@pytest.mark.asyncio
+async def test_enrich_with_kg_context_populates_matching_results():
+    from scripts.core.recall_learnings import enrich_with_kg_context
+
+    mid = str(uuid.uuid4())
+    results = [{"id": mid, "content": "pytest + asyncpg"}]
+    rows = [
+        {
+            "id": uuid.UUID(mid),
+            "kg_entities": [{"id": "e1", "name": "pytest", "type": "tool", "mention_count": 1}],
+            "kg_edges": [],
+        }
+    ]
+
+    with (
+        patch("scripts.core.recall_learnings.get_backend", return_value="postgres"),
+        patch(
+            "scripts.core.recall_learnings._fetch_kg_rows",
+            new_callable=AsyncMock,
+            return_value=rows,
+        ),
+    ):
+        out = await enrich_with_kg_context(results)
+
+    assert "kg_context" in out[0]
+    assert out[0]["kg_context"]["entities"][0]["name"] == "pytest"

--- a/tests/test_kg_extractor.py
+++ b/tests/test_kg_extractor.py
@@ -258,3 +258,69 @@ class TestRealLearnings:
         types_found = {e.entity_type for e in entities}
         assert "config" in types_found  # OPC_DIR
         assert "tool" in types_found    # uv
+
+
+class TestRelationTypedResolution:
+    """Regression tests for typed entity resolution in relations (issue: overlapping names)."""
+
+    def test_pytest_overlapping_types_carry_entity_type(self):
+        """pytest appears as tool, module, and library — relations should carry types."""
+        content = "Using pytest to test the asyncpg connection pool"
+        entities = extract_entities(content)
+        pytest_entities = [e for e in entities if e.name == "pytest"]
+        # pytest should be extracted as at least tool and library
+        pytest_types = {e.entity_type for e in pytest_entities}
+        assert len(pytest_types) >= 2, f"Expected multiple types for pytest, got {pytest_types}"
+
+        relations = extract_relations(content, entities)
+        # Relations should have source_type and target_type set
+        for rel in relations:
+            assert rel.source_type is not None, (
+                f"Relation {rel.source}->{rel.target} missing source_type"
+            )
+            assert rel.target_type is not None, (
+                f"Relation {rel.source}->{rel.target} missing target_type"
+            )
+
+    def test_overlapping_names_produce_typed_dedup(self):
+        """Same-name entities with different types get separate relations."""
+        content = "Using pytest to test the asyncpg connection pool"
+        entities = extract_entities(content)
+        relations = extract_relations(content, entities)
+
+        # With type-aware dedup, pytest-as-tool and pytest-as-library
+        # should each get their own relation to asyncpg
+        pytest_asyncpg_rels = [
+            r for r in relations
+            if r.source == "pytest" and r.target == "asyncpg"
+        ]
+        source_types = {r.source_type for r in pytest_asyncpg_rels}
+        # Should have at least 2 different source types (tool, library)
+        assert len(source_types) >= 2, (
+            f"Expected multiple typed relations for pytest->asyncpg, "
+            f"got source_types={source_types}"
+        )
+
+    def test_deterministic_relations_across_runs(self):
+        """Same input must produce identical relations every time."""
+        content = "Using pytest to test the asyncpg connection pool"
+        # Run extraction 10 times and verify all produce identical output
+        baseline_entities = extract_entities(content)
+        baseline_rels = extract_relations(content, baseline_entities)
+        baseline_keys = sorted(
+            (r.source, r.source_type, r.target, r.target_type, r.relation)
+            for r in baseline_rels
+        )
+
+        for _ in range(9):
+            entities = extract_entities(content)
+            rels = extract_relations(content, entities)
+            keys = sorted(
+                (r.source, r.source_type, r.target, r.target_type, r.relation)
+                for r in rels
+            )
+            assert keys == baseline_keys, (
+                f"Nondeterministic relation output:\n"
+                f"  baseline: {baseline_keys}\n"
+                f"  this run: {keys}"
+            )

--- a/tests/test_kg_extractor.py
+++ b/tests/test_kg_extractor.py
@@ -1,0 +1,260 @@
+"""Tests for knowledge graph entity and relationship extraction."""
+
+from scripts.core.kg_extractor import (
+    extract_entities,
+    extract_relations,
+)
+
+# ---------------------------------------------------------------------------
+# Entity extraction tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractFilePaths:
+    def test_simple_path(self):
+        entities = extract_entities("Modified scripts/core/reranker.py to add weights")
+        names = {e.name for e in entities if e.entity_type == "file"}
+        assert "scripts/core/reranker.py" in names
+
+    def test_path_with_extension_only(self):
+        entities = extract_entities("Edit the config.yaml file")
+        names = {e.name for e in entities if e.entity_type == "file"}
+        assert "config.yaml" in names
+
+    def test_nested_path(self):
+        entities = extract_entities("See hooks/ts/src/shared/db.ts for details")
+        names = {e.name for e in entities if e.entity_type == "file"}
+        assert "hooks/ts/src/shared/db.ts" in names
+
+    def test_no_false_version_numbers(self):
+        entities = extract_entities("Python 3.12 is required")
+        file_names = {e.name for e in entities if e.entity_type == "file"}
+        assert "3.12" not in file_names
+
+
+class TestExtractPythonImports:
+    def test_from_import(self):
+        entities = extract_entities("from scripts.core.reranker import rerank")
+        names = {e.name for e in entities if e.entity_type == "module"}
+        assert "scripts.core.reranker" in names
+
+    def test_plain_import(self):
+        entities = extract_entities("import asyncpg")
+        names = {e.name for e in entities if e.entity_type == "module"}
+        assert "asyncpg" in names
+
+
+class TestExtractEnvVars:
+    def test_database_url(self):
+        entities = extract_entities("Set DATABASE_URL to connect")
+        names = {e.name for e in entities if e.entity_type == "config"}
+        assert "database_url" in names
+
+    def test_voyage_api_key(self):
+        entities = extract_entities("Export VOYAGE_API_KEY before running")
+        names = {e.name for e in entities if e.entity_type == "config"}
+        assert "voyage_api_key" in names
+
+    def test_no_short_caps(self):
+        """Single-word ALL_CAPS without underscores should not match."""
+        entities = extract_entities("The URL is important")
+        config_names = {e.name for e in entities if e.entity_type == "config"}
+        assert "URL" not in config_names
+
+
+class TestExtractErrors:
+    def test_import_error(self):
+        entities = extract_entities("Got ImportError when loading the module")
+        names = {e.name for e in entities if e.entity_type == "error"}
+        assert "importerror" in names
+
+    def test_connection_refused(self):
+        entities = extract_entities("ConnectionRefusedError on startup")
+        names = {e.name for e in entities if e.entity_type == "error"}
+        assert "connectionrefusederror" in names
+
+
+class TestExtractTools:
+    def test_docker(self):
+        entities = extract_entities("Run docker compose up to start")
+        names = {e.name for e in entities if e.entity_type == "tool"}
+        assert "docker" in names
+
+    def test_pytest(self):
+        entities = extract_entities("Use pytest to run the test suite")
+        names = {e.name for e in entities if e.entity_type == "tool"}
+        assert "pytest" in names
+
+
+class TestExtractLanguages:
+    def test_python(self):
+        entities = extract_entities("Written in Python with type hints")
+        names = {e.name for e in entities if e.entity_type == "language"}
+        assert "python" in names
+
+    def test_typescript(self):
+        entities = extract_entities("Hooks are TypeScript compiled to JS")
+        names = {e.name for e in entities if e.entity_type == "language"}
+        assert "typescript" in names
+
+
+class TestExtractLibraries:
+    def test_pgvector(self):
+        entities = extract_entities("Using pgvector for similarity search")
+        names = {e.name for e in entities if e.entity_type == "library"}
+        assert "pgvector" in names
+
+    def test_asyncpg(self):
+        entities = extract_entities("asyncpg pool for database connections")
+        names = {e.name for e in entities if e.entity_type == "library"}
+        assert "asyncpg" in names
+
+
+class TestExtractConcepts:
+    def test_backtick_concept(self):
+        entities = extract_entities("The `semantic dedup` feature prevents duplicates")
+        names = {e.name for e in entities if e.entity_type == "concept"}
+        assert "semantic dedup" in names
+
+    def test_no_duplicate_with_other_type(self):
+        """A backtick term already captured as a tool should not also be a concept."""
+        entities = extract_entities("Use `docker` to run containers")
+        concept_names = {e.name for e in entities if e.entity_type == "concept"}
+        assert "docker" not in concept_names
+
+
+class TestDeduplication:
+    def test_same_entity_mentioned_twice(self):
+        content = "reranker.py handles scoring. See reranker.py for details."
+        entities = extract_entities(content)
+        file_entities = [e for e in entities if e.name == "reranker.py"]
+        assert len(file_entities) == 1
+
+    def test_different_types_not_deduped(self):
+        """Same name but different type should produce two entities."""
+        content = "import pytest; Use pytest to run tests"
+        entities = extract_entities(content)
+        pytest_entities = [e for e in entities if "pytest" in e.name]
+        types = {e.entity_type for e in pytest_entities}
+        # Should have both module and tool (or library)
+        assert len(types) >= 2
+
+
+class TestEdgeCases:
+    def test_empty_content(self):
+        assert extract_entities("") == []
+
+    def test_no_entities(self):
+        entities = extract_entities("This is a simple sentence with no technical terms.")
+        # May still find some noise, but should be minimal
+        assert isinstance(entities, list)
+
+    def test_noise_filtering(self):
+        entities = extract_entities("The value is true and not false")
+        names = {e.name for e in entities}
+        assert "true" not in names
+        assert "false" not in names
+
+
+# ---------------------------------------------------------------------------
+# Relation extraction tests
+# ---------------------------------------------------------------------------
+
+
+class TestRelationExtraction:
+    def test_related_to_in_same_sentence(self):
+        content = "pgvector handles vector search in PostgreSQL"
+        entities = extract_entities(content)
+        relations = extract_relations(content, entities)
+        assert len(relations) > 0
+        rel_types = {r.relation for r in relations}
+        assert "related_to" in rel_types or "uses" in rel_types
+
+    def test_solves_relation(self):
+        content = "ruff fixes the ImportError in the linter pipeline"
+        entities = extract_entities(content)
+        relations = extract_relations(content, entities)
+        solves = [r for r in relations if r.relation == "solves"]
+        assert len(solves) > 0
+
+    def test_supersedes_relation(self):
+        content = "asyncpg replaced psycopg2 as the database driver"
+        entities = extract_entities(content)
+        relations = extract_relations(content, entities)
+        supers = [r for r in relations if r.relation == "supersedes"]
+        assert len(supers) > 0
+
+    def test_uses_relation(self):
+        content = "recall_learnings.py uses the reranker.py module"
+        entities = extract_entities(content)
+        relations = extract_relations(content, entities)
+        uses = [r for r in relations if r.relation == "uses"]
+        assert len(uses) > 0
+
+    def test_no_self_relation(self):
+        content = "docker uses docker to build containers"
+        entities = extract_entities(content)
+        relations = extract_relations(content, entities)
+        self_rels = [r for r in relations if r.source == r.target]
+        assert len(self_rels) == 0
+
+    def test_fewer_than_two_entities(self):
+        content = "Just docker alone"
+        entities = extract_entities(content)
+        # Even with 1 entity, should not crash
+        relations = extract_relations(content, entities)
+        assert relations == []
+
+    def test_directory_containment(self):
+        content = "Modified scripts/core/reranker.py and scripts/core/store_learning.py"
+        entities = extract_entities(content)
+        relations = extract_relations(content, entities)
+        contains = [r for r in relations if r.relation == "contains"]
+        assert len(contains) > 0
+
+    def test_conflicts_relation(self):
+        content = "pgvector conflicts with the old sqlite backend"
+        entities = extract_entities(content)
+        relations = extract_relations(content, entities)
+        conflicts = [r for r in relations if r.relation == "conflicts_with"]
+        assert len(conflicts) > 0
+
+
+# ---------------------------------------------------------------------------
+# Integration-style tests (extraction on real-ish learnings)
+# ---------------------------------------------------------------------------
+
+
+class TestRealLearnings:
+    def test_sample_learning_1(self):
+        content = (
+            "Using localhost:11434 or a LAN IP for Ollama from inside a Docker "
+            "container fails silently. The describe_photo function catches the "
+            "ConnectionRefusedError. Fix: use host.docker.internal instead."
+        )
+        entities = extract_entities(content)
+        types = {e.entity_type for e in entities}
+        assert "error" in types  # ConnectionRefusedError
+        assert "tool" in types   # docker
+
+    def test_sample_learning_2(self):
+        content = (
+            "pgvector cosine distance ranges from 0 to 2, not 0 to 1. "
+            "When converting distance to a similarity score, use: "
+            "score = 1 - (distance / 2). This affects scripts/core/recall_backends.py."
+        )
+        entities = extract_entities(content)
+        names = {e.name for e in entities}
+        assert "scripts/core/recall_backends.py" in names
+        assert "pgvector" in names
+
+    def test_sample_learning_3(self):
+        content = (
+            "subprocess.run(..., cwd=OPC_DIR) changes directory AFTER command setup. "
+            "When using `uv run python scripts/core/script.py` with a relative path, "
+            "uv resolves the path from the original cwd, not the target."
+        )
+        entities = extract_entities(content)
+        types_found = {e.entity_type for e in entities}
+        assert "config" in types_found  # OPC_DIR
+        assert "tool" in types_found    # uv

--- a/tests/test_recall_formatters.py
+++ b/tests/test_recall_formatters.py
@@ -40,6 +40,7 @@ def _make_result(
     recall_count: int = 0,
     pattern_strength: float = 0.0,
     pattern_tags: list | None = None,
+    kg_context: dict | None = None,
 ) -> dict:
     """Factory for building result dicts matching the recall pipeline shape."""
     result = {
@@ -57,6 +58,8 @@ def _make_result(
         result["final_score"] = final_score
     if rerank_details is not None:
         result["rerank_details"] = rerank_details
+    if kg_context is not None:
+        result["kg_context"] = kg_context
     return result
 
 
@@ -664,3 +667,45 @@ class TestGroupByType:
         group_by_type(results)
         assert results[0] == original[0]
         assert results[1] == original[1]
+
+
+# ---------------------------------------------------------------------------
+# KG context serialization (Phase 3 fix for D2/E1 finding)
+# ---------------------------------------------------------------------------
+
+
+class TestKGContextSerialization:
+    _KG_CTX = {
+        "entities": [
+            {"id": "e1", "name": "pytest", "type": "tool", "mention_count": 5}
+        ],
+        "edges": [
+            {"source": "pytest", "target": "asyncpg", "relation": "used_with",
+             "weight": 2.0}
+        ],
+    }
+
+    def test_build_json_result_includes_kg_context(self):
+        r = _make_result(kg_context=self._KG_CTX)
+        out = _build_json_result(r)
+        assert out["kg_context"] == self._KG_CTX
+
+    def test_build_json_result_omits_kg_context_when_absent(self):
+        r = _make_result()
+        out = _build_json_result(r)
+        assert "kg_context" not in out
+
+    def test_format_json_output_round_trips_kg_context(self):
+        r = _make_result(kg_context=self._KG_CTX)
+        payload = json.loads(format_json_output([r]))
+        assert payload["results"][0]["kg_context"] == self._KG_CTX
+
+    def test_format_json_full_output_round_trips_kg_context(self):
+        r = _make_result(kg_context=self._KG_CTX)
+        payload = json.loads(format_json_full_output([r]))
+        assert payload["results"][0]["kg_context"] == self._KG_CTX
+
+    def test_format_json_output_no_kg_key_when_absent(self):
+        r = _make_result()
+        payload = json.loads(format_json_output([r]))
+        assert "kg_context" not in payload["results"][0]

--- a/tests/test_recall_kg_integration.py
+++ b/tests/test_recall_kg_integration.py
@@ -127,6 +127,38 @@ async def test_kg_weight_zero_produces_no_boost():
 
 
 @pytest.mark.asyncio
+async def test_make_recall_context_caps_query_for_extraction():
+    """Aegis LOW-1 fix: make_recall_context must not feed unbounded queries
+    to kg_extractor (regex CPU blowup). The cap is applied before extraction
+    so the extractor only ever sees up to _KG_QUERY_EXTRACTION_MAX_CHARS."""
+    from unittest.mock import MagicMock
+    from scripts.core.recall_learnings import (
+        _KG_QUERY_EXTRACTION_MAX_CHARS,
+        make_recall_context,
+    )
+
+    giant_query = "x" * (_KG_QUERY_EXTRACTION_MAX_CHARS * 4) + " pytest"
+
+    fake_extract = MagicMock(return_value=[])
+    with (
+        patch("scripts.core.recall_learnings.get_backend", return_value="postgres"),
+        patch(
+            "scripts.core.kg_extractor.extract_entities",
+            fake_extract,
+        ),
+    ):
+        make_recall_context(
+            project=None, tags=None, retrieval_mode="vector", query=giant_query,
+        )
+
+    fake_extract.assert_called_once()
+    call_arg = fake_extract.call_args[0][0]
+    assert len(call_arg) == _KG_QUERY_EXTRACTION_MAX_CHARS
+    # The cap truncates from the end, so the tail ("pytest") is dropped.
+    assert call_arg == "x" * _KG_QUERY_EXTRACTION_MAX_CHARS
+
+
+@pytest.mark.asyncio
 async def test_sqlite_backend_skips_kg_path_end_to_end():
     """sqlite backend: no query entities extracted, no kg_context attached."""
     mid = str(uuid.uuid4())

--- a/tests/test_recall_kg_integration.py
+++ b/tests/test_recall_kg_integration.py
@@ -1,0 +1,143 @@
+"""Phase 3 Commit C: integration tests for query-side KG flow.
+
+Exercises make_recall_context (entity extraction), enrich_with_kg_context
+(fetch plumbing from Commit A), and rerank()+kg_overlap (signal from
+Commit B) end-to-end. DB boundary is mocked via _fetch_kg_rows so these
+run without a live Postgres.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from scripts.core.recall_learnings import (
+    enrich_with_kg_context,
+    make_recall_context,
+)
+from scripts.core.reranker import RerankerConfig, rerank
+
+
+def _mk_result(rid: str, similarity: float, content: str = "") -> dict:
+    return {
+        "id": rid,
+        "session_id": "s",
+        "content": content,
+        "metadata": {"type": "session_learning"},
+        "similarity": similarity,
+    }
+
+
+@pytest.mark.asyncio
+async def test_postgres_query_populates_kg_context_and_query_entities():
+    """End-to-end: query with known entity -> context.query_entities populated,
+    enrichment attaches kg_context, rerank boosts matching result."""
+    mid_match = str(uuid.uuid4())
+    mid_miss = str(uuid.uuid4())
+    results = [
+        _mk_result(mid_miss, similarity=0.5, content="generic stuff"),
+        _mk_result(mid_match, similarity=0.5, content="uses pytest heavily"),
+    ]
+
+    rows = [
+        {
+            "id": uuid.UUID(mid_match),
+            "kg_entities": [
+                {"id": "e1", "name": "pytest", "type": "tool", "mention_count": 10}
+            ],
+            "kg_edges": [],
+        }
+    ]
+
+    with (
+        patch("scripts.core.recall_learnings.get_backend", return_value="postgres"),
+        patch(
+            "scripts.core.recall_learnings._fetch_kg_rows",
+            new_callable=AsyncMock,
+            return_value=rows,
+        ),
+    ):
+        ctx = make_recall_context(
+            project=None, tags=None, retrieval_mode="vector",
+            query="how do I use pytest in async tests",
+        )
+        enriched = await enrich_with_kg_context(results)
+
+    assert ctx.query_entities is not None
+    assert any(e["name"] == "pytest" for e in ctx.query_entities)
+
+    matching = next(r for r in enriched if r["id"] == mid_match)
+    missing = next(r for r in enriched if r["id"] == mid_miss)
+    assert "kg_context" in matching
+    assert "kg_context" not in missing
+
+    # With kg_weight > 0, matching outranks missing even at equal similarity.
+    config = RerankerConfig(
+        project_weight=0.0, recency_weight=0.0, confidence_weight=0.0,
+        recall_weight=0.0, type_affinity_weight=0.0, tag_overlap_weight=0.0,
+        pattern_weight=0.0, kg_weight=0.3,
+    )
+    ranked = rerank(enriched, ctx, config=config, k=2)
+    assert ranked[0]["id"] == mid_match
+
+
+@pytest.mark.asyncio
+async def test_kg_weight_zero_produces_no_boost():
+    """With kg_weight=0, ordering reflects retrieval only (no KG effect)."""
+    mid_match = str(uuid.uuid4())
+    mid_miss = str(uuid.uuid4())
+    results = [
+        _mk_result(mid_miss, similarity=0.9),    # higher retrieval
+        _mk_result(mid_match, similarity=0.3),   # lower retrieval
+    ]
+
+    rows = [
+        {
+            "id": uuid.UUID(mid_match),
+            "kg_entities": [
+                {"id": "e1", "name": "pytest", "type": "tool", "mention_count": 1}
+            ],
+            "kg_edges": [],
+        }
+    ]
+
+    with (
+        patch("scripts.core.recall_learnings.get_backend", return_value="postgres"),
+        patch(
+            "scripts.core.recall_learnings._fetch_kg_rows",
+            new_callable=AsyncMock,
+            return_value=rows,
+        ),
+    ):
+        ctx = make_recall_context(
+            project=None, tags=None, retrieval_mode="vector", query="pytest tricks",
+        )
+        enriched = await enrich_with_kg_context(results)
+
+    config = RerankerConfig(
+        project_weight=0.0, recency_weight=0.0, confidence_weight=0.0,
+        recall_weight=0.0, type_affinity_weight=0.0, tag_overlap_weight=0.0,
+        pattern_weight=0.0, kg_weight=0.0,
+    )
+    ranked = rerank(enriched, ctx, config=config, k=2)
+    # Retrieval-only: higher similarity wins.
+    assert ranked[0]["id"] == mid_miss
+
+
+@pytest.mark.asyncio
+async def test_sqlite_backend_skips_kg_path_end_to_end():
+    """sqlite backend: no query entities extracted, no kg_context attached."""
+    mid = str(uuid.uuid4())
+    results = [_mk_result(mid, similarity=0.5, content="pytest mention")]
+
+    with patch("scripts.core.recall_learnings.get_backend", return_value="sqlite"):
+        ctx = make_recall_context(
+            project=None, tags=None, retrieval_mode="sqlite",
+            query="anything involving pytest",
+        )
+        enriched = await enrich_with_kg_context(results)
+
+    assert ctx.query_entities is None
+    assert "kg_context" not in enriched[0]

--- a/tests/test_recall_reranking.py
+++ b/tests/test_recall_reranking.py
@@ -128,6 +128,8 @@ class TestProjectFlag:
                 return_value=fake_results,
             ),
             patch("scripts.core.recall_learnings.record_recall", new_callable=AsyncMock),
+            patch("scripts.core.recall_learnings.enrich_with_kg_context", new_callable=AsyncMock, side_effect=lambda rs: rs),
+            patch("scripts.core.recall_learnings.enrich_with_pattern_strength", new_callable=AsyncMock, side_effect=lambda rs: rs),
             patch("scripts.core.reranker.rerank", side_effect=spy_rerank),
             patch("sys.argv", ["recall", "--query", "test", "--k", "3", "--project", "my-project", "--json"]),
         ):
@@ -161,6 +163,8 @@ class TestAdaptiveOverfetch:
                 return_value=fake_results,
             ) as mock_search,
             patch("scripts.core.recall_learnings.record_recall", new_callable=AsyncMock),
+            patch("scripts.core.recall_learnings.enrich_with_kg_context", new_callable=AsyncMock, side_effect=lambda rs: rs),
+            patch("scripts.core.recall_learnings.enrich_with_pattern_strength", new_callable=AsyncMock, side_effect=lambda rs: rs),
             patch("sys.argv", ["recall", "--query", "test", "--k", "5", "--json"]),
         ):
             from scripts.core.recall_learnings import main
@@ -190,6 +194,8 @@ class TestAdaptiveOverfetch:
                 return_value=fake_results,
             ) as mock_search,
             patch("scripts.core.recall_learnings.record_recall", new_callable=AsyncMock),
+            patch("scripts.core.recall_learnings.enrich_with_kg_context", new_callable=AsyncMock, side_effect=lambda rs: rs),
+            patch("scripts.core.recall_learnings.enrich_with_pattern_strength", new_callable=AsyncMock, side_effect=lambda rs: rs),
             patch("sys.argv", ["recall", "--query", "test", "--k", "25", "--json"]),
         ):
             from scripts.core.recall_learnings import main
@@ -216,6 +222,8 @@ class TestAdaptiveOverfetch:
                 return_value=fake_results,
             ) as mock_search,
             patch("scripts.core.recall_learnings.record_recall", new_callable=AsyncMock),
+            patch("scripts.core.recall_learnings.enrich_with_kg_context", new_callable=AsyncMock, side_effect=lambda rs: rs),
+            patch("scripts.core.recall_learnings.enrich_with_pattern_strength", new_callable=AsyncMock, side_effect=lambda rs: rs),
             patch("sys.argv", ["recall", "--query", "test", "--k", "5", "--no-rerank", "--json"]),
         ):
             from scripts.core.recall_learnings import main
@@ -304,6 +312,8 @@ class TestJsonOutputWithRerank:
                 return_value=fake_results,
             ),
             patch("scripts.core.recall_learnings.record_recall", new_callable=AsyncMock),
+            patch("scripts.core.recall_learnings.enrich_with_kg_context", new_callable=AsyncMock, side_effect=lambda rs: rs),
+            patch("scripts.core.recall_learnings.enrich_with_pattern_strength", new_callable=AsyncMock, side_effect=lambda rs: rs),
             patch("sys.argv", ["recall", "--query", "test", "--k", "3", "--json"]),
         ):
             from scripts.core.recall_learnings import main
@@ -348,6 +358,8 @@ class TestRetrievalModeDetection:
                 return_value=fake_results,
             ),
             patch("scripts.core.recall_learnings.record_recall", new_callable=AsyncMock),
+            patch("scripts.core.recall_learnings.enrich_with_kg_context", new_callable=AsyncMock, side_effect=lambda rs: rs),
+            patch("scripts.core.recall_learnings.enrich_with_pattern_strength", new_callable=AsyncMock, side_effect=lambda rs: rs),
             patch("sys.argv", ["recall", "--query", "test", "--k", "3", "--text-only", "--json"]),
         ):
             # Patch the reranker module-level function so the lazy import picks it up
@@ -379,6 +391,8 @@ class TestRetrievalModeDetection:
                 return_value=fake_results,
             ),
             patch("scripts.core.recall_learnings.record_recall", new_callable=AsyncMock),
+            patch("scripts.core.recall_learnings.enrich_with_kg_context", new_callable=AsyncMock, side_effect=lambda rs: rs),
+            patch("scripts.core.recall_learnings.enrich_with_pattern_strength", new_callable=AsyncMock, side_effect=lambda rs: rs),
             patch("sys.argv", ["recall", "--query", "test", "--k", "3", "--json"]),
         ):
             with patch("scripts.core.reranker.rerank", side_effect=spy_rerank):
@@ -409,6 +423,8 @@ class TestRetrievalModeDetection:
                 return_value=fake_results,
             ),
             patch("scripts.core.recall_learnings.record_recall", new_callable=AsyncMock),
+            patch("scripts.core.recall_learnings.enrich_with_kg_context", new_callable=AsyncMock, side_effect=lambda rs: rs),
+            patch("scripts.core.recall_learnings.enrich_with_pattern_strength", new_callable=AsyncMock, side_effect=lambda rs: rs),
             patch("sys.argv", ["recall", "--query", "test", "--k", "3", "--json"]),
         ):
             with patch("scripts.core.reranker.rerank", side_effect=spy_rerank):

--- a/tests/test_reranker.py
+++ b/tests/test_reranker.py
@@ -19,6 +19,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from scripts.core.reranker import (  # noqa: E402
+    KG_TYPE_WEIGHTS,
     RecallContext,
     RerankerConfig,
     _cosine_similarity,
@@ -26,6 +27,7 @@ from scripts.core.reranker import (  # noqa: E402
     compute_type_centroids,
     confidence_score,
     infer_query_type,
+    kg_overlap,
     load_centroids,
     pattern_score,
     project_match,
@@ -664,7 +666,9 @@ class TestRerankerConfigDefaults:
 
     def test_default_total_signal_weight(self):
         config = RerankerConfig()
-        expected = 0.15 + 0.05 + 0.05 + 0.05 + 0.05 + 0.05 + 0.05
+        # project + 7 secondary signals (recency, confidence, recall,
+        # type_affinity, tag_overlap, pattern, kg) -- all at default 0.05.
+        expected = 0.15 + 0.05 * 7
         assert abs(config.total_signal_weight - expected) < 1e-9
 
 
@@ -729,3 +733,150 @@ class TestRecallScoreWithConfig:
         expected = min(1.0, math.log2(1 + 3) / 4.0)
         score = recall_score(result, config=config)
         assert abs(score - expected) < 0.01
+
+
+# ---------------------------------------------------------------------------
+# Signal Function Tests: kg_overlap (Phase 3)
+# ---------------------------------------------------------------------------
+
+
+def _result_with_kg(entities: list[dict]) -> dict:
+    """Build a result dict carrying a kg_context entities list."""
+    result = _make_result()
+    result["kg_context"] = {"entities": entities, "edges": []}
+    return result
+
+
+class TestKGOverlap:
+    def test_zero_when_query_entities_none(self):
+        result = _result_with_kg([{"name": "pytest", "type": "tool"}])
+        ctx = RecallContext(query_entities=None)
+        assert kg_overlap(result, ctx) == 0.0
+
+    def test_zero_when_query_entities_empty(self):
+        result = _result_with_kg([{"name": "pytest", "type": "tool"}])
+        ctx = RecallContext(query_entities=[])
+        assert kg_overlap(result, ctx) == 0.0
+
+    def test_zero_when_result_has_no_kg_context(self):
+        result = _make_result()  # no kg_context key
+        ctx = RecallContext(query_entities=[{"name": "pytest", "type": "tool"}])
+        assert kg_overlap(result, ctx) == 0.0
+
+    def test_one_point_zero_on_identical_sets(self):
+        entities = [
+            {"name": "pytest", "type": "tool"},
+            {"name": "store_learning.py", "type": "file"},
+        ]
+        result = _result_with_kg(entities)
+        ctx = RecallContext(query_entities=list(entities))
+        assert kg_overlap(result, ctx) == 1.0
+
+    def test_partial_overlap_between_zero_and_one(self):
+        result = _result_with_kg([
+            {"name": "pytest", "type": "tool"},
+            {"name": "asyncpg", "type": "library"},
+        ])
+        ctx = RecallContext(query_entities=[{"name": "pytest", "type": "tool"}])
+        score = kg_overlap(result, ctx)
+        assert 0.0 < score < 1.0
+
+    def test_case_insensitive_name_match(self):
+        result = _result_with_kg([{"name": "Pytest", "type": "tool"}])
+        ctx = RecallContext(query_entities=[{"name": "PYTEST", "type": "tool"}])
+        assert kg_overlap(result, ctx) == 1.0
+
+    def test_file_type_overlap_scores_higher_than_language(self):
+        """Type weights: file (1.0) > language (0.4) for equal-size overlap."""
+        file_result = _result_with_kg([{"name": "a.py", "type": "file"}])
+        file_ctx = RecallContext(query_entities=[{"name": "a.py", "type": "file"}])
+        lang_result = _result_with_kg([{"name": "python", "type": "language"}])
+        lang_ctx = RecallContext(query_entities=[{"name": "python", "type": "language"}])
+        # Both are full matches in their own set, so weighted-Jaccard = 1.0 for
+        # each individually. The differentiation appears when mixed with
+        # non-matching entities of the same type. Test a mixed case instead.
+
+        mixed_result = _result_with_kg([
+            {"name": "a.py", "type": "file"},
+            {"name": "b.py", "type": "file"},        # not in query
+            {"name": "python", "type": "language"},
+            {"name": "ruby", "type": "language"},    # not in query
+        ])
+        file_match_ctx = RecallContext(
+            query_entities=[{"name": "a.py", "type": "file"}]
+        )
+        lang_match_ctx = RecallContext(
+            query_entities=[{"name": "python", "type": "language"}]
+        )
+        file_score = kg_overlap(mixed_result, file_match_ctx)
+        lang_score = kg_overlap(mixed_result, lang_match_ctx)
+        # file weight (1.0) >> language weight (0.4), so overlap contributes
+        # relatively more when the matching entity is typed 'file'.
+        assert file_score > lang_score
+        # Sanity: individual full matches are still 1.0
+        assert kg_overlap(file_result, file_ctx) == 1.0
+        assert kg_overlap(lang_result, lang_ctx) == 1.0
+
+    def test_type_weights_table_has_expected_entries(self):
+        """KG_TYPE_WEIGHTS covers the entity types emitted by kg_extractor."""
+        required = {"file", "module", "library", "tool", "language", "concept", "error"}
+        assert required.issubset(set(KG_TYPE_WEIGHTS.keys()))
+        assert KG_TYPE_WEIGHTS["file"] > KG_TYPE_WEIGHTS["language"]
+
+
+class TestRerankKGWeight:
+    def test_rerank_boosts_kg_matches_when_weight_positive(self):
+        """With kg_weight > 0, a matching result ranks above a non-matching one
+        that would otherwise be tied on retrieval."""
+        matching = _result_with_kg([{"name": "pytest", "type": "tool"}])
+        matching["id"] = "matching"
+        non_matching = _result_with_kg([{"name": "other", "type": "tool"}])
+        non_matching["id"] = "non_matching"
+
+        ctx = RecallContext(
+            query_entities=[{"name": "pytest", "type": "tool"}],
+            retrieval_mode="vector",
+        )
+        # Kill all other signal weights to isolate kg_weight effect.
+        config = RerankerConfig(
+            project_weight=0.0,
+            recency_weight=0.0,
+            confidence_weight=0.0,
+            recall_weight=0.0,
+            type_affinity_weight=0.0,
+            tag_overlap_weight=0.0,
+            pattern_weight=0.0,
+            kg_weight=0.2,
+        )
+
+        ranked = rerank([non_matching, matching], ctx, config=config, k=2)
+        assert ranked[0]["id"] == "matching"
+        assert "kg_overlap" in ranked[0]["rerank_details"]
+
+    def test_rerank_zero_kg_weight_is_noop(self):
+        """With kg_weight=0.0, ranking is unchanged from non-KG scoring."""
+        matching = _result_with_kg([{"name": "pytest", "type": "tool"}])
+        matching["id"] = "matching"
+        matching["similarity"] = 0.3  # lower retrieval
+        non_matching = _result_with_kg([{"name": "other", "type": "tool"}])
+        non_matching["id"] = "non_matching"
+        non_matching["similarity"] = 0.9  # higher retrieval
+
+        ctx = RecallContext(
+            query_entities=[{"name": "pytest", "type": "tool"}],
+            retrieval_mode="vector",
+        )
+        config = RerankerConfig(
+            project_weight=0.0,
+            recency_weight=0.0,
+            confidence_weight=0.0,
+            recall_weight=0.0,
+            type_affinity_weight=0.0,
+            tag_overlap_weight=0.0,
+            pattern_weight=0.0,
+            kg_weight=0.0,
+        )
+
+        ranked = rerank([matching, non_matching], ctx, config=config, k=2)
+        # Retrieval dominates: non_matching wins.
+        assert ranked[0]["id"] == "non_matching"

--- a/tests/test_reranker.py
+++ b/tests/test_reranker.py
@@ -878,6 +878,60 @@ class TestRerankKGWeight:
         assert ranked[0]["id"] == "matching"
         assert "kg_overlap" in ranked[0]["rerank_details"]
 
+    def test_kg_inactive_scores_match_pre_phase3_exactly(self):
+        """Finding D1 fix: when KG is inactive (no query entities OR no
+        result carries kg_context), final_score must be byte-identical to
+        the pre-Phase-3 reranker with kg_weight=0. Proves kg_weight is
+        redirected to retrieval, not deducted. Load-bearing invariant."""
+        # Two results, no kg_context attached, no query entities.
+        results = [
+            {"id": "a", "session_id": "s", "content": "x",
+             "metadata": {"learning_type": "WORKING_SOLUTION"}, "similarity": 0.5},
+            {"id": "b", "session_id": "s", "content": "y",
+             "metadata": {"learning_type": "ERROR_FIX"}, "similarity": 0.3},
+        ]
+        ctx_active_but_empty = RecallContext(
+            query_entities=None, retrieval_mode="vector",
+        )
+        # Reference: pre-Phase-3 behavior simulated by kg_weight=0.
+        ref_config = RerankerConfig(kg_weight=0.0)
+        # Current config: kg_weight=0.05 default.
+        current_config = RerankerConfig()
+
+        ref_ranked = rerank(
+            [dict(r) for r in results], ctx_active_but_empty,
+            config=ref_config, k=2,
+        )
+        cur_ranked = rerank(
+            [dict(r) for r in results], ctx_active_but_empty,
+            config=current_config, k=2,
+        )
+        # Byte-identical final_score, byte-identical order.
+        assert [r["id"] for r in ref_ranked] == [r["id"] for r in cur_ranked]
+        for ref_r, cur_r in zip(ref_ranked, cur_ranked):
+            assert ref_r["final_score"] == cur_r["final_score"], (
+                f"Score drift on {ref_r['id']}: "
+                f"ref={ref_r['final_score']} vs cur={cur_r['final_score']}"
+            )
+
+    def test_kg_active_flag_reported_in_rerank_details(self):
+        """Operators need to tell which mode was used. kg_active lands in
+        rerank_details."""
+        active_result = _result_with_kg([{"name": "pytest", "type": "tool"}])
+        active_result["id"] = "active"
+        ctx_active = RecallContext(
+            query_entities=[{"name": "pytest", "type": "tool"}],
+            retrieval_mode="vector",
+        )
+        ranked_active = rerank([active_result], ctx_active, k=1)
+        assert ranked_active[0]["rerank_details"]["kg_active"] is True
+
+        inactive_result = dict(active_result)
+        inactive_result.pop("kg_context")
+        ctx_inactive = RecallContext(retrieval_mode="vector")
+        ranked_inactive = rerank([inactive_result], ctx_inactive, k=1)
+        assert ranked_inactive[0]["rerank_details"]["kg_active"] is False
+
     def test_rerank_zero_kg_weight_is_noop(self):
         """With kg_weight=0.0, ranking is unchanged from non-KG scoring."""
         matching = _result_with_kg([{"name": "pytest", "type": "tool"}])

--- a/tests/test_reranker.py
+++ b/tests/test_reranker.py
@@ -823,6 +823,31 @@ class TestKGOverlap:
         assert required.issubset(set(KG_TYPE_WEIGHTS.keys()))
         assert KG_TYPE_WEIGHTS["file"] > KG_TYPE_WEIGHTS["language"]
 
+    def test_canonical_field_matches_across_case_and_path_norm(self):
+        """Finding F1 fix: when kg_context entities carry a 'canonical' field
+        (added by _fetch_kg_rows), kg_overlap uses it for matching so display
+        casing and un-normalized paths don't break overlap."""
+        # Result has display 'name' preserving the stored form, and the
+        # canonical form the extractor would produce.
+        result = _result_with_kg([
+            {"name": "./scripts/core/reranker.py",
+             "canonical": "scripts/core/reranker.py",
+             "type": "file"},
+        ])
+        # Query-side entity uses the canonical value directly (extract_entities
+        # returns canonical in .name).
+        ctx = RecallContext(
+            query_entities=[{"name": "scripts/core/reranker.py", "type": "file"}]
+        )
+        assert kg_overlap(result, ctx) == 1.0
+
+    def test_config_type_weight_matches_extractor_type_name(self):
+        """Finding F3 fix: kg_extractor emits entity_type='config' for env
+        variables; KG_TYPE_WEIGHTS must key on 'config' (not 'config_var')
+        or the intended salience is silently lost to the default weight."""
+        assert "config" in KG_TYPE_WEIGHTS
+        assert KG_TYPE_WEIGHTS["config"] != 0.5  # not the default fallback
+
 
 class TestRerankKGWeight:
     def test_rerank_boosts_kg_matches_when_weight_positive(self):

--- a/tests/test_store_kg_integration.py
+++ b/tests/test_store_kg_integration.py
@@ -1,0 +1,246 @@
+"""Tests for KG extraction integration in store_learning_v2."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from scripts.core.store_learning import store_learning_v2
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_memory_service(memory_id: str | None = None):
+    """Create a mock memory service that returns a given memory_id."""
+    if memory_id is None:
+        memory_id = str(uuid.uuid4())
+    svc = AsyncMock()
+    svc.store.return_value = memory_id
+    svc.close.return_value = None
+    # search_vector_global returns empty (no duplicates)
+    svc.search_vector_global.return_value = []
+    return svc, memory_id
+
+
+def _mock_embedding():
+    """Return a mock EmbeddingService that produces a dummy vector."""
+    embedder = AsyncMock()
+    embedder.embed.return_value = [0.1] * 1024
+    embedder._provider = MagicMock()
+    embedder._provider.model = "test-model"
+    return embedder
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_store_learning_v2_calls_kg_extractor():
+    """KG extraction runs after successful store and populates result."""
+    svc, mid = _mock_memory_service()
+    embedder = _mock_embedding()
+
+    kg_result = {"entities": 3, "edges": 2, "mentions": 3}
+
+    with (
+        patch("scripts.core.store_learning.create_memory_service", return_value=svc),
+        patch("scripts.core.store_learning.get_default_backend", return_value="postgres"),
+        patch("scripts.core.store_learning.EmbeddingService", return_value=embedder),
+        patch(
+            "scripts.core.kg_extractor.store_entities_and_edges",
+            new_callable=AsyncMock,
+            return_value=kg_result,
+        ) as mock_store_kg,
+        patch(
+            "scripts.core.kg_extractor.extract_entities",
+        ) as mock_extract_ents,
+        patch(
+            "scripts.core.kg_extractor.extract_relations",
+        ) as mock_extract_rels,
+        patch.dict("os.environ", {"DATABASE_URL": "postgresql://test"}),
+    ):
+        # extract_entities returns some entities so KG path runs
+        mock_extract_ents.return_value = [MagicMock(name="pytest", entity_type="tool")]
+        mock_extract_rels.return_value = []
+
+        result = await store_learning_v2(
+            session_id="test-session",
+            content="Using pytest for testing with asyncpg",
+            learning_type="WORKING_SOLUTION",
+        )
+
+        assert result["success"] is True
+        assert result["kg_stats"] == kg_result
+        mock_extract_ents.assert_called_once()
+        mock_store_kg.assert_called_once_with(mid, mock_extract_ents.return_value, [])
+
+
+@pytest.mark.asyncio
+async def test_store_learning_v2_kg_failure_is_nonfatal():
+    """KG extraction failure does not break the store path."""
+    svc, mid = _mock_memory_service()
+    embedder = _mock_embedding()
+
+    with (
+        patch("scripts.core.store_learning.create_memory_service", return_value=svc),
+        patch("scripts.core.store_learning.get_default_backend", return_value="postgres"),
+        patch("scripts.core.store_learning.EmbeddingService", return_value=embedder),
+        patch(
+            "scripts.core.kg_extractor.extract_entities",
+            side_effect=RuntimeError("KG boom"),
+        ),
+        patch.dict("os.environ", {"DATABASE_URL": "postgresql://test"}),
+    ):
+        result = await store_learning_v2(
+            session_id="test-session",
+            content="Using pytest for testing",
+            learning_type="WORKING_SOLUTION",
+        )
+
+        assert result["success"] is True
+        assert result["memory_id"] == mid
+        assert "kg_stats" not in result  # KG failed, no kg key
+
+
+@pytest.mark.asyncio
+async def test_store_learning_v2_no_entities_skips_kg():
+    """When no entities extracted, KG storage is skipped entirely."""
+    svc, mid = _mock_memory_service()
+    embedder = _mock_embedding()
+
+    with (
+        patch("scripts.core.store_learning.create_memory_service", return_value=svc),
+        patch("scripts.core.store_learning.get_default_backend", return_value="postgres"),
+        patch("scripts.core.store_learning.EmbeddingService", return_value=embedder),
+        patch(
+            "scripts.core.kg_extractor.extract_entities",
+            return_value=[],  # no entities
+        ),
+        patch(
+            "scripts.core.kg_extractor.store_entities_and_edges",
+            new_callable=AsyncMock,
+        ) as mock_store_kg,
+        patch.dict("os.environ", {"DATABASE_URL": "postgresql://test"}),
+    ):
+        result = await store_learning_v2(
+            session_id="test-session",
+            content="just some text with no technical entities",
+            learning_type="WORKING_SOLUTION",
+        )
+
+        assert result["success"] is True
+        assert "kg_stats" not in result
+        mock_store_kg.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_store_learning_v2_kg_skipped_for_sqlite():
+    """KG extraction only runs on postgres backend."""
+    svc, mid = _mock_memory_service()
+    embedder = _mock_embedding()
+
+    with (
+        patch("scripts.core.store_learning.create_memory_service", return_value=svc),
+        patch("scripts.core.store_learning.get_default_backend", return_value="sqlite"),
+        patch("scripts.core.store_learning.EmbeddingService", return_value=embedder),
+        patch(
+            "scripts.core.kg_extractor.extract_entities",
+        ) as mock_extract,
+        patch.dict("os.environ", {}, clear=True),
+    ):
+        result = await store_learning_v2(
+            session_id="test-session",
+            content="Using pytest for testing",
+            learning_type="WORKING_SOLUTION",
+        )
+
+        assert result["success"] is True
+        assert "kg_stats" not in result
+        mock_extract.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_store_learning_v2_dedup_backfills_kg():
+    """When content is a duplicate, KG is backfilled for the existing memory."""
+    svc = AsyncMock()
+    svc.store.return_value = ""  # empty = dedup
+    svc.close.return_value = None
+    svc.search_vector_global.return_value = []
+    embedder = _mock_embedding()
+
+    existing_id = str(uuid.uuid4())
+    mock_conn = AsyncMock()
+    mock_conn.fetchval.return_value = existing_id
+
+    # pool.acquire() is a sync call returning an async context manager
+    acm = AsyncMock()
+    acm.__aenter__.return_value = mock_conn
+    acm.__aexit__.return_value = False
+    mock_pool = MagicMock()
+    mock_pool.acquire.return_value = acm
+
+    kg_result = {"entities": 2, "edges": 1, "mentions": 2}
+
+    with (
+        patch("scripts.core.store_learning.create_memory_service", return_value=svc),
+        patch("scripts.core.store_learning.get_default_backend", return_value="postgres"),
+        patch("scripts.core.store_learning.EmbeddingService", return_value=embedder),
+        patch("scripts.core.db.postgres_pool.get_pool", new_callable=AsyncMock, return_value=mock_pool),
+        patch(
+            "scripts.core.kg_extractor.extract_entities",
+            return_value=[MagicMock(name="pytest", entity_type="tool")],
+        ),
+        patch("scripts.core.kg_extractor.extract_relations", return_value=[]),
+        patch(
+            "scripts.core.kg_extractor.store_entities_and_edges",
+            new_callable=AsyncMock,
+            return_value=kg_result,
+        ) as mock_store_kg,
+        patch.dict("os.environ", {"DATABASE_URL": "postgresql://test"}),
+    ):
+        result = await store_learning_v2(
+            session_id="test-session",
+            content="duplicate content with pytest",
+            learning_type="WORKING_SOLUTION",
+        )
+
+        assert result["skipped"] is True
+        mock_store_kg.assert_called_once()
+        # Verify it used the existing memory_id, not a new one
+        call_args = mock_store_kg.call_args
+        assert call_args[0][0] == existing_id
+
+
+@pytest.mark.asyncio
+async def test_store_learning_v2_dedup_kg_backfill_failure_nonfatal():
+    """KG backfill failure on dedup does not break the dedup path."""
+    svc = AsyncMock()
+    svc.store.return_value = ""  # empty = dedup
+    svc.close.return_value = None
+    svc.search_vector_global.return_value = []
+    embedder = _mock_embedding()
+
+    with (
+        patch("scripts.core.store_learning.create_memory_service", return_value=svc),
+        patch("scripts.core.store_learning.get_default_backend", return_value="postgres"),
+        patch("scripts.core.store_learning.EmbeddingService", return_value=embedder),
+        patch(
+            "scripts.core.db.postgres_pool.get_pool",
+            side_effect=RuntimeError("pool boom"),
+        ),
+        patch.dict("os.environ", {"DATABASE_URL": "postgresql://test"}),
+    ):
+        result = await store_learning_v2(
+            session_id="test-session",
+            content="duplicate content",
+            learning_type="WORKING_SOLUTION",
+        )
+
+        assert result["skipped"] is True
+        assert result["success"] is True

--- a/thoughts/shared/plans/kg-phase3-query-time-integration.md
+++ b/thoughts/shared/plans/kg-phase3-query-time-integration.md
@@ -1,0 +1,274 @@
+# Knowledge Graph — Phase 3: Query-Time Integration
+
+**Branch:** `feature/knowledge-graph`
+**Scope:** Read-side only. No schema changes, no new write paths.
+**Predecessors:** Phase 1 (`b76330c`, KG schema + extractor), Phase 2 (`1e7b3b1`, store-time integration — `kg_stats` in store result).
+**Status:** Draft — awaiting ARCHITECT review before implementation.
+
+---
+
+## 1. Goal
+
+Enrich `recall_learnings` results with structured entity/edge context from the KG tables, and let the reranker weight candidates that share entity overlap with the query. Current recall is hybrid RRF + contextual reranker (project, recency, confidence, recall, type, tags, pattern). Phase 3 adds **one new signal** (`kg_overlap`) and **one new output field** (`kg_context`).
+
+---
+
+## 2. Non-Goals (scope discipline)
+
+- ❌ No new KG tables, columns, or migrations. Read-side only.
+- ❌ No changes to the KG extractor, `store_learning_v2`, or the `kg_stats` key.
+- ❌ No new embedding computation at recall time. Query-side entity extraction reuses `kg_extractor.extract_entities()` already used at store time.
+- ❌ No graph traversal beyond 1 hop. Multi-hop reasoning is deferred to a later phase.
+- ❌ No changes to default reranker behavior when KG data is unavailable (sqlite backend, empty tables). Gracefully degrades to current behavior.
+
+---
+
+## 3. Architecture
+
+### 3.1 Data fetch — mirror the pattern-enrichment pattern
+
+`recall_learnings.enrich_with_pattern_strength()` (lines 328–352) is the exact template. Phase 3 adds a parallel `enrich_with_kg_context()` in the same file, following the same shape:
+
+```
+_fetch_kg_rows(result_ids: list[str]) -> list[dict]      # pure I/O
+build_kg_lookup(rows: list[dict]) -> dict[str, dict]     # pure
+apply_kg_enrichment(results, lookup) -> list[dict]       # pure
+enrich_with_kg_context(results) -> list[dict]            # orchestrator
+```
+
+**SQL (single round trip, per-memory aggregation):**
+
+```sql
+SELECT m.memory_id AS id,
+       ARRAY_AGG(DISTINCT jsonb_build_object(
+         'id', e.id,
+         'name', e.display_name,
+         'type', e.entity_type,
+         'mention_count', e.mention_count
+       )) AS kg_entities,
+       COALESCE((
+         SELECT ARRAY_AGG(DISTINCT jsonb_build_object(
+           'source', se.display_name,
+           'target', te.display_name,
+           'relation', ed.relation,
+           'weight', ed.weight
+         ))
+         FROM kg_edges ed
+         JOIN kg_entities se ON se.id = ed.source_id
+         JOIN kg_entities te ON te.id = ed.target_id
+         WHERE ed.memory_id = m.memory_id
+       ), ARRAY[]::jsonb[]) AS kg_edges
+FROM kg_entity_mentions m
+JOIN kg_entities e ON e.id = m.entity_id
+WHERE m.memory_id = ANY($1::uuid[])
+GROUP BY m.memory_id;
+```
+
+- Indexes already in place: `idx_kg_mentions_memory`, `idx_kg_edge_unique(source_id, target_id, relation, memory_id)`. No new indexes needed — the primary access paths are covered.
+- **Caveat:** the edge subquery is not covered by a single index on `memory_id`. Current `idx_kg_edge_unique` has `memory_id` as the **4th column**, which postgres can use for equality lookup via skip-scan but may not be optimal. I will benchmark with `EXPLAIN ANALYZE` during implementation; if the edge subquery exceeds ~10ms for k=50 candidates, I'll file a follow-up (not in this phase) to add `idx_kg_edge_memory` on `(memory_id)`. This is a deliberate deferral to respect read-side-only scope.
+
+### 3.2 Reranker signal — `kg_overlap`
+
+New pure function in `scripts/core/reranker.py`:
+
+```python
+def kg_overlap(result: dict, ctx: RecallContext) -> float:
+    """Score based on entity overlap between query and result.
+
+    Uses pre-computed ctx.query_entities (set[str] of canonical names) and
+    result['kg_entities'] (list of dicts from enrichment). Returns 0..1.
+    """
+```
+
+**Signal definition (weighted Jaccard over entity names, weighted by entity type salience):**
+
+```
+overlap = sum(w(e.type) for e in query_entities ∩ result_entities)
+union   = sum(w(e.type) for e in query_entities ∪ result_entities)
+score   = overlap / union if union > 0 else 0.0
+```
+
+Type weights (justification below):
+
+| Entity type | Weight | Rationale |
+|-------------|--------|-----------|
+| `file`      | 1.0    | Highly specific — overlap is strong evidence |
+| `module`    | 1.0    | Same as file |
+| `library`   | 0.8    | Specific but often generic (`pytest`, `asyncpg`) |
+| `tool`      | 0.6    | Common across many learnings |
+| `language`  | 0.4    | Too coarse (`python` matches everything) |
+| `concept`   | 0.5    | Ambiguous by design |
+| `error`     | 0.9    | Rare + specific — strong signal |
+| `config_var`| 0.7    | Specific |
+
+Weights are a **dataclass field** `KG_TYPE_WEIGHTS` in `reranker.py`, so they're configurable later without schema thrash.
+
+### 3.3 Reranker integration — new weight, preserve invariants
+
+Add to `RerankerConfig` (`scripts/core/config/models.py`):
+
+```python
+kg_weight: float = 0.05           # default signal weight
+```
+
+And extend `total_signal_weight` property to include it. Default starting value of **0.05** matches `pattern_weight` (which is the most similar signal in character: structured, read-side, enriched post-fetch). Rationale:
+
+- Starting low avoids regressing existing behavior for users without populated KG data.
+- After measurement (Phase 3 includes an offline eval harness — see §5), weights can be retuned in a follow-up. The architecture treats signal weight as a config value, not a hardcoded constant.
+- **Invariant preserved:** `retrieval_weight + Σ signal_weights = 1.0`. Raising `kg_weight` requires lowering another weight or accepting reduced retrieval contribution. Not done automatically — requires explicit follow-up.
+
+The `rerank()` function (reranker.py:309) adds one line to compute `sig_kg` and one line in the weighted sum. `rerank_details` gains a `kg_overlap` key.
+
+### 3.4 Query-side entity extraction
+
+`make_recall_context()` (recall_learnings.py:165) gains:
+
+```python
+query_entities: set[str]  # canonical names from kg_extractor.extract_entities(query)
+```
+
+Extraction is **synchronous, pure, already exists** in `kg_extractor`. Cost is negligible (regex-based). Populated only when backend == postgres (sqlite path has no KG data to compare against).
+
+---
+
+## 4. Output enrichment — `kg_context` namespace
+
+Per architect guidance, use `kg_context` (not `kg`, not `kg_stats`) for the recall-side output field. Each recall result dict gains:
+
+```python
+result["kg_context"] = {
+    "entities": [
+        {"id": "...", "name": "pytest", "type": "tool", "mention_count": 42},
+        ...
+    ],
+    "edges": [
+        {"source": "pytest", "target": "asyncpg", "relation": "used_with", "weight": 2.0},
+        ...
+    ],
+    "query_overlap": {
+        "matched_entities": ["pytest", "asyncpg"],  # intersection with query_entities
+        "score": 0.67,                              # kg_overlap signal value
+    },
+}
+```
+
+**Namespace discipline:**
+- `kg_stats` (store-side, Phase 2): stats dict from `store_entities_and_edges` — `{entities, edges, mentions}`.
+- `kg_context` (recall-side, Phase 3): structured per-result context from KG tables.
+
+These are different shapes with different purposes. Keeping them in separate keys avoids overloading one field.
+
+When enrichment fails or yields no data, `kg_context` is **omitted** (not set to empty). Consumers must check `"kg_context" in result`. This matches the pattern-enrichment convention.
+
+**Safety cap:** A module-level constant `KG_MAX_EDGES_PER_MEMORY = 50` caps the edge list per result. When a memory's edge count exceeds the cap, the top-50 by `weight` are kept and a `logger.warning` is emitted identifying the memory_id and total edge count. Typical usage is < 10 edges per memory; the cap exists to prevent pathological payload bloat on future high-connectivity learnings without breaking the output contract.
+
+---
+
+## 5. TDD test strategy
+
+### 5.1 Unit tests
+
+**`tests/test_kg_enrichment.py`** (new, ~8 tests):
+- `_fetch_kg_rows` returns empty list for empty input
+- `build_kg_lookup` groups entities + edges correctly by memory_id
+- `apply_kg_enrichment` sets `kg_context` on matching results, omits for non-matches
+- `apply_kg_enrichment` does not mutate input list
+- `enrich_with_kg_context` returns unchanged list when backend is sqlite
+- `enrich_with_kg_context` returns unchanged list when result_ids is empty
+- `enrich_with_kg_context` gracefully handles DB connection error (non-fatal)
+- `enrich_with_kg_context` correctly handles results with no KG entries (no `kg_context` key)
+
+**`tests/test_reranker.py`** (extend, ~5 tests):
+- `kg_overlap` returns 0.0 when query_entities is None/empty
+- `kg_overlap` returns 0.0 when result has no `kg_context`
+- `kg_overlap` returns 1.0 for identical entity sets
+- `kg_overlap` type-weight calculation (verify `file` entity overlap scores higher than `language` overlap of same size)
+- `rerank()` with `kg_weight > 0` boosts results with matching entities; zero weight is a no-op
+
+### 5.2 Integration test
+
+**`tests/test_recall_kg_integration.py`** (new, ~3 tests):
+- Against seeded KG (fixture inserts ~5 learnings with entities/edges), verify recall returns `kg_context` populated correctly.
+- Verify query containing a known entity name causes that entity's learnings to rank higher with `kg_weight=0.2` vs `kg_weight=0.0`.
+- Verify sqlite backend returns results without `kg_context` and without error.
+
+### 5.3 Offline eval (nice-to-have, not blocking)
+
+`scripts/eval_kg_reranker.py` runs a fixed set of 20 handcrafted queries against a seeded KG with and without `kg_weight` > 0. Reports MRR / nDCG@5 delta. Used to justify future weight tuning. **Not** a hard gate for Phase 3 merge — weights start conservative at 0.05 regardless.
+
+### 5.4 Coverage targets
+
+`uv run pytest --cov=scripts/core/recall_learnings --cov=scripts/core/reranker --cov=scripts/core/kg_extractor` must show ≥ baseline coverage for all three files (baselines captured before this work starts).
+
+---
+
+## 6. Implementation phasing (TDD red → green → refactor)
+
+1. **Commit A — fetch + enrichment plumbing**
+   - Red: write `test_kg_enrichment.py` against stubbed `_fetch_kg_rows`.
+   - Green: implement the four functions in `recall_learnings.py`.
+   - Refactor: deduplicate with `enrich_with_pattern_strength` if a clean shared helper emerges (likely not — keep separate).
+
+2. **Commit B — reranker signal**
+   - Red: extend `test_reranker.py` with `kg_overlap` and `rerank` tests.
+   - Green: add `kg_overlap()`, `KG_TYPE_WEIGHTS`, `kg_weight` to `RerankerConfig`, wire into `rerank()`.
+   - Refactor: verify `total_signal_weight` math and existing tests still pass.
+
+3. **Commit C — query-side entity extraction + wiring**
+   - Red: extend `RecallContext` tests, `test_recall_kg_integration.py`.
+   - Green: add `query_entities` to `RecallContext`, call `extract_entities` in `make_recall_context`, call `enrich_with_kg_context` in the recall pipeline.
+
+4. **Commit D — adversarial round 1 findings** (required by workflow).
+5. **Commit E — adversarial round 2 findings**.
+6. **Commit F — adversarial round 3 findings**.
+7. **Commit G — security audit findings + coverage report in PR body**.
+
+Each commit stays small, reviewable, and keeps tests green.
+
+---
+
+## 7. Risks & mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| Edge subquery perf on large KG | `EXPLAIN ANALYZE` during implementation; defer to follow-up if > 10ms |
+| Existing recall tests over-index on result shape | Run full `tests/test_recall_*` early; if strict-dict assertions exist, update them alongside the change and note in commit message (per architect precedent) |
+| `kg_overlap` signal fires on trivial entities (e.g. every learning mentions `python`) | Type weights down-rank `language` to 0.4; also considered but rejected: IDF-weighting over mention_count (more complex, defer) |
+| Query entity extraction misses intent (short queries like "error") | Non-fatal — signal contributes 0 when no entities extracted. Other reranker signals compensate. |
+| Reranker weight sum drifts from 1.0 | `RerankerConfig.__post_init__` can assert invariant; alternative: leave `total_signal_weight` computed and document that retrieval_weight is the remainder |
+| KG tables empty (fresh install) | `enrich_with_kg_context` returns results unchanged; `kg_overlap` returns 0; recall behaves exactly as before Phase 3 |
+
+---
+
+## 8. Open questions for ARCHITECT
+
+1. **Weight starting value** — `kg_weight = 0.05` is conservative. Acceptable, or prefer 0.10 since KG is a higher-signal feature than e.g. `recency`?
+2. **Query entity extraction** — use full `kg_extractor.extract_entities()` (regex-heavy, extracts file paths) or a subset tuned for query strings (no file-path extraction)? My default is the full extractor for consistency with store-side.
+3. **Edge inclusion in `kg_context`** — include all edges for the memory, or cap at top-N by weight? Default: all (typically < 10 per learning; cap if measured > 50).
+4. **Follow-up scope** — if edge subquery perf is poor, file a follow-up issue rather than adding `idx_kg_edge_memory` in this PR. Confirm?
+
+---
+
+## 9. Success criteria (from assignment)
+
+- ✅ Recall results include entity/edge context (§4)
+- ✅ Reranker uses KG-derived signal with justified weights (§3.2, §3.3)
+- ✅ Coverage on changed files ≥ existing baseline (§5.4)
+- ✅ 3 adversarial review rounds pass (§6 commits D/E/F)
+- ✅ PR merged after 2+ AI reviewer cycles
+
+---
+
+## 10. Files touched (expected)
+
+| File | Change |
+|------|--------|
+| `scripts/core/recall_learnings.py` | +4 functions (fetch, build, apply, enrich), wire enrich into pipeline, extend RecallContext construction |
+| `scripts/core/reranker.py` | +1 signal function, +1 constant dict, wire into `rerank()` |
+| `scripts/core/config/models.py` | +1 field `kg_weight`, extend `total_signal_weight` |
+| `tests/test_kg_enrichment.py` | NEW |
+| `tests/test_recall_kg_integration.py` | NEW |
+| `tests/test_reranker.py` | extend |
+| `tests/test_recall_learnings.py` | extend for RecallContext changes |
+
+Estimated net LOC: **+400 / -30**.


### PR DESCRIPTION
# Knowledge Graph — Phase 3: Query-Time Integration

Completes the three-phase KG feature. Phase 1 (`87eeb93`) added the schema and extractor; Phase 2 (`e0faf80`) wired store-time indexing; **this PR adds the read-side**: recall results now carry structured entity/edge context and a new reranker signal weights candidates by entity overlap with the query.

Plan: [thoughts/shared/plans/kg-phase3-query-time-integration.md](https://github.com/stephenfeather/opc/blob/main/thoughts/shared/plans/kg-phase3-query-time-integration.md) (on `main` since commit `4a4ae2f`).

## What landed

- **Data fetch.** `_fetch_kg_rows` pulls entities and edges for a batch of memory ids in a single round trip. SQL-side edge cap via correlated subquery with `ORDER BY ed.weight DESC LIMIT $2`, so Postgres never materializes more than `KG_MAX_EDGES_PER_MEMORY` (50) edges per memory. Python-side re-cap in `build_kg_lookup` is defense-in-depth.
- **Enrichment.** `enrich_with_kg_context` mirrors the existing `enrich_with_pattern_strength` shape. Gracefully degrades on sqlite, empty KG, missing ids, and expected availability failures (`ImportError`/`OSError`/`ConnectionError`/`asyncpg.InterfaceError`). Genuine SQL defects propagate instead of masquerading as silent degradation.
- **Reranker signal.** New `kg_overlap` signal: weighted-Jaccard over entity names, type-salience-weighted (`file`/`module` = 1.0; `language` = 0.4). Case-insensitive comparison, with a `canonical` field added to SQL output so path normalization (`./foo.py` ↔ `foo.py`) doesn't break matching.
- **Graceful degradation by redistribution.** `kg_weight=0.05` is redirected to `retrieval_weight` when KG is inactive (no query entities or no result carries `kg_context`). Deterministic single-branch redistribution via `RerankerConfig.effective_signal_weight(kg_active=bool)`. Byte-identical ranking to pre-Phase-3 when inactive — proven by regression test.
- **Config validation.** `RerankerConfig.__post_init__` rejects weights whose total is outside `[0, 1]`, preventing silent regressions from legacy `opc.toml` files summing to 1.0 after adding the new `kg_weight`.
- **Output contract.** `kg_context` flows through both `format_json_output` and `format_json_full_output` via `_build_json_result`. Consumers of `--json` and `--json-full` now see the enrichment.
- **Query-side extraction.** `make_recall_context(query=...)` populates `ctx.query_entities` via `kg_extractor.extract_entities`. Input is capped at `_KG_QUERY_EXTRACTION_MAX_CHARS=4096` before extraction (defense in depth).

## What did *not* change

No schema changes, no write-path changes, no migrations. Phase 3 is read-side only. `store_learning_v2` unchanged. `kg_extractor.py` unchanged.

## Workflow

Per project "Large Plan Workflow":

- Plan written, reviewed, approved, and committed to `main` (`4a4ae2f`) before implementation.
- **Three adversarial-review rounds completed** (`/codex:adversarial-review`) with distinct focus areas — correctness/degradation, SQL/resource/exceptions, math/invariants/canonicalization. Seven findings total (5 HIGH, 2 MEDIUM); all resolved in commits D1/D2/D3.
- `/security` audit completed, 3 LOW advisory findings. LOW-1 fixed inline (query length cap). LOW-2 (`kg_extractor` regex ReDoS audit) filed as [#120](https://github.com/stephenfeather/opc/issues/120) — out of Phase 3 scope. LOW-3 documented with a trust-boundary comment.

## Commits

| Commit | Purpose |
|--------|---------|
| `87eeb93` | Phase 1 (schema + extractor) — from previous work |
| `e0faf80` | Phase 2 (store-time + TDD/FP port onto main) — from previous work |
| `1681c65` | Commit A — read-side fetch plumbing + enrichment functions |
| `c4fe25d` | Commit B — `kg_overlap` reranker signal + `KG_TYPE_WEIGHTS` + `kg_weight` in config |
| `77ff8a3` | Commit C — pipeline wiring + query-side entity extraction |
| `f313c55` | Commit D2 — `kg_context` serialized in JSON output (Round D/E finding) |
| `3448962` | Commit D3 — canonical names, SQL edge cap via correlated subquery, narrowed exception handling, `config` type key (Rounds D/E/F) |
| `bf183e1` | Commit D1 — `effective_signal_weight` redistribution + `__post_init__` validation (Round D/F) |
| `23acb48` | Commit G — query length cap + kg_context trust-boundary comment (security audit LOW-1/LOW-3) |

## Test coverage

`uv run pytest --cov=scripts.core.recall_learnings --cov=scripts.core.reranker --cov=scripts.core.recall_formatters --cov=scripts.core.config.models --cov-report=term-missing tests/`

```
Name                                Stmts   Miss  Cover   Missing
-----------------------------------------------------------------
scripts/core/config/models.py          96      0   100%
scripts/core/recall_formatters.py      95      2    98%   23-24
scripts/core/recall_learnings.py      263     24    91%   56-57, 202-203, 374, 382-383, 516-517, 535-536, 600, 603, 650-652, 674, 677-684, 721
scripts/core/reranker.py              214     10    95%   76-77, 168, 224, 249, 281, 302, 311, 383-384
-----------------------------------------------------------------
TOTAL                                 668     36    95%
================ 2240 passed, 1 skipped, 1 deselected in 6.38s =================
```

**2240 tests pass. Zero regressions.** One pre-existing failure (`test_memory_daemon_db::test_adds_six_columns`) is deselected and tracked in [#111](https://github.com/stephenfeather/opc/issues/111) — unrelated to Phase 3; flagged during rebase verification.

## Follow-ups (intentionally deferred)

- [#111](https://github.com/stephenfeather/opc/issues/111) — Pre-existing test failure on main (6 vs 9 ALTER TABLE calls).
- [#120](https://github.com/stephenfeather/opc/issues/120) — Regex ReDoS audit of `kg_extractor.py` patterns. Input length cap in this PR mitigates worst case.
- Future phase: multi-hop graph traversal, IDF-weighted entity scoring, eval harness for reranker weight tuning. All explicitly out of §2 scope here.

## Breaking changes

None. New `kg_context` key on result dicts is additive. `RerankerConfig` construction now validates weight sum — may reject improperly-tuned legacy configs with a clear error message, which is the intended behavior.



## Note on diff scope

Reviewers correctly flagged that the diff against `origin/main` includes write-path code in `scripts/core/store_learning.py` (e.g. `_try_index_kg`, `_try_backfill_kg`) despite this PR's description claiming "read-side only."

**Clarification:** this PR is the first time **any** of Phase 1 or Phase 2 is reaching `origin/main`. The `feature/knowledge-graph` branch was carrying three unmerged phases:

- Phase 1 (commits `87eeb93`) — schema + extractor. Write-side precondition for Phases 2/3.
- Phase 2 (commit `e0faf80`) — store-time KG indexing. Write-side.
- Phase 3 (commits `1681c65`...`84f7c68`) — **this phase's new work**. Read-side only.

Only Phase 3 commits are new in this PR by original intent. Phase 1 and 2 appear in the diff because they have not been merged to `main` yet. Splitting them into separate PRs is not feasible at this point — they were authored and reviewed earlier in this branch lineage, and rebasing/cherry-picking them out now would rewrite history and invalidate prior review/work.

**What this means for reviewers:**
- New Phase 3 changes live in `scripts/core/recall_learnings.py` (enrichment), `scripts/core/reranker.py` (`kg_overlap` signal), `scripts/core/config/models.py` (`kg_weight` + validation), `scripts/core/recall_formatters.py` (JSON serialization), plus their tests.
- Phase 1/2 code in the diff (`kg_extractor.py`, schema files, `store_learning.py` KG hooks) is included for context but any issues there are tracked as follow-up work.
