### PR TITLE
fix(kg): sys.path bootstrap for direct file invocation of backfill_kg.py

### DIFF
--- a/scripts/core/backfill_kg.py
+++ b/scripts/core/backfill_kg.py
@@ -28,7 +28,15 @@ import time
 import uuid
 from collections.abc import Sequence
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
+
+# Ensure project root is on sys.path so `scripts.*` imports work
+# when launched via `uv run python scripts/core/backfill_kg.py`
+# (which doesn't add cwd to sys.path) — memory_daemon.py pattern
+_project_root = str(Path(__file__).parent.parent.parent)
+if _project_root not in sys.path:
+    sys.path.insert(0, _project_root)
 
 from scripts.core.db.postgres_pool import close_pool, get_pool
 from scripts.core.kg_extractor import (

--- a/scripts/core/backfill_kg.py
+++ b/scripts/core/backfill_kg.py
@@ -34,7 +34,7 @@ from typing import Any
 # Ensure project root is on sys.path so `scripts.*` imports work
 # when launched via `uv run python scripts/core/backfill_kg.py`
 # (which doesn't add cwd to sys.path) — memory_daemon.py pattern
-_project_root = str(Path(__file__).parent.parent.parent)
+_project_root = str(Path(__file__).resolve().parent.parent.parent)
 if _project_root not in sys.path:
     sys.path.insert(0, _project_root)
 

--- a/tests/test_backfill_kg.py
+++ b/tests/test_backfill_kg.py
@@ -590,14 +590,19 @@ class TestDirectInvocation:
     def test_script_runs_directly_without_module_flag(self):
         """Issue #124 acceptance uses `python scripts/core/backfill_kg.py`;
         the script needs the project root on sys.path (memory_daemon pattern)."""
+        import os
         import subprocess
         import sys
         from pathlib import Path
 
-        project_root = Path(__file__).parent.parent
+        project_root = Path(__file__).resolve().parent.parent
+        # Sanitized env: an inherited PYTHONPATH containing the project root
+        # would make scripts.* importable and false-green this test
+        child_env = {k: v for k, v in os.environ.items() if k != "PYTHONPATH"}
         proc = subprocess.run(
             [sys.executable, "scripts/core/backfill_kg.py", "--help"],
             cwd=project_root,
+            env=child_env,
             capture_output=True,
             text=True,
             timeout=30,

--- a/tests/test_backfill_kg.py
+++ b/tests/test_backfill_kg.py
@@ -582,6 +582,31 @@ class TestMainAsync:
 
 
 # ---------------------------------------------------------------------------
+# CLI: direct file invocation
+# ---------------------------------------------------------------------------
+
+
+class TestDirectInvocation:
+    def test_script_runs_directly_without_module_flag(self):
+        """Issue #124 acceptance uses `python scripts/core/backfill_kg.py`;
+        the script needs the project root on sys.path (memory_daemon pattern)."""
+        import subprocess
+        import sys
+        from pathlib import Path
+
+        project_root = Path(__file__).parent.parent
+        proc = subprocess.run(
+            [sys.executable, "scripts/core/backfill_kg.py", "--help"],
+            cwd=project_root,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert "--dry-run" in proc.stdout
+
+
+# ---------------------------------------------------------------------------
 # Integration: real PostgreSQL (skipped when unavailable)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Follow-up to #132. The issue #124 acceptance criteria use direct file invocation (`uv run python scripts/core/backfill_kg.py --dry-run`), which failed with `ModuleNotFoundError: No module named 'scripts'` because `uv run` does not add the cwd to `sys.path`. Only the `-m` module form worked.

Fix: the same project-root `sys.path` bootstrap used by `scripts/core/memory_daemon.py` (lines 43-47), inserted before the `scripts.*` imports.

TDD: added `TestDirectInvocation::test_script_runs_directly_without_module_flag` (subprocess `--help` run from the project root) — watched it fail with the ModuleNotFoundError, then green after the bootstrap. 41 module tests pass; ruff clean. Full suite green except the pre-existing machine-local false positive tracked in #133.

Note: `backfill_learnings.py` has the same direct-invocation failure; left untouched per out-of-scope policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * The backfill script can now be executed directly from the command line (e.g., `python scripts/core/backfill_kg.py --help`) without requiring special module-style invocation, improving usability.

* **Tests**
  * Added CLI acceptance test to verify direct script execution functions correctly and displays expected help information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->