### PR TITLE
feat(kg): backfill knowledge graph for existing archival_memory rows (#124)

### DIFF
--- a/scripts/core/backfill_kg.py
+++ b/scripts/core/backfill_kg.py
@@ -1,0 +1,248 @@
+"""Backfill knowledge graph for existing archival_memory rows (#124).
+
+Walks archival_memory rows that have no kg_entity_mentions yet and runs the
+same extraction + storage path used by store_learning._try_index_kg.
+
+Idempotent and resumable: store_entities_and_edges dedupes on
+(memory_id, entity_id) and (source_id, target_id, relation, memory_id), and
+the fetch query excludes memories that already have a mention row, so partial
+runs resume cleanly and re-running is a no-op.
+
+Usage:
+    uv run python scripts/core/backfill_kg.py --dry-run         # counts only
+    uv run python scripts/core/backfill_kg.py                   # full backfill
+    uv run python scripts/core/backfill_kg.py --limit 100       # first 100
+    uv run python scripts/core/backfill_kg.py --since 2026-01-01
+    uv run python scripts/core/backfill_kg.py --memory-id <uuid>
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+import time
+import uuid
+from collections.abc import Iterator, Sequence
+from datetime import datetime
+from typing import Any
+
+from scripts.core.db.postgres_pool import get_pool
+from scripts.core.kg_extractor import (
+    extract_entities,
+    extract_relations,
+    store_entities_and_edges,
+)
+from scripts.core.store_learning import detect_backend
+
+# ---------------------------------------------------------------------------
+# Pure functions
+# ---------------------------------------------------------------------------
+
+
+def build_fetch_query(
+    limit: int | None = None,
+    since: datetime | None = None,
+    memory_id: str | None = None,
+    count_only: bool = False,
+) -> tuple[str, list[Any]]:
+    """Build the SQL to select memories with no KG mentions yet.
+
+    Returns (sql, params) with consecutively numbered placeholders.
+    The NOT EXISTS filter makes partial runs resumable.
+    """
+    select = "SELECT count(*)" if count_only else "SELECT id, content"
+    sql = (
+        f"{select} FROM archival_memory m "
+        "WHERE NOT EXISTS ("
+        "SELECT 1 FROM kg_entity_mentions km WHERE km.memory_id = m.id)"
+    )
+    params: list[Any] = []
+    if since is not None:
+        params.append(since)
+        sql += f" AND m.created_at >= ${len(params)}"
+    if memory_id is not None:
+        params.append(memory_id)
+        sql += f" AND m.id = ${len(params)}::uuid"
+    if not count_only:
+        sql += " ORDER BY m.created_at"
+    if limit is not None:
+        params.append(limit)
+        sql += f" LIMIT ${len(params)}"
+    return sql, params
+
+
+def chunked(items: Sequence[Any], size: int) -> Iterator[list[Any]]:
+    """Yield successive lists of at most ``size`` items."""
+    for i in range(0, len(items), size):
+        yield list(items[i : i + size])
+
+
+def format_summary(stats: dict[str, int]) -> str:
+    """Format the final run summary line."""
+    return (
+        f"Backfill complete: {stats['processed']} processed, "
+        f"{stats['indexed']} indexed, {stats['no_entities']} no_entities, "
+        f"{stats['errors']} errors"
+    )
+
+
+def _positive_int(value: str) -> int:
+    """Argparse type for positive integers."""
+    ivalue = int(value)
+    if ivalue <= 0:
+        raise argparse.ArgumentTypeError(f"must be a positive integer, got {value!r}")
+    return ivalue
+
+
+def _iso_datetime(value: str) -> datetime:
+    """Argparse type for ISO-8601 dates/datetimes."""
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError as e:
+        raise argparse.ArgumentTypeError(f"invalid ISO date: {value!r}") from e
+
+
+def _uuid_str(value: str) -> str:
+    """Argparse type validating UUID format, returning the original string."""
+    try:
+        uuid.UUID(value)
+    except ValueError as e:
+        raise argparse.ArgumentTypeError(f"invalid UUID: {value!r}") from e
+    return value
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(
+        description="Backfill knowledge graph for existing archival_memory rows."
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report eligible memory counts without writing",
+    )
+    parser.add_argument(
+        "--limit",
+        type=_positive_int,
+        default=None,
+        help="Process at most N memories",
+    )
+    parser.add_argument(
+        "--since",
+        type=_iso_datetime,
+        default=None,
+        help="Only memories created at or after this ISO date",
+    )
+    parser.add_argument(
+        "--memory-id",
+        type=_uuid_str,
+        default=None,
+        help="Backfill a single memory by UUID",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=_positive_int,
+        default=500,
+        help="Progress-logging batch size (default 500)",
+    )
+    return parser.parse_args(argv)
+
+
+# ---------------------------------------------------------------------------
+# Async I/O
+# ---------------------------------------------------------------------------
+
+
+async def backfill_one(memory_id: str, content: str) -> dict[str, Any]:
+    """Extract and store KG rows for one memory. Never raises."""
+    try:
+        entities = extract_entities(content)
+        if not entities:
+            return {"status": "no_entities"}
+        relations = extract_relations(content, entities)
+        stats = await store_entities_and_edges(memory_id, entities, relations)
+        return {"status": "indexed", "stats": stats}
+    except Exception as e:
+        return {"status": "error", "error": str(e)[:200]}
+
+
+async def run_backfill(args: argparse.Namespace) -> int:
+    """Run the backfill per parsed CLI args. Returns a process exit code."""
+    backend = detect_backend(dict(os.environ), fallback="sqlite")
+    if backend != "postgres":
+        _log(
+            "KG backfill requires the postgres backend; "
+            "set DATABASE_URL or CONTINUOUS_CLAUDE_DB_URL"
+        )
+        return 1
+
+    pool = await get_pool()
+
+    if args.dry_run:
+        sql, params = build_fetch_query(
+            since=args.since, memory_id=args.memory_id, count_only=True
+        )
+        async with pool.acquire() as conn:
+            eligible = await conn.fetchval(sql, *params)
+        _log(f"Dry run: {eligible} memories eligible for KG backfill")
+        if args.limit is not None:
+            _log(f"--limit {args.limit} would cap this run at {min(eligible, args.limit)}")
+        return 0
+
+    sql, params = build_fetch_query(
+        limit=args.limit, since=args.since, memory_id=args.memory_id
+    )
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(sql, *params)
+
+    total = len(rows)
+    _log(f"{total} memories to index")
+    stats = {"processed": 0, "indexed": 0, "no_entities": 0, "errors": 0}
+    for batch in chunked(rows, args.batch_size):
+        for row in batch:
+            result = await backfill_one(str(row["id"]), row["content"])
+            stats["processed"] += 1
+            status = result["status"]
+            stats["errors" if status == "error" else status] += 1
+            if status == "error":
+                _log(f"error indexing {row['id']}: {result['error']}")
+        _log(f"progress: {stats['processed']}/{total}")
+    print(format_summary(stats), flush=True)
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def _log(msg: str) -> None:
+    """Write a timestamped progress message to stdout."""
+    print(f"[{time.strftime('%H:%M:%S')}] {msg}", flush=True)
+
+
+def _bootstrap() -> None:
+    """Load .env files (global ~/.claude/.env, then project .env). Called from main()."""
+    from pathlib import Path
+
+    from dotenv import load_dotenv
+
+    global_env = Path.home() / ".claude" / ".env"
+    if global_env.exists():
+        load_dotenv(global_env)
+    opc_env = Path(__file__).parent.parent.parent / ".env"
+    if opc_env.exists():
+        load_dotenv(opc_env, override=True)
+
+
+def main() -> None:
+    """CLI entry point."""
+    _bootstrap()
+    args = parse_args(sys.argv[1:])
+    sys.exit(asyncio.run(run_backfill(args)))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/core/backfill_kg.py
+++ b/scripts/core/backfill_kg.py
@@ -36,7 +36,13 @@ from scripts.core.kg_extractor import (
     extract_relations,
     store_entities_and_edges,
 )
+from scripts.core.log_safety import safe
 from scripts.core.store_learning import detect_backend
+
+# Per-row cap before regex extraction: a single oversized adversarial
+# transcript row must not stall the whole backfill. Extraction is heuristic;
+# the leading portion of a learning carries the salient entities.
+MAX_CONTENT_CHARS = 100_000
 
 # ---------------------------------------------------------------------------
 # Pure functions
@@ -68,6 +74,8 @@ def build_fetch_query(
     deterministic ORDER BY it pages through the backlog without loading it
     all at once, and advances past rows that errored mid-run.
     """
+    # Invariant: f-string parts below are compile-time constants or in-code
+    # integers (placeholder numbers) only; every user/data value binds via $N
     select = "SELECT count(*)" if count_only else "SELECT id, content, created_at"
     sql = (
         f"{select} FROM archival_memory m "
@@ -204,6 +212,9 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
 async def backfill_one(memory_id: str, content: str) -> dict[str, Any]:
     """Extract and store KG rows for one memory. Never raises."""
     try:
+        # Truncate once so entity spans and relation extraction index into
+        # the same string
+        content = content[:MAX_CONTENT_CHARS]
         entities = extract_entities(content)
         if not entities:
             return {"status": "no_entities"}
@@ -298,7 +309,10 @@ async def run_backfill(args: argparse.Namespace) -> int:
             status = result["status"]
             stats["errors" if status == "error" else status] += 1
             if status == "error":
-                _log(f"error indexing {row['id']}: {result['error']}")
+                # safe() at the log site, after the raw [:200] slice in
+                # backfill_one: exception text can embed semi-trusted memory
+                # content (issue #104 log-injection class)
+                _log(f"error indexing {row['id']}: {safe(result['error'])}")
             elif status == "no_entities":
                 no_entity_ids.append(str(row["id"]))
         await mark_no_entities(pool, no_entity_ids)

--- a/scripts/core/backfill_kg.py
+++ b/scripts/core/backfill_kg.py
@@ -210,7 +210,11 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
 
 
 async def backfill_one(memory_id: str, content: str) -> dict[str, Any]:
-    """Extract and store KG rows for one memory. Never raises."""
+    """Extract and store KG rows for one memory.
+
+    Returns a status dict; regular exceptions are converted into
+    ``{"status": "error", "error": ...}``.
+    """
     try:
         # Truncate once so entity spans and relation extraction index into
         # the same string

--- a/scripts/core/backfill_kg.py
+++ b/scripts/core/backfill_kg.py
@@ -4,9 +4,11 @@ Walks archival_memory rows that have no kg_entity_mentions yet and runs the
 same extraction + storage path used by store_learning._try_index_kg.
 
 Idempotent and resumable: store_entities_and_edges dedupes on
-(memory_id, entity_id) and (source_id, target_id, relation, memory_id), and
-the fetch query excludes memories that already have a mention row, so partial
-runs resume cleanly and re-running is a no-op.
+(memory_id, entity_id) and (source_id, target_id, relation, memory_id); the
+fetch query excludes memories that already have a mention row and memories
+durably marked kg_backfill=no_entities in metadata, so partial runs resume
+cleanly and re-running converges to a no-op. Rows that error stay eligible
+and are retried on the next run (exit code 2 signals partial failure).
 
 Usage:
     uv run python scripts/core/backfill_kg.py --dry-run         # counts only
@@ -24,7 +26,7 @@ import os
 import sys
 import time
 import uuid
-from collections.abc import Iterator, Sequence
+from collections.abc import Sequence
 from datetime import datetime
 from typing import Any
 
@@ -46,17 +48,25 @@ def build_fetch_query(
     since: datetime | None = None,
     memory_id: str | None = None,
     count_only: bool = False,
+    after: tuple[datetime, str] | None = None,
 ) -> tuple[str, list[Any]]:
-    """Build the SQL to select memories with no KG mentions yet.
+    """Build the SQL to select memories that still need KG indexing.
 
     Returns (sql, params) with consecutively numbered placeholders.
-    The NOT EXISTS filter makes partial runs resumable.
+    Eligibility excludes memories that already have a kg_entity_mentions row
+    and memories durably marked kg_backfill in metadata (zero-entity rows),
+    so partial runs resume cleanly and reruns converge to a no-op.
+
+    ``after`` is a (created_at, id) keyset cursor: combined with the
+    deterministic ORDER BY it pages through the backlog without loading it
+    all at once, and advances past rows that errored mid-run.
     """
-    select = "SELECT count(*)" if count_only else "SELECT id, content"
+    select = "SELECT count(*)" if count_only else "SELECT id, content, created_at"
     sql = (
         f"{select} FROM archival_memory m "
         "WHERE NOT EXISTS ("
         "SELECT 1 FROM kg_entity_mentions km WHERE km.memory_id = m.id)"
+        " AND (m.metadata->>'kg_backfill') IS NULL"
     )
     params: list[Any] = []
     if since is not None:
@@ -65,18 +75,17 @@ def build_fetch_query(
     if memory_id is not None:
         params.append(memory_id)
         sql += f" AND m.id = ${len(params)}::uuid"
+    if after is not None:
+        params.extend([after[0], after[1]])
+        sql += (
+            f" AND (m.created_at, m.id) > (${len(params) - 1}, ${len(params)}::uuid)"
+        )
     if not count_only:
-        sql += " ORDER BY m.created_at"
+        sql += " ORDER BY m.created_at, m.id"
     if limit is not None:
         params.append(limit)
         sql += f" LIMIT ${len(params)}"
     return sql, params
-
-
-def chunked(items: Sequence[Any], size: int) -> Iterator[list[Any]]:
-    """Yield successive lists of at most ``size`` items."""
-    for i in range(0, len(items), size):
-        yield list(items[i : i + size])
 
 
 def format_summary(stats: dict[str, int]) -> str:
@@ -168,8 +177,43 @@ async def backfill_one(memory_id: str, content: str) -> dict[str, Any]:
         return {"status": "error", "error": str(e)[:200]}
 
 
+async def mark_no_entities(pool: Any, memory_ids: list[str]) -> None:
+    """Durably mark zero-entity memories so reruns skip them."""
+    if not memory_ids:
+        return
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE archival_memory "
+            "SET metadata = COALESCE(metadata, '{}'::jsonb) "
+            "|| '{\"kg_backfill\": \"no_entities\"}'::jsonb "
+            "WHERE id = ANY($1::uuid[])",
+            memory_ids,
+        )
+
+
+async def _fetch_page(
+    pool: Any,
+    args: argparse.Namespace,
+    after: tuple[datetime, str] | None,
+    page_size: int,
+) -> list[Any]:
+    """Fetch one keyset page of eligible memories."""
+    sql, params = build_fetch_query(
+        limit=page_size,
+        since=args.since,
+        memory_id=args.memory_id,
+        after=after,
+    )
+    async with pool.acquire() as conn:
+        return await conn.fetch(sql, *params)
+
+
 async def run_backfill(args: argparse.Namespace) -> int:
-    """Run the backfill per parsed CLI args. Returns a process exit code."""
+    """Run the backfill per parsed CLI args.
+
+    Exit codes: 0 = success, 1 = unusable backend, 2 = some rows failed
+    (failed rows stay eligible and are retried on the next run).
+    """
     backend = detect_backend(dict(os.environ), fallback="sqlite")
     if backend != "postgres":
         _log(
@@ -191,26 +235,41 @@ async def run_backfill(args: argparse.Namespace) -> int:
             _log(f"--limit {args.limit} would cap this run at {min(eligible, args.limit)}")
         return 0
 
-    sql, params = build_fetch_query(
-        limit=args.limit, since=args.since, memory_id=args.memory_id
-    )
-    async with pool.acquire() as conn:
-        rows = await conn.fetch(sql, *params)
-
-    total = len(rows)
-    _log(f"{total} memories to index")
     stats = {"processed": 0, "indexed": 0, "no_entities": 0, "errors": 0}
-    for batch in chunked(rows, args.batch_size):
-        for row in batch:
+    after: tuple[datetime, str] | None = None
+    remaining = args.limit
+    while True:
+        page_size = (
+            args.batch_size if remaining is None else min(args.batch_size, remaining)
+        )
+        if page_size <= 0:
+            break
+        rows = await _fetch_page(pool, args, after, page_size)
+        if not rows:
+            break
+
+        no_entity_ids: list[str] = []
+        for row in rows:
             result = await backfill_one(str(row["id"]), row["content"])
             stats["processed"] += 1
             status = result["status"]
             stats["errors" if status == "error" else status] += 1
             if status == "error":
                 _log(f"error indexing {row['id']}: {result['error']}")
-        _log(f"progress: {stats['processed']}/{total}")
+            elif status == "no_entities":
+                no_entity_ids.append(str(row["id"]))
+        await mark_no_entities(pool, no_entity_ids)
+
+        last = rows[-1]
+        after = (last["created_at"], str(last["id"]))
+        if remaining is not None:
+            remaining -= len(rows)
+        _log(f"progress: {stats['processed']} processed")
+        if len(rows) < page_size:
+            break
+
     print(format_summary(stats), flush=True)
-    return 0
+    return 2 if stats["errors"] else 0
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/core/backfill_kg.py
+++ b/scripts/core/backfill_kg.py
@@ -30,7 +30,7 @@ from collections.abc import Sequence
 from datetime import UTC, datetime
 from typing import Any
 
-from scripts.core.db.postgres_pool import get_pool
+from scripts.core.db.postgres_pool import close_pool, get_pool
 from scripts.core.kg_extractor import (
     extract_entities,
     extract_relations,
@@ -353,11 +353,19 @@ def _bootstrap() -> None:
         load_dotenv(opc_env, override=True)
 
 
+async def _main_async(argv: Sequence[str]) -> int:
+    """Run the CLI and always close the connection pool on the way out."""
+    _bootstrap()
+    args = parse_args(argv)
+    try:
+        return await run_backfill(args)
+    finally:
+        await close_pool()
+
+
 def main() -> None:
     """CLI entry point."""
-    _bootstrap()
-    args = parse_args(sys.argv[1:])
-    sys.exit(asyncio.run(run_backfill(args)))
+    sys.exit(asyncio.run(_main_async(sys.argv[1:])))
 
 
 if __name__ == "__main__":

--- a/scripts/core/backfill_kg.py
+++ b/scripts/core/backfill_kg.py
@@ -50,6 +50,7 @@ def build_fetch_query(
     count_only: bool = False,
     after: tuple[datetime, str] | None = None,
     project: str | None = None,
+    recheck_no_entities: bool = False,
 ) -> tuple[str, list[Any]]:
     """Build the SQL to select memories that still need KG indexing.
 
@@ -60,6 +61,8 @@ def build_fetch_query(
 
     A targeted ``memory_id`` run bypasses the kg_backfill marker so a row
     previously marked no_entities can be reprocessed (repair path).
+    ``recheck_no_entities`` does the same for bulk runs, letting an
+    extractor upgrade revisit previously marked rows.
 
     ``after`` is a (created_at, id) keyset cursor: combined with the
     deterministic ORDER BY it pages through the backlog without loading it
@@ -71,7 +74,7 @@ def build_fetch_query(
         "WHERE NOT EXISTS ("
         "SELECT 1 FROM kg_entity_mentions km WHERE km.memory_id = m.id)"
     )
-    if memory_id is None:
+    if memory_id is None and not recheck_no_entities:
         sql += " AND (m.metadata->>'kg_backfill') IS NULL"
     params: list[Any] = []
     if since is not None:
@@ -163,7 +166,9 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
         "--memory-id",
         type=_uuid_str,
         default=None,
-        help="Backfill a single memory by UUID (bypasses the no_entities marker)",
+        help="Backfill a single still-unindexed memory by UUID. Bypasses the "
+        "no_entities marker; rows that already have kg_entity_mentions are "
+        "skipped. Mutually exclusive with --since/--project/--limit.",
     )
     parser.add_argument(
         "--project",
@@ -172,12 +177,23 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
         "the KG is a global graph by design)",
     )
     parser.add_argument(
+        "--recheck-no-entities",
+        action="store_true",
+        help="Re-include rows previously marked kg_backfill=no_entities "
+        "(use after extractor upgrades)",
+    )
+    parser.add_argument(
         "--batch-size",
         type=_positive_int,
         default=500,
-        help="Progress-logging batch size (default 500)",
+        help="DB page size and progress-logging batch (default 500)",
     )
-    return parser.parse_args(argv)
+    args = parser.parse_args(argv)
+    if args.memory_id is not None and (
+        args.since is not None or args.project is not None or args.limit is not None
+    ):
+        parser.error("--memory-id cannot be combined with --since/--project/--limit")
+    return args
 
 
 # ---------------------------------------------------------------------------
@@ -225,6 +241,7 @@ async def _fetch_page(
         memory_id=args.memory_id,
         after=after,
         project=args.project,
+        recheck_no_entities=args.recheck_no_entities,
     )
     async with pool.acquire() as conn:
         return await conn.fetch(sql, *params)
@@ -252,6 +269,7 @@ async def run_backfill(args: argparse.Namespace) -> int:
             memory_id=args.memory_id,
             count_only=True,
             project=args.project,
+            recheck_no_entities=args.recheck_no_entities,
         )
         async with pool.acquire() as conn:
             eligible = await conn.fetchval(sql, *params)

--- a/scripts/core/backfill_kg.py
+++ b/scripts/core/backfill_kg.py
@@ -27,7 +27,7 @@ import sys
 import time
 import uuid
 from collections.abc import Sequence
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 from scripts.core.db.postgres_pool import get_pool
@@ -49,6 +49,7 @@ def build_fetch_query(
     memory_id: str | None = None,
     count_only: bool = False,
     after: tuple[datetime, str] | None = None,
+    project: str | None = None,
 ) -> tuple[str, list[Any]]:
     """Build the SQL to select memories that still need KG indexing.
 
@@ -56,6 +57,9 @@ def build_fetch_query(
     Eligibility excludes memories that already have a kg_entity_mentions row
     and memories durably marked kg_backfill in metadata (zero-entity rows),
     so partial runs resume cleanly and reruns converge to a no-op.
+
+    A targeted ``memory_id`` run bypasses the kg_backfill marker so a row
+    previously marked no_entities can be reprocessed (repair path).
 
     ``after`` is a (created_at, id) keyset cursor: combined with the
     deterministic ORDER BY it pages through the backlog without loading it
@@ -66,8 +70,9 @@ def build_fetch_query(
         f"{select} FROM archival_memory m "
         "WHERE NOT EXISTS ("
         "SELECT 1 FROM kg_entity_mentions km WHERE km.memory_id = m.id)"
-        " AND (m.metadata->>'kg_backfill') IS NULL"
     )
+    if memory_id is None:
+        sql += " AND (m.metadata->>'kg_backfill') IS NULL"
     params: list[Any] = []
     if since is not None:
         params.append(since)
@@ -75,6 +80,9 @@ def build_fetch_query(
     if memory_id is not None:
         params.append(memory_id)
         sql += f" AND m.id = ${len(params)}::uuid"
+    if project is not None:
+        params.append(project)
+        sql += f" AND m.project = ${len(params)}"
     if after is not None:
         params.extend([after[0], after[1]])
         sql += (
@@ -106,11 +114,18 @@ def _positive_int(value: str) -> int:
 
 
 def _iso_datetime(value: str) -> datetime:
-    """Argparse type for ISO-8601 dates/datetimes."""
+    """Argparse type for ISO-8601 dates/datetimes.
+
+    Naive inputs are normalized to UTC so the cutoff against the
+    TIMESTAMPTZ created_at column does not depend on runtime timezone.
+    """
     try:
-        return datetime.fromisoformat(value)
+        parsed = datetime.fromisoformat(value)
     except ValueError as e:
         raise argparse.ArgumentTypeError(f"invalid ISO date: {value!r}") from e
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed
 
 
 def _uuid_str(value: str) -> str:
@@ -148,7 +163,13 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
         "--memory-id",
         type=_uuid_str,
         default=None,
-        help="Backfill a single memory by UUID",
+        help="Backfill a single memory by UUID (bypasses the no_entities marker)",
+    )
+    parser.add_argument(
+        "--project",
+        default=None,
+        help="Only memories tagged with this project (default: all projects; "
+        "the KG is a global graph by design)",
     )
     parser.add_argument(
         "--batch-size",
@@ -203,6 +224,7 @@ async def _fetch_page(
         since=args.since,
         memory_id=args.memory_id,
         after=after,
+        project=args.project,
     )
     async with pool.acquire() as conn:
         return await conn.fetch(sql, *params)
@@ -226,7 +248,10 @@ async def run_backfill(args: argparse.Namespace) -> int:
 
     if args.dry_run:
         sql, params = build_fetch_query(
-            since=args.since, memory_id=args.memory_id, count_only=True
+            since=args.since,
+            memory_id=args.memory_id,
+            count_only=True,
+            project=args.project,
         )
         async with pool.acquire() as conn:
             eligible = await conn.fetchval(sql, *params)

--- a/tests/test_backfill_kg.py
+++ b/tests/test_backfill_kg.py
@@ -11,8 +11,8 @@ import pytest
 from scripts.core.backfill_kg import (
     backfill_one,
     build_fetch_query,
-    chunked,
     format_summary,
+    mark_no_entities,
     parse_args,
     run_backfill,
 )
@@ -32,25 +32,38 @@ def _mock_pool(conn: AsyncMock) -> MagicMock:
     return pool
 
 
+def _row(content: str = "content") -> dict:
+    """Build a fake archival_memory row."""
+    return {
+        "id": uuid.uuid4(),
+        "content": content,
+        "created_at": datetime(2026, 1, 1, tzinfo=UTC),
+    }
+
+
 # ---------------------------------------------------------------------------
 # Pure: build_fetch_query
 # ---------------------------------------------------------------------------
 
 
 class TestBuildFetchQuery:
-    def test_default_selects_unindexed_memories(self):
+    def test_default_selects_unindexed_unmarked_memories(self):
         sql, params = build_fetch_query()
         assert "SELECT id, content" in sql
         assert "archival_memory" in sql
         assert "NOT EXISTS" in sql
         assert "kg_entity_mentions" in sql
-        assert "ORDER BY" in sql
+        # Zero-entity memories are durably marked and excluded on reruns
+        assert "kg_backfill" in sql
+        # Keyset pagination requires a deterministic order with id tiebreak
+        assert "ORDER BY m.created_at, m.id" in sql
         assert params == []
 
     def test_count_only_uses_count_star(self):
         sql, params = build_fetch_query(count_only=True)
         assert "count(*)" in sql.lower()
         assert "NOT EXISTS" in sql
+        assert "kg_backfill" in sql
         assert "ORDER BY" not in sql
         assert params == []
 
@@ -71,28 +84,20 @@ class TestBuildFetchQuery:
         assert "id = $1" in sql
         assert params == [mid]
 
+    def test_after_adds_keyset_predicate(self):
+        after = (datetime(2026, 1, 1, tzinfo=UTC), str(uuid.uuid4()))
+        sql, params = build_fetch_query(after=after)
+        assert "(m.created_at, m.id) > ($1, $2::uuid)" in sql
+        assert params == [after[0], after[1]]
+
     def test_combined_filters_number_params_consecutively(self):
         since = datetime(2026, 1, 1, tzinfo=UTC)
-        sql, params = build_fetch_query(limit=10, since=since)
+        after = (datetime(2026, 2, 1, tzinfo=UTC), str(uuid.uuid4()))
+        sql, params = build_fetch_query(limit=10, since=since, after=after)
         assert "created_at >= $1" in sql
-        assert "LIMIT $2" in sql
-        assert params == [since, 10]
-
-
-# ---------------------------------------------------------------------------
-# Pure: chunked
-# ---------------------------------------------------------------------------
-
-
-class TestChunked:
-    def test_even_split(self):
-        assert list(chunked([1, 2, 3, 4], 2)) == [[1, 2], [3, 4]]
-
-    def test_remainder_in_last_chunk(self):
-        assert list(chunked([1, 2, 3, 4, 5], 2)) == [[1, 2], [3, 4], [5]]
-
-    def test_empty_input(self):
-        assert list(chunked([], 3)) == []
+        assert "(m.created_at, m.id) > ($2, $3::uuid)" in sql
+        assert "LIMIT $4" in sql
+        assert params == [since, after[0], after[1], 10]
 
 
 # ---------------------------------------------------------------------------
@@ -206,6 +211,34 @@ class TestBackfillOne:
 
 
 # ---------------------------------------------------------------------------
+# Async: mark_no_entities
+# ---------------------------------------------------------------------------
+
+
+class TestMarkNoEntities:
+    async def test_marks_ids_in_metadata(self):
+        conn = AsyncMock()
+        pool = _mock_pool(conn)
+        ids = [str(uuid.uuid4()), str(uuid.uuid4())]
+
+        await mark_no_entities(pool, ids)
+
+        conn.execute.assert_awaited_once()
+        sql_arg = conn.execute.await_args[0][0]
+        assert "kg_backfill" in sql_arg
+        assert "UPDATE archival_memory" in sql_arg
+        assert conn.execute.await_args[0][1] == ids
+
+    async def test_empty_ids_is_noop(self):
+        conn = AsyncMock()
+        pool = _mock_pool(conn)
+
+        await mark_no_entities(pool, [])
+
+        conn.execute.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
 # Async: run_backfill orchestration
 # ---------------------------------------------------------------------------
 
@@ -250,12 +283,10 @@ class TestRunBackfill:
         assert "42" in capsys.readouterr().out
         mock_store.assert_not_called()
 
-    async def test_processes_rows_and_continues_on_error(self, capsys):
-        rows = [
-            {"id": uuid.uuid4(), "content": f"content {i}"} for i in range(3)
-        ]
+    async def test_partial_errors_exit_nonzero(self, capsys):
+        rows = [_row(f"content {i}") for i in range(3)]
         conn = AsyncMock()
-        conn.fetch.return_value = rows
+        conn.fetch.side_effect = [rows, []]
         pool = _mock_pool(conn)
 
         outcomes = [
@@ -281,19 +312,45 @@ class TestRunBackfill:
         ):
             rc = await run_backfill(parse_args([]))
 
-        assert rc == 0
+        # Partial failure must be visible to automation
+        assert rc == 2
         assert mock_one.await_count == 3
         out = capsys.readouterr().out
-        # Summary reflects one of each outcome
         assert "indexed" in out
         assert "errors" in out
 
-    async def test_batching_respects_batch_size(self):
-        rows = [
-            {"id": uuid.uuid4(), "content": f"content {i}"} for i in range(5)
-        ]
+    async def test_all_success_exits_zero(self):
+        rows = [_row()]
         conn = AsyncMock()
-        conn.fetch.return_value = rows
+        conn.fetch.side_effect = [rows, []]
+        pool = _mock_pool(conn)
+
+        with (
+            patch(
+                "scripts.core.backfill_kg.detect_backend", return_value="postgres"
+            ),
+            patch(
+                "scripts.core.backfill_kg.get_pool",
+                new_callable=AsyncMock,
+                return_value=pool,
+            ),
+            patch(
+                "scripts.core.backfill_kg.backfill_one",
+                new_callable=AsyncMock,
+                return_value={
+                    "status": "indexed",
+                    "stats": {"entities": 1, "edges": 0, "mentions": 1},
+                },
+            ),
+        ):
+            rc = await run_backfill(parse_args([]))
+
+        assert rc == 0
+
+    async def test_no_entity_rows_are_marked(self):
+        rows = [_row("plain text")]
+        conn = AsyncMock()
+        conn.fetch.side_effect = [rows, []]
         pool = _mock_pool(conn)
 
         with (
@@ -309,12 +366,84 @@ class TestRunBackfill:
                 "scripts.core.backfill_kg.backfill_one",
                 new_callable=AsyncMock,
                 return_value={"status": "no_entities"},
+            ),
+            patch(
+                "scripts.core.backfill_kg.mark_no_entities",
+                new_callable=AsyncMock,
+            ) as mock_mark,
+        ):
+            rc = await run_backfill(parse_args([]))
+
+        assert rc == 0
+        mock_mark.assert_awaited_once()
+        marked_ids = mock_mark.await_args[0][1]
+        assert marked_ids == [str(rows[0]["id"])]
+
+    async def test_pagination_fetches_in_batch_sized_pages(self):
+        pages = [
+            [_row("a"), _row("b")],
+            [_row("c"), _row("d")],
+            [_row("e")],
+        ]
+        conn = AsyncMock()
+        conn.fetch.side_effect = pages
+        pool = _mock_pool(conn)
+
+        with (
+            patch(
+                "scripts.core.backfill_kg.detect_backend", return_value="postgres"
+            ),
+            patch(
+                "scripts.core.backfill_kg.get_pool",
+                new_callable=AsyncMock,
+                return_value=pool,
+            ),
+            patch(
+                "scripts.core.backfill_kg.backfill_one",
+                new_callable=AsyncMock,
+                return_value={
+                    "status": "indexed",
+                    "stats": {"entities": 1, "edges": 0, "mentions": 1},
+                },
             ) as mock_one,
         ):
             rc = await run_backfill(parse_args(["--batch-size", "2"]))
 
         assert rc == 0
         assert mock_one.await_count == 5
+        # Short final page (1 < 2) terminates the loop without a 4th fetch
+        assert conn.fetch.await_count == 3
+
+    async def test_limit_caps_total_processed(self):
+        pages = [[_row("a"), _row("b")], [_row("c")]]
+        conn = AsyncMock()
+        conn.fetch.side_effect = pages
+        pool = _mock_pool(conn)
+
+        with (
+            patch(
+                "scripts.core.backfill_kg.detect_backend", return_value="postgres"
+            ),
+            patch(
+                "scripts.core.backfill_kg.get_pool",
+                new_callable=AsyncMock,
+                return_value=pool,
+            ),
+            patch(
+                "scripts.core.backfill_kg.backfill_one",
+                new_callable=AsyncMock,
+                return_value={
+                    "status": "indexed",
+                    "stats": {"entities": 1, "edges": 0, "mentions": 1},
+                },
+            ) as mock_one,
+        ):
+            rc = await run_backfill(
+                parse_args(["--batch-size", "2", "--limit", "3"])
+            )
+
+        assert rc == 0
+        assert mock_one.await_count == 3
 
 
 # ---------------------------------------------------------------------------
@@ -350,9 +479,10 @@ class TestBackfillIntegration:
         yield
         reset_pool()
 
-    async def _seed(self, conn, marker: str, n: int = 3) -> list[str]:
+    async def _seed(self, conn, marker: str) -> tuple[list[str], str]:
+        """Insert 3 entity-bearing memories plus 1 zero-entity memory."""
         ids = []
-        for i in range(n):
+        for i in range(3):
             row = await conn.fetchrow(
                 """
                 INSERT INTO archival_memory (session_id, content, content_hash)
@@ -364,7 +494,18 @@ class TestBackfillIntegration:
                 f"bf124-{marker}-{i}",
             )
             ids.append(str(row["id"]))
-        return ids
+        row = await conn.fetchrow(
+            """
+            INSERT INTO archival_memory (session_id, content, content_hash)
+            VALUES ($1, $2, $3)
+            RETURNING id
+            """,
+            f"test-backfill-kg-{marker}",
+            "the meeting went well and everyone agreed on the plan",
+            f"bf124-{marker}-noent",
+        )
+        no_entity_id = str(row["id"])
+        return ids + [no_entity_id], no_entity_id
 
     async def _cleanup(self, conn, marker: str, ids: list[str]):
         await conn.execute(
@@ -397,9 +538,8 @@ class TestBackfillIntegration:
         marker = uuid.uuid4().hex[:8]
         pool = await get_pool()
         async with pool.acquire() as conn:
-            ids = await self._seed(conn, marker)
+            ids, no_entity_id = await self._seed(conn, marker)
         try:
-            seeded_at = None
             async with pool.acquire() as conn:
                 seeded_at = await conn.fetchval(
                     "SELECT min(created_at) FROM archival_memory "
@@ -418,7 +558,13 @@ class TestBackfillIntegration:
                     "WHERE memory_id = ANY($1::uuid[])",
                     ids,
                 )
+                no_entity_flag = await conn.fetchval(
+                    "SELECT metadata->>'kg_backfill' FROM archival_memory "
+                    "WHERE id = $1::uuid",
+                    no_entity_id,
+                )
             assert mentions_after_first > 0
+            assert no_entity_flag == "no_entities"
 
             rc2 = await run_backfill(parse_args(["--since", since_arg]))
             assert rc2 == 0
@@ -429,7 +575,13 @@ class TestBackfillIntegration:
                     "WHERE memory_id = ANY($1::uuid[])",
                     ids,
                 )
+                sql, params = build_fetch_query(
+                    since=seeded_at, count_only=True
+                )
+                eligible_after_second = await conn.fetchval(sql, *params)
             assert mentions_after_second == mentions_after_first
+            # Zero-entity row is durably marked: nothing left to retry
+            assert eligible_after_second == 0
         finally:
             async with pool.acquire() as conn:
                 await self._cleanup(conn, marker, ids)

--- a/tests/test_backfill_kg.py
+++ b/tests/test_backfill_kg.py
@@ -250,6 +250,17 @@ class TestBackfillOne:
         assert result["status"] == "error"
         assert "boom" in result["error"]
 
+    async def test_oversized_content_truncated_before_extraction(self):
+        from scripts.core.backfill_kg import MAX_CONTENT_CHARS
+
+        with patch(
+            "scripts.core.backfill_kg.extract_entities", return_value=[]
+        ) as mock_ents:
+            await backfill_one(str(uuid.uuid4()), "x" * (MAX_CONTENT_CHARS + 5000))
+
+        passed = mock_ents.call_args[0][0]
+        assert len(passed) == MAX_CONTENT_CHARS
+
 
 # ---------------------------------------------------------------------------
 # Async: mark_no_entities
@@ -359,6 +370,38 @@ class TestRunBackfill:
         out = capsys.readouterr().out
         assert "indexed" in out
         assert "errors" in out
+
+    async def test_error_log_sanitizes_control_characters(self, capsys):
+        rows = [_row("adversarial")]
+        conn = AsyncMock()
+        conn.fetch.side_effect = [rows, []]
+        pool = _mock_pool(conn)
+
+        with (
+            patch(
+                "scripts.core.backfill_kg.detect_backend", return_value="postgres"
+            ),
+            patch(
+                "scripts.core.backfill_kg.get_pool",
+                new_callable=AsyncMock,
+                return_value=pool,
+            ),
+            patch(
+                "scripts.core.backfill_kg.backfill_one",
+                new_callable=AsyncMock,
+                return_value={
+                    "status": "error",
+                    "error": "boom\x1b[2J\nFORGED LOG LINE",
+                },
+            ),
+        ):
+            rc = await run_backfill(parse_args([]))
+
+        assert rc == 2
+        out = capsys.readouterr().out
+        # Issue #104 class: no raw escapes or newline-forged lines on the TTY
+        assert "\x1b" not in out
+        assert "\nFORGED LOG LINE" not in out
 
     async def test_all_success_exits_zero(self):
         rows = [_row()]
@@ -521,29 +564,37 @@ class TestBackfillIntegration:
         reset_pool()
 
     async def _seed(self, conn, marker: str) -> tuple[list[str], str]:
-        """Insert 3 entity-bearing memories plus 1 zero-entity memory."""
+        """Insert 3 entity-bearing memories plus 1 zero-entity memory.
+
+        Rows carry a sentinel project so the real run_backfill calls below
+        can be scoped with --project and never touch unrelated memories.
+        """
         ids = []
         for i in range(3):
             row = await conn.fetchrow(
                 """
-                INSERT INTO archival_memory (session_id, content, content_hash)
-                VALUES ($1, $2, $3)
+                INSERT INTO archival_memory (session_id, content, content_hash,
+                                             project)
+                VALUES ($1, $2, $3, $4)
                 RETURNING id
                 """,
                 f"test-backfill-kg-{marker}",
                 f"Fixed bug in scripts/bf124_{marker}_{i}.py using pytest",
                 f"bf124-{marker}-{i}",
+                f"test-bf124-{marker}",
             )
             ids.append(str(row["id"]))
         row = await conn.fetchrow(
             """
-            INSERT INTO archival_memory (session_id, content, content_hash)
-            VALUES ($1, $2, $3)
+            INSERT INTO archival_memory (session_id, content, content_hash,
+                                         project)
+            VALUES ($1, $2, $3, $4)
             RETURNING id
             """,
             f"test-backfill-kg-{marker}",
             "the meeting went well and everyone agreed on the plan",
             f"bf124-{marker}-noent",
+            f"test-bf124-{marker}",
         )
         no_entity_id = str(row["id"])
         return ids + [no_entity_id], no_entity_id
@@ -589,8 +640,9 @@ class TestBackfillIntegration:
                 )
 
             since_arg = seeded_at.isoformat()
+            scope = ["--since", since_arg, "--project", f"test-bf124-{marker}"]
 
-            rc1 = await run_backfill(parse_args(["--since", since_arg]))
+            rc1 = await run_backfill(parse_args(scope))
             assert rc1 == 0
 
             async with pool.acquire() as conn:
@@ -607,7 +659,7 @@ class TestBackfillIntegration:
             assert mentions_after_first > 0
             assert no_entity_flag == "no_entities"
 
-            rc2 = await run_backfill(parse_args(["--since", since_arg]))
+            rc2 = await run_backfill(parse_args(scope))
             assert rc2 == 0
 
             async with pool.acquire() as conn:
@@ -617,7 +669,9 @@ class TestBackfillIntegration:
                     ids,
                 )
                 sql, params = build_fetch_query(
-                    since=seeded_at, count_only=True
+                    since=seeded_at,
+                    project=f"test-bf124-{marker}",
+                    count_only=True,
                 )
                 eligible_after_second = await conn.fetchval(sql, *params)
             assert mentions_after_second == mentions_after_first

--- a/tests/test_backfill_kg.py
+++ b/tests/test_backfill_kg.py
@@ -144,6 +144,12 @@ class TestParseArgs:
         args = parse_args(["--since", "2026-01-01T00:00:00+05:00"])
         assert args.since.utcoffset().total_seconds() == 5 * 3600
 
+    def test_z_suffix_since_accepted_as_utc(self):
+        # Python >= 3.11 fromisoformat accepts the Z suffix natively
+        # (repo floor is 3.13); regression-documented for PR #132 review
+        args = parse_args(["--since", "2026-01-01T00:00:00Z"])
+        assert args.since.utcoffset().total_seconds() == 0
+
     def test_project_flag(self):
         assert parse_args([]).project is None
         assert parse_args(["--project", "opc"]).project == "opc"
@@ -528,6 +534,51 @@ class TestRunBackfill:
 
         assert rc == 0
         assert mock_one.await_count == 3
+
+
+# ---------------------------------------------------------------------------
+# Async: _main_async pool cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestMainAsync:
+    async def test_returns_run_backfill_code_and_closes_pool(self):
+        from scripts.core.backfill_kg import _main_async
+
+        with (
+            patch("scripts.core.backfill_kg._bootstrap"),
+            patch(
+                "scripts.core.backfill_kg.run_backfill",
+                new_callable=AsyncMock,
+                return_value=0,
+            ),
+            patch(
+                "scripts.core.backfill_kg.close_pool", new_callable=AsyncMock
+            ) as mock_close,
+        ):
+            rc = await _main_async(["--dry-run"])
+
+        assert rc == 0
+        mock_close.assert_awaited_once()
+
+    async def test_closes_pool_even_when_run_raises(self):
+        from scripts.core.backfill_kg import _main_async
+
+        with (
+            patch("scripts.core.backfill_kg._bootstrap"),
+            patch(
+                "scripts.core.backfill_kg.run_backfill",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("boom"),
+            ),
+            patch(
+                "scripts.core.backfill_kg.close_pool", new_callable=AsyncMock
+            ) as mock_close,
+        ):
+            with pytest.raises(RuntimeError):
+                await _main_async([])
+
+        mock_close.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_backfill_kg.py
+++ b/tests/test_backfill_kg.py
@@ -78,11 +78,19 @@ class TestBuildFetchQuery:
         assert "created_at >= $1" in sql
         assert params == [since]
 
-    def test_memory_id_filters_id(self):
+    def test_memory_id_filters_id_and_bypasses_marker(self):
         mid = str(uuid.uuid4())
         sql, params = build_fetch_query(memory_id=mid)
         assert "id = $1" in sql
         assert params == [mid]
+        # Targeted repair: --memory-id must reprocess rows previously
+        # marked kg_backfill=no_entities
+        assert "kg_backfill" not in sql
+
+    def test_project_filters_project(self):
+        sql, params = build_fetch_query(project="opc")
+        assert "project = $1" in sql
+        assert params == ["opc"]
 
     def test_after_adds_keyset_predicate(self):
         after = (datetime(2026, 1, 1, tzinfo=UTC), str(uuid.uuid4()))
@@ -120,6 +128,18 @@ class TestParseArgs:
     def test_since_parsed_as_datetime(self):
         args = parse_args(["--since", "2026-01-01"])
         assert isinstance(args.since, datetime)
+
+    def test_naive_since_normalized_to_utc(self):
+        args = parse_args(["--since", "2026-01-01"])
+        assert args.since.tzinfo is UTC
+
+    def test_aware_since_preserves_offset(self):
+        args = parse_args(["--since", "2026-01-01T00:00:00+05:00"])
+        assert args.since.utcoffset().total_seconds() == 5 * 3600
+
+    def test_project_flag(self):
+        assert parse_args([]).project is None
+        assert parse_args(["--project", "opc"]).project == "opc"
 
     def test_invalid_since_rejected(self):
         with pytest.raises(SystemExit):
@@ -582,6 +602,16 @@ class TestBackfillIntegration:
             assert mentions_after_second == mentions_after_first
             # Zero-entity row is durably marked: nothing left to retry
             assert eligible_after_second == 0
+
+            # Targeted repair: --memory-id bypasses the no_entities marker
+            async with pool.acquire() as conn:
+                sql, params = build_fetch_query(
+                    memory_id=no_entity_id, count_only=True
+                )
+                repair_eligible = await conn.fetchval(sql, *params)
+            assert repair_eligible == 1
+            rc3 = await run_backfill(parse_args(["--memory-id", no_entity_id]))
+            assert rc3 == 0
         finally:
             async with pool.acquire() as conn:
                 await self._cleanup(conn, marker, ids)

--- a/tests/test_backfill_kg.py
+++ b/tests/test_backfill_kg.py
@@ -1,0 +1,435 @@
+"""Tests for scripts/core/backfill_kg.py — KG backfill for existing memories (#124)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from scripts.core.backfill_kg import (
+    backfill_one,
+    build_fetch_query,
+    chunked,
+    format_summary,
+    parse_args,
+    run_backfill,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_pool(conn: AsyncMock) -> MagicMock:
+    """Build a mock asyncpg pool whose acquire() yields the given conn."""
+    acm = AsyncMock()
+    acm.__aenter__.return_value = conn
+    acm.__aexit__.return_value = False
+    pool = MagicMock()
+    pool.acquire.return_value = acm
+    return pool
+
+
+# ---------------------------------------------------------------------------
+# Pure: build_fetch_query
+# ---------------------------------------------------------------------------
+
+
+class TestBuildFetchQuery:
+    def test_default_selects_unindexed_memories(self):
+        sql, params = build_fetch_query()
+        assert "SELECT id, content" in sql
+        assert "archival_memory" in sql
+        assert "NOT EXISTS" in sql
+        assert "kg_entity_mentions" in sql
+        assert "ORDER BY" in sql
+        assert params == []
+
+    def test_count_only_uses_count_star(self):
+        sql, params = build_fetch_query(count_only=True)
+        assert "count(*)" in sql.lower()
+        assert "NOT EXISTS" in sql
+        assert "ORDER BY" not in sql
+        assert params == []
+
+    def test_limit_adds_numbered_param(self):
+        sql, params = build_fetch_query(limit=500)
+        assert "LIMIT $1" in sql
+        assert params == [500]
+
+    def test_since_filters_created_at(self):
+        since = datetime(2026, 1, 1, tzinfo=UTC)
+        sql, params = build_fetch_query(since=since)
+        assert "created_at >= $1" in sql
+        assert params == [since]
+
+    def test_memory_id_filters_id(self):
+        mid = str(uuid.uuid4())
+        sql, params = build_fetch_query(memory_id=mid)
+        assert "id = $1" in sql
+        assert params == [mid]
+
+    def test_combined_filters_number_params_consecutively(self):
+        since = datetime(2026, 1, 1, tzinfo=UTC)
+        sql, params = build_fetch_query(limit=10, since=since)
+        assert "created_at >= $1" in sql
+        assert "LIMIT $2" in sql
+        assert params == [since, 10]
+
+
+# ---------------------------------------------------------------------------
+# Pure: chunked
+# ---------------------------------------------------------------------------
+
+
+class TestChunked:
+    def test_even_split(self):
+        assert list(chunked([1, 2, 3, 4], 2)) == [[1, 2], [3, 4]]
+
+    def test_remainder_in_last_chunk(self):
+        assert list(chunked([1, 2, 3, 4, 5], 2)) == [[1, 2], [3, 4], [5]]
+
+    def test_empty_input(self):
+        assert list(chunked([], 3)) == []
+
+
+# ---------------------------------------------------------------------------
+# Pure: parse_args
+# ---------------------------------------------------------------------------
+
+
+class TestParseArgs:
+    def test_defaults(self):
+        args = parse_args([])
+        assert args.dry_run is False
+        assert args.limit is None
+        assert args.since is None
+        assert args.memory_id is None
+        assert args.batch_size == 500
+
+    def test_dry_run_flag(self):
+        assert parse_args(["--dry-run"]).dry_run is True
+
+    def test_since_parsed_as_datetime(self):
+        args = parse_args(["--since", "2026-01-01"])
+        assert isinstance(args.since, datetime)
+
+    def test_invalid_since_rejected(self):
+        with pytest.raises(SystemExit):
+            parse_args(["--since", "not-a-date"])
+
+    def test_memory_id_validated_as_uuid(self):
+        mid = str(uuid.uuid4())
+        assert parse_args(["--memory-id", mid]).memory_id == mid
+
+    def test_invalid_memory_id_rejected(self):
+        with pytest.raises(SystemExit):
+            parse_args(["--memory-id", "not-a-uuid"])
+
+    def test_zero_limit_rejected(self):
+        with pytest.raises(SystemExit):
+            parse_args(["--limit", "0"])
+
+
+# ---------------------------------------------------------------------------
+# Pure: format_summary
+# ---------------------------------------------------------------------------
+
+
+class TestFormatSummary:
+    def test_includes_all_counts(self):
+        text = format_summary(
+            {"processed": 7, "indexed": 4, "no_entities": 2, "errors": 1}
+        )
+        assert "7" in text
+        assert "4" in text
+        assert "2" in text
+        assert "1" in text
+
+
+# ---------------------------------------------------------------------------
+# Async: backfill_one
+# ---------------------------------------------------------------------------
+
+
+class TestBackfillOne:
+    async def test_indexed_path_stores_entities(self):
+        mid = str(uuid.uuid4())
+        entities = [MagicMock()]
+        kg_stats = {"entities": 1, "edges": 0, "mentions": 1}
+
+        with (
+            patch(
+                "scripts.core.backfill_kg.extract_entities", return_value=entities
+            ) as mock_ents,
+            patch(
+                "scripts.core.backfill_kg.extract_relations", return_value=[]
+            ) as mock_rels,
+            patch(
+                "scripts.core.backfill_kg.store_entities_and_edges",
+                new_callable=AsyncMock,
+                return_value=kg_stats,
+            ) as mock_store,
+        ):
+            result = await backfill_one(mid, "uses pytest with asyncpg")
+
+        assert result["status"] == "indexed"
+        assert result["stats"] == kg_stats
+        mock_ents.assert_called_once_with("uses pytest with asyncpg")
+        mock_rels.assert_called_once()
+        mock_store.assert_called_once_with(mid, entities, [])
+
+    async def test_no_entities_skips_store(self):
+        with (
+            patch("scripts.core.backfill_kg.extract_entities", return_value=[]),
+            patch(
+                "scripts.core.backfill_kg.store_entities_and_edges",
+                new_callable=AsyncMock,
+            ) as mock_store,
+        ):
+            result = await backfill_one(str(uuid.uuid4()), "plain text")
+
+        assert result["status"] == "no_entities"
+        mock_store.assert_not_called()
+
+    async def test_exception_is_nonfatal(self):
+        with patch(
+            "scripts.core.backfill_kg.extract_entities",
+            side_effect=RuntimeError("boom"),
+        ):
+            result = await backfill_one(str(uuid.uuid4()), "anything")
+
+        assert result["status"] == "error"
+        assert "boom" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Async: run_backfill orchestration
+# ---------------------------------------------------------------------------
+
+
+class TestRunBackfill:
+    async def test_non_postgres_backend_exits_without_db(self):
+        with (
+            patch(
+                "scripts.core.backfill_kg.detect_backend", return_value="sqlite"
+            ),
+            patch(
+                "scripts.core.backfill_kg.get_pool", new_callable=AsyncMock
+            ) as mock_pool,
+        ):
+            rc = await run_backfill(parse_args([]))
+
+        assert rc == 1
+        mock_pool.assert_not_called()
+
+    async def test_dry_run_reports_count_without_writing(self, capsys):
+        conn = AsyncMock()
+        conn.fetchval.return_value = 42
+        pool = _mock_pool(conn)
+
+        with (
+            patch(
+                "scripts.core.backfill_kg.detect_backend", return_value="postgres"
+            ),
+            patch(
+                "scripts.core.backfill_kg.get_pool",
+                new_callable=AsyncMock,
+                return_value=pool,
+            ),
+            patch(
+                "scripts.core.backfill_kg.store_entities_and_edges",
+                new_callable=AsyncMock,
+            ) as mock_store,
+        ):
+            rc = await run_backfill(parse_args(["--dry-run"]))
+
+        assert rc == 0
+        assert "42" in capsys.readouterr().out
+        mock_store.assert_not_called()
+
+    async def test_processes_rows_and_continues_on_error(self, capsys):
+        rows = [
+            {"id": uuid.uuid4(), "content": f"content {i}"} for i in range(3)
+        ]
+        conn = AsyncMock()
+        conn.fetch.return_value = rows
+        pool = _mock_pool(conn)
+
+        outcomes = [
+            {"status": "indexed", "stats": {"entities": 1, "edges": 0, "mentions": 1}},
+            {"status": "error", "error": "row boom"},
+            {"status": "no_entities"},
+        ]
+
+        with (
+            patch(
+                "scripts.core.backfill_kg.detect_backend", return_value="postgres"
+            ),
+            patch(
+                "scripts.core.backfill_kg.get_pool",
+                new_callable=AsyncMock,
+                return_value=pool,
+            ),
+            patch(
+                "scripts.core.backfill_kg.backfill_one",
+                new_callable=AsyncMock,
+                side_effect=outcomes,
+            ) as mock_one,
+        ):
+            rc = await run_backfill(parse_args([]))
+
+        assert rc == 0
+        assert mock_one.await_count == 3
+        out = capsys.readouterr().out
+        # Summary reflects one of each outcome
+        assert "indexed" in out
+        assert "errors" in out
+
+    async def test_batching_respects_batch_size(self):
+        rows = [
+            {"id": uuid.uuid4(), "content": f"content {i}"} for i in range(5)
+        ]
+        conn = AsyncMock()
+        conn.fetch.return_value = rows
+        pool = _mock_pool(conn)
+
+        with (
+            patch(
+                "scripts.core.backfill_kg.detect_backend", return_value="postgres"
+            ),
+            patch(
+                "scripts.core.backfill_kg.get_pool",
+                new_callable=AsyncMock,
+                return_value=pool,
+            ),
+            patch(
+                "scripts.core.backfill_kg.backfill_one",
+                new_callable=AsyncMock,
+                return_value={"status": "no_entities"},
+            ) as mock_one,
+        ):
+            rc = await run_backfill(parse_args(["--batch-size", "2"]))
+
+        assert rc == 0
+        assert mock_one.await_count == 5
+
+
+# ---------------------------------------------------------------------------
+# Integration: real PostgreSQL (skipped when unavailable)
+# ---------------------------------------------------------------------------
+
+
+def _db_available() -> bool:
+    """Check if PostgreSQL is reachable by attempting a real connection."""
+    import socket
+
+    try:
+        sock = socket.create_connection(("localhost", 5432), timeout=2)
+        sock.close()
+        return True
+    except (OSError, TimeoutError):
+        return False
+
+
+@pytest.mark.skipif(not _db_available(), reason="PostgreSQL not available")
+class TestBackfillIntegration:
+    """Seed real memories, backfill twice, assert the second run is a no-op.
+
+    Uses unique file-path entities so seeded KG rows can be cleaned up
+    without touching pre-existing entities.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _reset_pool(self):
+        from scripts.core.db.postgres_pool import reset_pool
+
+        reset_pool()
+        yield
+        reset_pool()
+
+    async def _seed(self, conn, marker: str, n: int = 3) -> list[str]:
+        ids = []
+        for i in range(n):
+            row = await conn.fetchrow(
+                """
+                INSERT INTO archival_memory (session_id, content, content_hash)
+                VALUES ($1, $2, $3)
+                RETURNING id
+                """,
+                f"test-backfill-kg-{marker}",
+                f"Fixed bug in scripts/bf124_{marker}_{i}.py using pytest",
+                f"bf124-{marker}-{i}",
+            )
+            ids.append(str(row["id"]))
+        return ids
+
+    async def _cleanup(self, conn, marker: str, ids: list[str]):
+        await conn.execute(
+            "DELETE FROM kg_edges WHERE memory_id = ANY($1::uuid[])", ids
+        )
+        await conn.execute(
+            "DELETE FROM kg_entity_mentions WHERE memory_id = ANY($1::uuid[])", ids
+        )
+        await conn.execute(
+            "DELETE FROM kg_entities WHERE name LIKE $1", f"%bf124_{marker}%"
+        )
+        await conn.execute(
+            "DELETE FROM archival_memory WHERE id = ANY($1::uuid[])", ids
+        )
+
+    async def test_backfill_twice_second_run_is_noop(self):
+        import os
+
+        from scripts.core.db.postgres_pool import get_pool
+
+        if not (
+            os.environ.get("CONTINUOUS_CLAUDE_DB_URL")
+            or os.environ.get("DATABASE_URL")
+        ):
+            pytest.skip(
+                "No DB URL in env (CONTINUOUS_CLAUDE_DB_URL / DATABASE_URL); "
+                "issue #62 forbids hardcoded fallbacks"
+            )
+
+        marker = uuid.uuid4().hex[:8]
+        pool = await get_pool()
+        async with pool.acquire() as conn:
+            ids = await self._seed(conn, marker)
+        try:
+            seeded_at = None
+            async with pool.acquire() as conn:
+                seeded_at = await conn.fetchval(
+                    "SELECT min(created_at) FROM archival_memory "
+                    "WHERE id = ANY($1::uuid[])",
+                    ids,
+                )
+
+            since_arg = seeded_at.isoformat()
+
+            rc1 = await run_backfill(parse_args(["--since", since_arg]))
+            assert rc1 == 0
+
+            async with pool.acquire() as conn:
+                mentions_after_first = await conn.fetchval(
+                    "SELECT count(*) FROM kg_entity_mentions "
+                    "WHERE memory_id = ANY($1::uuid[])",
+                    ids,
+                )
+            assert mentions_after_first > 0
+
+            rc2 = await run_backfill(parse_args(["--since", since_arg]))
+            assert rc2 == 0
+
+            async with pool.acquire() as conn:
+                mentions_after_second = await conn.fetchval(
+                    "SELECT count(*) FROM kg_entity_mentions "
+                    "WHERE memory_id = ANY($1::uuid[])",
+                    ids,
+                )
+            assert mentions_after_second == mentions_after_first
+        finally:
+            async with pool.acquire() as conn:
+                await self._cleanup(conn, marker, ids)

--- a/tests/test_backfill_kg.py
+++ b/tests/test_backfill_kg.py
@@ -92,6 +92,13 @@ class TestBuildFetchQuery:
         assert "project = $1" in sql
         assert params == ["opc"]
 
+    def test_recheck_no_entities_includes_marked_rows(self):
+        # After an extractor upgrade, bulk runs can revisit rows previously
+        # marked no_entities
+        sql, params = build_fetch_query(recheck_no_entities=True)
+        assert "kg_backfill" not in sql
+        assert params == []
+
     def test_after_adds_keyset_predicate(self):
         after = (datetime(2026, 1, 1, tzinfo=UTC), str(uuid.uuid4()))
         sql, params = build_fetch_query(after=after)
@@ -156,6 +163,20 @@ class TestParseArgs:
     def test_zero_limit_rejected(self):
         with pytest.raises(SystemExit):
             parse_args(["--limit", "0"])
+
+    def test_recheck_no_entities_flag(self):
+        assert parse_args([]).recheck_no_entities is False
+        assert parse_args(["--recheck-no-entities"]).recheck_no_entities is True
+
+    def test_memory_id_exclusive_with_other_scoping_flags(self):
+        mid = str(uuid.uuid4())
+        for extra in (
+            ["--since", "2026-01-01"],
+            ["--project", "opc"],
+            ["--limit", "5"],
+        ):
+            with pytest.raises(SystemExit):
+                parse_args(["--memory-id", mid, *extra])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #124. Adds `scripts/core/backfill_kg.py`, a CLI that walks `archival_memory` rows with no KG presence and runs the same extraction + storage path as `store_learning._try_index_kg` (`extract_entities` → `extract_relations` → `store_entities_and_edges`), so the Phase 3 query-time enrichment (`kg_context`, `kg_overlap` reranker signal) has data for the ~5,540 historical memories.

## Design

- **Idempotent**: `store_entities_and_edges` dedupes on `(memory_id, entity_id)` and `(source_id, target_id, relation, memory_id)`; re-running is a no-op.
- **Convergent**: zero-entity rows are durably marked `metadata.kg_backfill = "no_entities"` so reruns skip them instead of retrying forever. `--recheck-no-entities` re-includes them after extractor upgrades; `--memory-id` bypasses the marker for targeted repair.
- **Resumable + bounded memory**: keyset pagination on `(created_at, id)` — `--batch-size` (default 500) bounds both the DB read window and progress logging; the backlog is never fully materialized.
- **Non-fatal per row, visible to automation**: per-row failures log and continue; exit codes are 0 = success, 1 = non-postgres backend, 2 = partial failure (failed rows stay eligible for retry).
- **Flags**: `--dry-run`, `--limit N`, `--since <iso>` (naive values normalized to UTC), `--memory-id <uuid>` (mutually exclusive with other scoping flags), `--project <name>`, `--recheck-no-entities`, `--batch-size N`.

## Review gates (Large Plan Workflow)

- **3 rounds of `/codex:adversarial-review`**, fixes committed between rounds:
  - R1: durable no_entities marker, exit 2 on partial failure, keyset pagination (replaced full-backlog fetch).
  - R2: `--memory-id` repair bypass for the marker, naive `--since` normalized to UTC, optional `--project` filter (KG stays global by design; broader scoping tracked in #130).
  - R3: `--recheck-no-entities` for bulk marker invalidation after extractor upgrades, `--memory-id` made mutually exclusive with `--since`/`--project`/`--limit`, help text narrowed to actual semantics.
- **Security review (aegis)**: 0 critical, 0 high, 3 medium, 3 low. SQL injection check clean — every user/data value binds via numbered `$N` parameters. Mediums fixed in `bb6e111`: error logs wrapped with `log_safety.safe()` (issue #104 class), per-row content capped at 100k chars before regex extraction, integration test scoped to a sentinel project. LOW (infra-vs-row error distinction) deferred to #131. Report: `thoughts/shared/agents/aegis/issue-124-backfill-kg-security.md` (untracked; thoughts/ is gitignored).

## Tests

TDD throughout (failing test first for every behavior). 37 tests in `tests/test_backfill_kg.py`: pure SQL-builder/arg-parsing units, mocked orchestration (pagination, exit codes, marker writes, log sanitization), and a live-Postgres integration test that seeds 3 entity-bearing + 1 zero-entity memory under a sentinel project, backfills twice, asserts the second run is a no-op (0 eligible rows), verifies the no_entities marker, exercises the `--memory-id` repair bypass, and cleans up after itself.

Full suite: 2412 passed, 1 skipped.

## Coverage

```
Name                          Stmts   Miss  Cover   Missing
-----------------------------------------------------------
scripts/core/backfill_kg.py     154     13    92%   289, 344-353, 358-360, 364
```

Missing lines are the CLI bootstrap (`_bootstrap`, `main`, `__main__` guard) and one loop-exit branch.

## Acceptance criteria (issue #124)

- [x] `--dry-run` reports counts without writing (unit + integration)
- [x] Backfill populates `kg_entities`/`kg_edges`/`kg_entity_mentions` for eligible memories (integration)
- [x] Re-running is a no-op (integration: second run finds 0 eligible)
- [ ] Post-merge: run the full backfill from `main` against the ~5,540 rows and validate one targeted `recall_learnings` query returns non-empty `kg_context` — will post results as a comment on this PR

The full production backfill is deliberately deferred until this code is merged, so the data write happens from reviewed code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a knowledge-graph backfill CLI to populate entity and relation data for archival memories. Supports dry-run, batching/limits, targeted memory repair, optional recheck of previously marked no-entity records, durable marking of zero-entity memories, content truncation for large inputs, idempotent runs, sanitized logging, and clear exit codes for success/partial-failure/environment gating.

* **Tests**
  * Added extensive coverage for query logic, CLI parsing/validation, per-item extraction/storage behavior, orchestration/pagination, idempotency, error handling, and integration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->