### PR TITLE
Recall-tuning loop: golden re-anchor + feedback labels + journal/keep-discard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,7 @@ thoughts/
 .vscode/
 
 .qlty/
+
+# Recall-tuning experiment journal (append-only, machine-local like
+# autoresearch's results.tsv — institutional memory, not source).
+scripts/benchmarks/results/journal.tsv

--- a/opc.toml
+++ b/opc.toml
@@ -159,6 +159,14 @@ bm25_normalization_divisor = 25.0
 # outside it, so keep this generous; lower only if EXPLAIN + recall quality hold.
 vector_candidate_multiplier = 8
 
+# Recall-tuning feedback loop. When true, recall_log stores the RAW query text
+# (alongside the always-recorded one-way query_hash) so the feedback miner can
+# materialize human-readable golden queries. DEFAULT false: this reverses the
+# deliberate "recall_log NEVER stores raw query text" privacy stance
+# (issue #139/#140). Enable only as an explicit operator decision, and only
+# after applying scripts/migrations/add_recall_log_query_link.sql.
+log_query_text = false
+
 
 [embedding]
 # Default Ollama model for local embeddings.

--- a/scripts/benchmarks/backfill_golden_hashes.py
+++ b/scripts/benchmarks/backfill_golden_hashes.py
@@ -19,6 +19,7 @@ import argparse
 import asyncio
 import json
 import sys
+import uuid
 from pathlib import Path
 
 from scripts.core.db.postgres_pool import get_pool
@@ -30,8 +31,22 @@ async def lookup_hashes(ids: list[str]) -> dict[str, str]:
     """Map archival_memory id -> content_hash for the given ids.
 
     Missing/NULL content_hash rows are simply absent from the result.
+
+    ``ids`` come from a user-curated JSON file, so they are parsed to
+    ``uuid.UUID`` defensively: asyncpg requires UUID objects (not raw strings)
+    for a ``uuid[]`` parameter, and any malformed id is skipped rather than
+    crashing the whole backfill. Keys in the returned dict are the canonical
+    string form (``id::text``), so callers still look up by their original id.
     """
     if not ids:
+        return {}
+    uuid_ids: list[uuid.UUID] = []
+    for uid in ids:
+        try:
+            uuid_ids.append(uuid.UUID(uid))
+        except (ValueError, TypeError):
+            print(f"  skipping non-UUID golden id: {uid!r}", file=sys.stderr)
+    if not uuid_ids:
         return {}
     pool = await get_pool()
     async with pool.acquire() as conn:
@@ -39,14 +54,14 @@ async def lookup_hashes(ids: list[str]) -> dict[str, str]:
             "SELECT id::text AS id, content_hash "
             "FROM archival_memory "
             "WHERE id = ANY($1::uuid[]) AND content_hash IS NOT NULL",
-            ids,
+            uuid_ids,
         )
     return {r["id"]: r["content_hash"] for r in rows}
 
 
 async def backfill(queries_path: Path, dry_run: bool = False) -> int:
     """Add golden_hashes to every query that has golden_ids. Returns exit code."""
-    query_data = json.loads(queries_path.read_text())
+    query_data = json.loads(queries_path.read_text(encoding="utf-8"))
     queries = query_data["queries"]
 
     # Gather every golden id across all queries, resolve in one round-trip.
@@ -82,7 +97,7 @@ async def backfill(queries_path: Path, dry_run: bool = False) -> int:
         print("Dry run — not writing.")
         return 0
 
-    queries_path.write_text(json.dumps(query_data, indent=2) + "\n")
+    queries_path.write_text(json.dumps(query_data, indent=2) + "\n", encoding="utf-8")
     print(f"Updated {queries_path}")
     return 0
 

--- a/scripts/benchmarks/backfill_golden_hashes.py
+++ b/scripts/benchmarks/backfill_golden_hashes.py
@@ -1,0 +1,110 @@
+"""One-time backfill: re-anchor an existing golden set from UUIDs to content hashes.
+
+Older golden sets (``scripts/benchmarks/rerank_queries.json``) pin relevance with
+``golden_ids`` — raw ``archival_memory`` UUIDs that only mean anything on the DB
+they were curated against. This script looks up each id's stored
+``content_hash`` and writes a parallel ``golden_hashes`` list, so the benchmark
+can judge relevance by content (surviving a fresh DB). Run once after curating or
+when migrating an old query file.
+
+Usage:
+    uv run python scripts/benchmarks/backfill_golden_hashes.py
+    uv run python scripts/benchmarks/backfill_golden_hashes.py --queries custom.json
+    uv run python scripts/benchmarks/backfill_golden_hashes.py --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+from scripts.core.db.postgres_pool import get_pool
+
+DEFAULT_QUERIES = Path("scripts/benchmarks/rerank_queries.json")
+
+
+async def lookup_hashes(ids: list[str]) -> dict[str, str]:
+    """Map archival_memory id -> content_hash for the given ids.
+
+    Missing/NULL content_hash rows are simply absent from the result.
+    """
+    if not ids:
+        return {}
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            "SELECT id::text AS id, content_hash "
+            "FROM archival_memory "
+            "WHERE id = ANY($1::uuid[]) AND content_hash IS NOT NULL",
+            ids,
+        )
+    return {r["id"]: r["content_hash"] for r in rows}
+
+
+async def backfill(queries_path: Path, dry_run: bool = False) -> int:
+    """Add golden_hashes to every query that has golden_ids. Returns exit code."""
+    query_data = json.loads(queries_path.read_text())
+    queries = query_data["queries"]
+
+    # Gather every golden id across all queries, resolve in one round-trip.
+    all_ids = sorted({gid for q in queries for gid in q.get("golden_ids", []) if gid})
+    id_to_hash = await lookup_hashes(all_ids)
+
+    total_resolved = 0
+    total_missing = 0
+    for q in queries:
+        gids = [gid for gid in q.get("golden_ids", []) if gid]
+        if not gids:
+            continue
+        hashes = [id_to_hash[gid] for gid in gids if gid in id_to_hash]
+        missing = [gid for gid in gids if gid not in id_to_hash]
+        total_resolved += len(hashes)
+        total_missing += len(missing)
+        q["golden_hashes"] = hashes
+        status = f"{len(hashes)}/{len(gids)} anchored"
+        if missing:
+            status += f" — {len(missing)} unresolved (not in this DB)"
+        print(f"  {q['id']}: {status}")
+
+    print("=" * 60)
+    print(f"Resolved {total_resolved} hashes; {total_missing} ids unresolved.")
+    if total_missing:
+        print(
+            "Unresolved ids are not in the current DB — re-bootstrap those "
+            "queries against this DB, or accept the partial anchor.",
+            file=sys.stderr,
+        )
+
+    if dry_run:
+        print("Dry run — not writing.")
+        return 0
+
+    queries_path.write_text(json.dumps(query_data, indent=2) + "\n")
+    print(f"Updated {queries_path}")
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Backfill golden_hashes from golden_ids for a benchmark query file"
+    )
+    parser.add_argument("--queries", type=Path, default=DEFAULT_QUERIES)
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Report without writing the file"
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if not args.queries.exists():
+        print(f"Query file not found: {args.queries}", file=sys.stderr)
+        sys.exit(1)
+    sys.exit(asyncio.run(backfill(args.queries, dry_run=args.dry_run)))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmarks/bootstrap_golden.py
+++ b/scripts/benchmarks/bootstrap_golden.py
@@ -19,6 +19,7 @@ import sys
 import textwrap
 from pathlib import Path
 
+from scripts.core.content_hash import content_hash
 
 FETCH_K = 20  # candidates shown per query
 
@@ -174,14 +175,23 @@ async def bootstrap(
             skipped += 1
             print("  Skipped.")
         else:
-            golden_ids = [
-                results[idx].get("id", "")
-                for idx in selection
-                if results[idx].get("id")
+            selected = [results[idx] for idx in selection]
+            golden_ids = [r.get("id", "") for r in selected if r.get("id")]
+            # Re-anchor: store content hashes alongside UUIDs so the golden set
+            # survives a fresh DB where ids differ (run_rerank_benchmark matches
+            # on these first). Same canonical hash used at memory-store time.
+            golden_hashes = [
+                content_hash(r["content"])
+                for r in selected
+                if r.get("content")
             ]
             q["golden_ids"] = golden_ids
+            q["golden_hashes"] = golden_hashes
             annotated += 1
-            print(f"  Marked {len(golden_ids)} results as relevant.")
+            print(
+                f"  Marked {len(golden_ids)} results as relevant "
+                f"({len(golden_hashes)} content-hash anchored)."
+            )
 
         print()
 

--- a/scripts/benchmarks/journal.py
+++ b/scripts/benchmarks/journal.py
@@ -1,0 +1,92 @@
+"""Append-only journal for recall-tuning experiments.
+
+autoresearch's loop keeps a ``results.tsv`` of every experiment — config, metric,
+keep/discard, why — so dead ends are never re-tried. This is OPC's equivalent: a
+tab-separated, untracked log (see .gitignore) with one row per evaluated config.
+
+Columns: timestamp · config_hash · ndcg@5 · p@5 · mrr · p95_latency_ms · status ·
+description, where status ∈ {keep, discard, crash}.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from scripts.core.content_hash import content_hash
+
+DEFAULT_JOURNAL = Path("scripts/benchmarks/results/journal.tsv")
+
+HEADER = [
+    "timestamp",
+    "config_hash",
+    "ndcg@5",
+    "p@5",
+    "mrr",
+    "p95_latency_ms",
+    "status",
+    "description",
+]
+
+VALID_STATUS = {"keep", "discard", "crash"}
+
+
+def config_hash(config: Any) -> str:
+    """Stable short id for a reranker config (a frozen dataclass).
+
+    Hashes the sorted field/value map so the same weights always map to the same
+    id — the journal key that ties a row to a reproducible configuration.
+    """
+    payload = json.dumps(asdict(config), sort_keys=True)
+    return content_hash(payload)[:12]
+
+
+def _clean(text: str) -> str:
+    """Make a value safe for a single TSV cell."""
+    return text.replace("\t", " ").replace("\n", " ").strip()
+
+
+def append_entry(
+    *,
+    timestamp: str,
+    cfg_hash: str,
+    ndcg: float,
+    p_at_k: float,
+    mrr: float,
+    p95_latency_ms: float,
+    status: str,
+    description: str,
+    path: Path = DEFAULT_JOURNAL,
+) -> None:
+    """Append one experiment row, writing the header if the file is new."""
+    if status not in VALID_STATUS:
+        raise ValueError(f"status must be one of {sorted(VALID_STATUS)}, got {status!r}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    new_file = not path.exists()
+    row = [
+        _clean(timestamp),
+        _clean(cfg_hash),
+        f"{ndcg:.4f}",
+        f"{p_at_k:.4f}",
+        f"{mrr:.4f}",
+        f"{p95_latency_ms:.3f}",
+        _clean(status),
+        _clean(description),
+    ]
+    with path.open("a", encoding="utf-8") as f:
+        if new_file:
+            f.write("\t".join(HEADER) + "\n")
+        f.write("\t".join(row) + "\n")
+
+
+def read_entries(path: Path = DEFAULT_JOURNAL) -> list[dict]:
+    """Parse the journal into a list of dict rows (empty if the file is absent)."""
+    if not path.exists():
+        return []
+    lines = path.read_text(encoding="utf-8").splitlines()
+    if not lines:
+        return []
+    header = lines[0].split("\t")
+    return [dict(zip(header, line.split("\t"))) for line in lines[1:] if line]

--- a/scripts/benchmarks/mine_feedback_labels.py
+++ b/scripts/benchmarks/mine_feedback_labels.py
@@ -42,8 +42,17 @@ DEFAULT_OUTPUT = Path("scripts/benchmarks/golden_mined.json")
 # Join feedback back to the query that surfaced the learning. A judgment is
 # attributed to a recall only when it happened in the same session, within a
 # bounded window AFTER the recall, on a learning that recall actually returned.
+#
+# DISTINCT ON (mf.id) collapses a feedback row to its single nearest preceding
+# recall: a session can recall the same learning many times before feedback is
+# given, and memory_feedback stores ONE judgment per row, so without this each
+# judgment would fan out to N recall_log rows and be counted N times toward
+# min_judgments (and could attach to an older, unrelated query that happened to
+# surface the same learning). ORDER BY mf.id, rl.created_at DESC keeps the most
+# recent recall at/under the feedback time.
 JOIN_SQL = """
-SELECT rl.query_hash       AS query_hash,
+SELECT DISTINCT ON (mf.id)
+       rl.query_hash       AS query_hash,
        rl.query_text       AS query_text,
        mf.helpful          AS helpful,
        am.content_hash     AS content_hash
@@ -57,6 +66,7 @@ JOIN archival_memory am ON am.id = mf.learning_id
 WHERE rl.session_id IS NOT NULL
   AND rl.query_hash IS NOT NULL
   AND am.content_hash IS NOT NULL
+ORDER BY mf.id, rl.created_at DESC
 """
 
 
@@ -130,7 +140,7 @@ def merge_into_queries(candidates: list[dict], queries_path: Path) -> int:
     warning. New queries default to the ``train`` split so they never silently
     enter the holdout decision set.
     """
-    query_data = json.loads(queries_path.read_text())
+    query_data = json.loads(queries_path.read_text(encoding="utf-8"))
     existing_hashes = {
         q.get("query_hash") for q in query_data["queries"] if q.get("query_hash")
     }
@@ -158,7 +168,7 @@ def merge_into_queries(candidates: list[dict], queries_path: Path) -> int:
         )
         added += 1
     if added:
-        queries_path.write_text(json.dumps(query_data, indent=2) + "\n")
+        queries_path.write_text(json.dumps(query_data, indent=2) + "\n", encoding="utf-8")
     return added
 
 
@@ -172,7 +182,7 @@ async def run(args: argparse.Namespace) -> int:
         "joined_rows": len(rows),
         "candidates": candidates,
     }
-    args.output.write_text(json.dumps(report, indent=2) + "\n")
+    args.output.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
     print(
         f"Mined {len(candidates)} candidate(s) from {len(rows)} judgment(s) "
         f"-> {args.output}"

--- a/scripts/benchmarks/mine_feedback_labels.py
+++ b/scripts/benchmarks/mine_feedback_labels.py
@@ -1,0 +1,225 @@
+"""Mine golden-set label candidates from the memory-feedback stream.
+
+The recall-tuning loop needs a growing, trustworthy golden set. Users already
+emit relevance judgments via ``memory_feedback`` (helpful / not-helpful on a
+recalled learning). This tool reconnects those judgments to the query that
+surfaced them — using the recall_log query-linkage columns
+(add_recall_log_query_link.sql) — and aggregates them into candidate golden
+records keyed by content hash (instance-independent, matches the benchmark).
+
+Output is written to ``golden_mined.json`` for HUMAN REVIEW. It is never merged
+into the scored ``rerank_queries.json`` automatically — the harness must stay
+trustworthy (report §6.5). A reviewer runs ``--merge-into rerank_queries.json``
+once the candidates look right.
+
+Requirements:
+  * add_recall_log_query_link.sql applied (session_id/query_hash/query_text).
+  * recall.log_query_text = true for some history (to get human-readable queries;
+    hash-only candidates are still emitted but cannot be merged as queries).
+
+Usage:
+    uv run python scripts/benchmarks/mine_feedback_labels.py
+    uv run python scripts/benchmarks/mine_feedback_labels.py --min-judgments 5
+    uv run python scripts/benchmarks/mine_feedback_labels.py --window-hours 48
+    uv run python scripts/benchmarks/mine_feedback_labels.py --merge-into \
+        scripts/benchmarks/rerank_queries.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from collections import defaultdict
+from datetime import UTC, datetime
+from pathlib import Path
+
+DEFAULT_MIN_JUDGMENTS = 3
+DEFAULT_WINDOW_HOURS = 24
+DEFAULT_OUTPUT = Path("scripts/benchmarks/golden_mined.json")
+
+# Join feedback back to the query that surfaced the learning. A judgment is
+# attributed to a recall only when it happened in the same session, within a
+# bounded window AFTER the recall, on a learning that recall actually returned.
+JOIN_SQL = """
+SELECT rl.query_hash       AS query_hash,
+       rl.query_text       AS query_text,
+       mf.helpful          AS helpful,
+       am.content_hash     AS content_hash
+FROM memory_feedback mf
+JOIN recall_log rl
+  ON rl.session_id = mf.session_id
+ AND mf.learning_id = ANY(rl.recalled_ids)
+ AND rl.created_at <= mf.created_at
+ AND rl.created_at > mf.created_at - make_interval(hours => $1)
+JOIN archival_memory am ON am.id = mf.learning_id
+WHERE rl.session_id IS NOT NULL
+  AND rl.query_hash IS NOT NULL
+  AND am.content_hash IS NOT NULL
+"""
+
+
+def aggregate_candidates(
+    rows: list[dict],
+    min_judgments: int = DEFAULT_MIN_JUDGMENTS,
+) -> list[dict]:
+    """Aggregate joined (query_hash, helpful, content_hash) rows into candidates.
+
+    Pure — no DB. Groups by query_hash; within each query a content hash is a
+    positive if helpful votes outnumber unhelpful, a hard negative if the
+    reverse, and dropped on a tie (ambiguous signal). A candidate is emitted only
+    once it has at least ``min_judgments`` total judgments, so a single stray
+    click cannot mint a golden label (report §6.2).
+    """
+    # query_hash -> {"query_text": str|None, "votes": {content_hash: [pos, neg]}}
+    by_query: dict[str, dict] = defaultdict(
+        lambda: {"query_text": None, "votes": defaultdict(lambda: [0, 0])}
+    )
+    for r in rows:
+        qh = r["query_hash"]
+        bucket = by_query[qh]
+        if bucket["query_text"] is None and r.get("query_text"):
+            bucket["query_text"] = r["query_text"]
+        votes = bucket["votes"][r["content_hash"]]
+        if r["helpful"]:
+            votes[0] += 1
+        else:
+            votes[1] += 1
+
+    candidates: list[dict] = []
+    for qh, bucket in by_query.items():
+        votes = bucket["votes"]
+        num_judgments = sum(pos + neg for pos, neg in votes.values())
+        if num_judgments < min_judgments:
+            continue
+        positives = sorted(ch for ch, (p, n) in votes.items() if p > n)
+        negatives = sorted(ch for ch, (p, n) in votes.items() if n > p)
+        if not positives and not negatives:
+            continue
+        candidates.append(
+            {
+                "query_hash": qh,
+                "query": bucket["query_text"],  # None if log_query_text was off
+                "golden_hashes": positives,
+                "golden_negatives": negatives,
+                "num_judgments": num_judgments,
+                "note": "review before merging into rerank_queries.json",
+            }
+        )
+    # Most-evidenced candidates first.
+    candidates.sort(key=lambda c: c["num_judgments"], reverse=True)
+    return candidates
+
+
+async def fetch_join_rows(window_hours: int) -> list[dict]:
+    """Run the feedback↔recall join against Postgres. Returns plain dicts."""
+    from scripts.core.db.postgres_pool import get_pool
+
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(JOIN_SQL, window_hours)
+    return [dict(r) for r in rows]
+
+
+def merge_into_queries(candidates: list[dict], queries_path: Path) -> int:
+    """Append review-approved candidates as new benchmark queries. Returns count.
+
+    Only candidates that carry a human-readable ``query`` (i.e. log_query_text
+    was on) can become benchmark queries; hash-only candidates are skipped with a
+    warning. New queries default to the ``train`` split so they never silently
+    enter the holdout decision set.
+    """
+    query_data = json.loads(queries_path.read_text())
+    existing_hashes = {
+        q.get("query_hash") for q in query_data["queries"] if q.get("query_hash")
+    }
+    added = 0
+    for c in candidates:
+        if not c.get("query"):
+            print(
+                f"  skip {c['query_hash'][:8]}: hash-only (no query text)",
+                file=sys.stderr,
+            )
+            continue
+        if c["query_hash"] in existing_hashes:
+            continue
+        query_data["queries"].append(
+            {
+                "id": f"mined-{c['query_hash'][:8]}",
+                "query": c["query"],
+                "query_hash": c["query_hash"],
+                "k": 5,
+                "category": "mined_feedback",
+                "split": "train",
+                "golden_hashes": c["golden_hashes"],
+                "golden_negatives": c["golden_negatives"],
+            }
+        )
+        added += 1
+    if added:
+        queries_path.write_text(json.dumps(query_data, indent=2) + "\n")
+    return added
+
+
+async def run(args: argparse.Namespace) -> int:
+    rows = await fetch_join_rows(args.window_hours)
+    candidates = aggregate_candidates(rows, min_judgments=args.min_judgments)
+    report = {
+        "generated_at": datetime.now(UTC).isoformat(),
+        "min_judgments": args.min_judgments,
+        "window_hours": args.window_hours,
+        "joined_rows": len(rows),
+        "candidates": candidates,
+    }
+    args.output.write_text(json.dumps(report, indent=2) + "\n")
+    print(
+        f"Mined {len(candidates)} candidate(s) from {len(rows)} judgment(s) "
+        f"-> {args.output}"
+    )
+    hash_only = sum(1 for c in candidates if not c.get("query"))
+    if hash_only:
+        print(
+            f"  {hash_only} candidate(s) are hash-only (recall.log_query_text was "
+            f"off) and cannot be merged as queries.",
+            file=sys.stderr,
+        )
+
+    if args.merge_into:
+        added = merge_into_queries(candidates, args.merge_into)
+        print(f"Merged {added} reviewed candidate(s) into {args.merge_into}")
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Mine golden-set label candidates from memory feedback"
+    )
+    parser.add_argument(
+        "--min-judgments", type=int, default=DEFAULT_MIN_JUDGMENTS,
+        help=f"Min judgments before a candidate counts (default: {DEFAULT_MIN_JUDGMENTS})",
+    )
+    parser.add_argument(
+        "--window-hours", type=int, default=DEFAULT_WINDOW_HOURS,
+        help=(
+            "Max hours between a recall and a feedback event for them to be "
+            f"linked (default: {DEFAULT_WINDOW_HOURS})"
+        ),
+    )
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument(
+        "--merge-into", type=Path, default=None,
+        help=(
+            "After mining, append review-approved candidates (those with query "
+            "text) into this queries file as new train-split benchmark queries."
+        ),
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    sys.exit(asyncio.run(run(parse_args())))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmarks/rerank_queries.json
+++ b/scripts/benchmarks/rerank_queries.json
@@ -1,5 +1,5 @@
 {
-  "description": "Benchmark queries for A/B testing reranker vs raw retrieval Each query carries split=train|holdout; the tuning loop decides keep/discard on the holdout split only. golden_hashes (content-hash anchored) take precedence over golden_ids; golden_negatives are content-hashes judged not relevant.",
+  "description": "Benchmark queries for A/B testing reranker vs raw retrieval. Each query carries split=train|holdout; the tuning loop decides keep/discard on the holdout split only. golden_hashes (content-hash anchored) take precedence over golden_ids; golden_negatives are content-hashes judged not relevant.",
   "version": 1,
   "queries": [
     {

--- a/scripts/benchmarks/rerank_queries.json
+++ b/scripts/benchmarks/rerank_queries.json
@@ -1,5 +1,5 @@
 {
-  "description": "Benchmark queries for A/B testing reranker vs raw retrieval",
+  "description": "Benchmark queries for A/B testing reranker vs raw retrieval Each query carries split=train|holdout; the tuning loop decides keep/discard on the holdout split only. golden_hashes (content-hash anchored) take precedence over golden_ids; golden_negatives are content-hashes judged not relevant.",
   "version": 1,
   "queries": [
     {
@@ -18,7 +18,8 @@
         "PreToolUse",
         "PostToolUse",
         "hooks"
-      ]
+      ],
+      "split": "train"
     },
     {
       "id": "q002",
@@ -37,7 +38,8 @@
         "ALTER",
         "CREATE TABLE",
         "postgresql"
-      ]
+      ],
+      "split": "train"
     },
     {
       "id": "q003",
@@ -55,7 +57,8 @@
         "daemon",
         "memory",
         "pipeline"
-      ]
+      ],
+      "split": "train"
     },
     {
       "id": "q004",
@@ -70,7 +73,8 @@
         "bug",
         "error",
         "resolved"
-      ]
+      ],
+      "split": "holdout"
     },
     {
       "id": "q005",
@@ -85,7 +89,8 @@
         "didn't work",
         "avoid",
         "mistake"
-      ]
+      ],
+      "split": "train"
     },
     {
       "id": "q006",
@@ -103,7 +108,8 @@
         "tsc",
         "compile",
         "type error"
-      ]
+      ],
+      "split": "holdout"
     },
     {
       "id": "q007",
@@ -123,7 +129,8 @@
         "build",
         "compile",
         "npm"
-      ]
+      ],
+      "split": "train"
     },
     {
       "id": "q008",
@@ -142,7 +149,8 @@
         "signal",
         "weight",
         "contextual"
-      ]
+      ],
+      "split": "train"
     },
     {
       "id": "q009",
@@ -160,7 +168,8 @@
         "git worktree",
         "branch",
         "isolation"
-      ]
+      ],
+      "split": "train"
     },
     {
       "id": "q010",
@@ -175,7 +184,8 @@
         "exception",
         "failure",
         "traceback"
-      ]
+      ],
+      "split": "train"
     },
     {
       "id": "q011",
@@ -192,7 +202,8 @@
         "pattern",
         "idiom",
         "pythonic"
-      ]
+      ],
+      "split": "holdout"
     },
     {
       "id": "q012",
@@ -210,7 +221,8 @@
         "server",
         "tool",
         "handler"
-      ]
+      ],
+      "split": "train"
     },
     {
       "id": "q013",
@@ -229,7 +241,8 @@
         "fixture",
         "pytest",
         "assert"
-      ]
+      ],
+      "split": "train"
     },
     {
       "id": "q014",
@@ -247,7 +260,8 @@
         "Popen",
         "asyncio",
         "process"
-      ]
+      ],
+      "split": "holdout"
     },
     {
       "id": "q015",
@@ -267,7 +281,8 @@
         "terminal",
         "heartbeat",
         "claim"
-      ]
+      ],
+      "split": "train"
     },
     {
       "id": "q016",
@@ -286,7 +301,8 @@
         "cosine",
         "similarity",
         "bge"
-      ]
+      ],
+      "split": "holdout"
     },
     {
       "id": "q017",
@@ -304,7 +320,8 @@
         "config",
         "format",
         "handoff"
-      ]
+      ],
+      "split": "train"
     },
     {
       "id": "q018",
@@ -322,7 +339,8 @@
         "SKILL.md",
         "slash command",
         "workflow"
-      ]
+      ],
+      "split": "train"
     },
     {
       "id": "q019",
@@ -338,7 +356,8 @@
         "slow",
         "cache",
         "latency"
-      ]
+      ],
+      "split": "holdout"
     },
     {
       "id": "q020",
@@ -356,7 +375,8 @@
         "trace",
         "span",
         "logging"
-      ]
+      ],
+      "split": "train"
     },
     {
       "id": "q021",
@@ -375,7 +395,8 @@
         "start",
         "stop",
         "pid"
-      ]
+      ],
+      "split": "holdout"
     },
     {
       "id": "q022",
@@ -393,7 +414,8 @@
         "classification",
         "llm",
         "learning_type"
-      ]
+      ],
+      "split": "train"
     },
     {
       "id": "q023",
@@ -409,7 +431,8 @@
         "chose",
         "rationale",
         "design"
-      ]
+      ],
+      "split": "train"
     },
     {
       "id": "q024",
@@ -424,7 +447,8 @@
         "cold",
         "unused",
         "never"
-      ]
+      ],
+      "split": "holdout"
     },
     {
       "id": "q025",
@@ -441,7 +465,8 @@
         "serialize",
         "format",
         "output"
-      ]
+      ],
+      "split": "train"
     }
   ]
 }

--- a/scripts/benchmarks/run_rerank_benchmark.py
+++ b/scripts/benchmarks/run_rerank_benchmark.py
@@ -29,6 +29,7 @@ from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
+from scripts.core.content_hash import content_hash
 from scripts.core.llm_selector import _parse_timeout
 from scripts.core.reranker import RecallContext, RerankerConfig, rerank
 
@@ -88,12 +89,26 @@ def is_relevant(
     content: str,
     golden_ids: list[str],
     golden_keywords: list[str],
+    *,
+    golden_hashes: list[str] | None = None,
+    golden_negatives: list[str] | None = None,
 ) -> bool:
-    """Check if a result is relevant based on golden IDs or keywords.
+    """Check if a result is relevant against the golden judgments.
 
-    When golden_ids are present they are authoritative — keyword matching
-    is only used as a fallback when no curated IDs exist.
+    Precedence (most robust first):
+      1. ``golden_negatives`` — a content-hash judged unhelpful is never relevant,
+         overriding any positive signal below.
+      2. ``golden_hashes`` — content-hash match (instance-independent; survives a
+         fresh DB where UUIDs differ). This is the re-anchored ground truth.
+      3. ``golden_ids`` — legacy UUID match (only meaningful on the same DB).
+      4. ``golden_keywords`` — substring fallback when no curated labels exist.
     """
+    if golden_negatives or golden_hashes:
+        h = content_hash(content)
+        if golden_negatives and h in golden_negatives:
+            return False
+        if golden_hashes:
+            return h in golden_hashes
     if golden_ids:
         return result_id in golden_ids
     if golden_keywords:
@@ -107,6 +122,9 @@ def compute_precision_at_k(
     result_contents: list[str],
     golden_ids: list[str],
     golden_keywords: list[str],
+    *,
+    golden_hashes: list[str] | None = None,
+    golden_negatives: list[str] | None = None,
 ) -> float:
     """Fraction of top-k results that match the golden set."""
     if not result_ids:
@@ -114,7 +132,10 @@ def compute_precision_at_k(
     relevant = sum(
         1
         for rid, content in zip(result_ids, result_contents)
-        if is_relevant(rid, content, golden_ids, golden_keywords)
+        if is_relevant(
+            rid, content, golden_ids, golden_keywords,
+            golden_hashes=golden_hashes, golden_negatives=golden_negatives,
+        )
     )
     return relevant / len(result_ids)
 
@@ -125,6 +146,9 @@ def compute_ndcg(
     golden_ids: list[str],
     golden_keywords: list[str],
     k: int,
+    *,
+    golden_hashes: list[str] | None = None,
+    golden_negatives: list[str] | None = None,
 ) -> float:
     """Normalized Discounted Cumulative Gain at k."""
     if not result_ids:
@@ -136,14 +160,17 @@ def compute_ndcg(
         zip(result_ids[:k], result_contents[:k])
     ):
         rel = 1.0 if is_relevant(
-            rid, content, golden_ids, golden_keywords
+            rid, content, golden_ids, golden_keywords,
+            golden_hashes=golden_hashes, golden_negatives=golden_negatives,
         ) else 0.0
         dcg += rel / math.log2(i + 2)  # i+2 because rank is 1-indexed
 
     # Compute ideal DCG (all relevant items at top).
     # Use the full golden set size, not just retrieved relevant items,
     # so IDCG reflects total judged positives.
-    if golden_ids:
+    if golden_hashes:
+        num_relevant = len(golden_hashes)
+    elif golden_ids:
         num_relevant = len(golden_ids)
     elif golden_keywords:
         # Keywords: count from retrieved results (no external ground truth)
@@ -166,12 +193,18 @@ def compute_mrr(
     result_contents: list[str],
     golden_ids: list[str],
     golden_keywords: list[str],
+    *,
+    golden_hashes: list[str] | None = None,
+    golden_negatives: list[str] | None = None,
 ) -> float:
     """Mean Reciprocal Rank of first relevant result."""
     for i, (rid, content) in enumerate(
         zip(result_ids, result_contents)
     ):
-        if is_relevant(rid, content, golden_ids, golden_keywords):
+        if is_relevant(
+            rid, content, golden_ids, golden_keywords,
+            golden_hashes=golden_hashes, golden_negatives=golden_negatives,
+        ):
             return 1.0 / (i + 1)
     return 0.0
 
@@ -441,6 +474,9 @@ def compute_comparison_metrics(
     golden_keywords: list[str],
     k: int,
     llm: QueryResult | None = None,
+    *,
+    golden_hashes: list[str] | None = None,
+    golden_negatives: list[str] | None = None,
 ) -> ComparisonMetrics:
     """Assemble per-query metrics from the reranked, raw, and optional LLM arms.
 
@@ -451,29 +487,33 @@ def compute_comparison_metrics(
     reranked vs raw (the LLM arm filters/reorders independently of the linear
     reranker's per-signal contributions, which it does not expose).
     """
+    labels = {
+        "golden_hashes": golden_hashes,
+        "golden_negatives": golden_negatives,
+    }
     p_reranked = compute_precision_at_k(
         reranked.result_ids, reranked.result_contents,
-        golden_ids, golden_keywords,
+        golden_ids, golden_keywords, **labels,
     )
     p_raw = compute_precision_at_k(
         raw.result_ids, raw.result_contents,
-        golden_ids, golden_keywords,
+        golden_ids, golden_keywords, **labels,
     )
     ndcg_reranked = compute_ndcg(
         reranked.result_ids, reranked.result_contents,
-        golden_ids, golden_keywords, k,
+        golden_ids, golden_keywords, k, **labels,
     )
     ndcg_raw = compute_ndcg(
         raw.result_ids, raw.result_contents,
-        golden_ids, golden_keywords, k,
+        golden_ids, golden_keywords, k, **labels,
     )
     mrr_reranked = compute_mrr(
         reranked.result_ids, reranked.result_contents,
-        golden_ids, golden_keywords,
+        golden_ids, golden_keywords, **labels,
     )
     mrr_raw = compute_mrr(
         raw.result_ids, raw.result_contents,
-        golden_ids, golden_keywords,
+        golden_ids, golden_keywords, **labels,
     )
     mean_disp, max_disp = compute_rank_displacement(
         reranked.result_ids, raw.result_ids,
@@ -487,15 +527,15 @@ def compute_comparison_metrics(
     if llm is not None:
         p_llm = compute_precision_at_k(
             llm.result_ids, llm.result_contents,
-            golden_ids, golden_keywords,
+            golden_ids, golden_keywords, **labels,
         )
         ndcg_llm = compute_ndcg(
             llm.result_ids, llm.result_contents,
-            golden_ids, golden_keywords, k,
+            golden_ids, golden_keywords, k, **labels,
         )
         mrr_llm = compute_mrr(
             llm.result_ids, llm.result_contents,
-            golden_ids, golden_keywords,
+            golden_ids, golden_keywords, **labels,
         )
         llm_elapsed = llm.elapsed_ms
 
@@ -578,6 +618,8 @@ async def run_benchmark(
         llm = all_results[base + 2] if with_llm else None
         golden_ids = q.get("golden_ids", [])
         golden_keywords = q.get("golden_keywords", [])
+        golden_hashes = q.get("golden_hashes", [])
+        golden_negatives = q.get("golden_negatives", [])
         k = q.get("k", 5)
 
         # Cross-arm evidence check (Finding 1, round 2): decided here where all
@@ -600,6 +642,7 @@ async def run_benchmark(
 
         metrics = compute_comparison_metrics(
             reranked, raw, golden_ids, golden_keywords, k, llm=llm,
+            golden_hashes=golden_hashes, golden_negatives=golden_negatives,
         )
         output.append((reranked, raw, metrics))
 
@@ -1055,6 +1098,8 @@ def sweep_rerank(
             k = q.get("k", 5)
             golden_ids = q.get("golden_ids", [])
             golden_keywords = q.get("golden_keywords", [])
+            golden_hashes = q.get("golden_hashes", [])
+            golden_negatives = q.get("golden_negatives", [])
             raw_items = cached_results.get(qid, [])
 
             ctx = RecallContext(
@@ -1071,14 +1116,18 @@ def sweep_rerank(
             rids = [r.get("id", "") for r in reranked]
             rcontents = [r.get("content", "") for r in reranked]
 
+            labels = {
+                "golden_hashes": golden_hashes,
+                "golden_negatives": golden_negatives,
+            }
             p_at_k_vals.append(compute_precision_at_k(
-                rids, rcontents, golden_ids, golden_keywords,
+                rids, rcontents, golden_ids, golden_keywords, **labels,
             ))
             ndcg_vals.append(compute_ndcg(
-                rids, rcontents, golden_ids, golden_keywords, k,
+                rids, rcontents, golden_ids, golden_keywords, k, **labels,
             ))
             mrr_vals.append(compute_mrr(
-                rids, rcontents, golden_ids, golden_keywords,
+                rids, rcontents, golden_ids, golden_keywords, **labels,
             ))
 
         n = len(queries)
@@ -1095,6 +1144,85 @@ def sweep_rerank(
         })
 
     return sweep_results
+
+
+def build_reranker_config(wc: dict) -> RerankerConfig:
+    """Construct a RerankerConfig from a WEIGHT_SWEEPS entry (name + 7 weights)."""
+    return RerankerConfig(
+        project_weight=wc["project_weight"],
+        recency_weight=wc["recency_weight"],
+        confidence_weight=wc["confidence_weight"],
+        recall_weight=wc["recall_weight"],
+        type_affinity_weight=wc["type_affinity_weight"],
+        tag_overlap_weight=wc["tag_overlap_weight"],
+        pattern_weight=wc["pattern_weight"],
+    )
+
+
+def _percentile(values: list[float], pct: float) -> float:
+    """Nearest-rank percentile (small-n friendly). Empty -> 0.0."""
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    # nearest-rank: ceil(pct/100 * n), 1-indexed
+    rank = max(1, math.ceil(pct / 100.0 * len(ordered)))
+    return ordered[rank - 1]
+
+
+def evaluate_config(
+    cached_results: dict[str, list[dict]],
+    queries: list[dict],
+    config: RerankerConfig,
+) -> dict:
+    """Score one RerankerConfig over cached candidate pools.
+
+    Returns mean NDCG@5 / P@k / MRR plus p95 in-process rerank latency — the
+    headline metric and its latency co-metric for the tuning loop's keep/discard
+    rule. Reuses the same metric functions and golden precedence as the A/B
+    benchmark, so a loop result is comparable to a hand-run benchmark.
+    """
+    ndcg_vals: list[float] = []
+    p_at_k_vals: list[float] = []
+    mrr_vals: list[float] = []
+    latencies_ms: list[float] = []
+
+    for q in queries:
+        qid = q["id"]
+        k = q.get("k", 5)
+        raw_items = cached_results.get(qid, [])
+        ctx = RecallContext(
+            project=q.get("project"),
+            tags_hint=q.get("tags") or None,
+            retrieval_mode="hybrid_rrf",
+        )
+
+        start = time.perf_counter()
+        if config.total_signal_weight > 0:
+            reranked = rerank(raw_items, ctx, config=config, k=k)
+        else:
+            reranked = raw_items[:k]
+        latencies_ms.append((time.perf_counter() - start) * 1000.0)
+
+        rids = [r.get("id", "") for r in reranked]
+        rcontents = [r.get("content", "") for r in reranked]
+        labels = {
+            "golden_hashes": q.get("golden_hashes", []),
+            "golden_negatives": q.get("golden_negatives", []),
+        }
+        gids = q.get("golden_ids", [])
+        gkw = q.get("golden_keywords", [])
+        p_at_k_vals.append(compute_precision_at_k(rids, rcontents, gids, gkw, **labels))
+        ndcg_vals.append(compute_ndcg(rids, rcontents, gids, gkw, k, **labels))
+        mrr_vals.append(compute_mrr(rids, rcontents, gids, gkw, **labels))
+
+    n = len(queries) or 1
+    return {
+        "ndcg_at_k": round(sum(ndcg_vals) / n, 4),
+        "precision_at_k": round(sum(p_at_k_vals) / n, 4),
+        "mrr": round(sum(mrr_vals) / n, 4),
+        "p95_latency_ms": round(_percentile(latencies_ms, 95), 3),
+        "n": len(queries),
+    }
 
 
 def print_sweep_summary(sweep_results: list[dict]) -> None:
@@ -1138,6 +1266,25 @@ def print_sweep_summary(sweep_results: list[dict]) -> None:
 # CLI
 # -------------------------------------------------------------------
 
+def filter_by_split(queries: list[dict], split: str) -> list[dict]:
+    """Return queries belonging to ``split`` ('train' | 'holdout' | 'all').
+
+    The held-out split exists so the tuning loop can decide keep/discard on
+    queries it never optimized against (report §6.1 — guards against tuning to
+    noise on a tiny set). A query with no ``split`` key is unlabeled; if the file
+    has no labels at all the filter is a no-op (back-compat) with a warning.
+    """
+    if split == "all":
+        return queries
+    if not any("split" in q for q in queries):
+        print(
+            f"  WARN: query file has no 'split' labels; --split {split} ignored",
+            file=sys.stderr,
+        )
+        return queries
+    return [q for q in queries if q.get("split") == split]
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="A/B benchmark for reranker vs raw retrieval"
@@ -1165,6 +1312,15 @@ def parse_args() -> argparse.Namespace:
         help="Run weight sensitivity sweep across configurations",
     )
     parser.add_argument(
+        "--split",
+        choices=["train", "holdout", "all"],
+        default="all",
+        help=(
+            "Evaluate only queries tagged with this split (default: all). "
+            "'holdout' is the tuning loop's keep/discard decision set."
+        ),
+    )
+    parser.add_argument(
         "--llm-rerank",
         action="store_true",
         help=(
@@ -1181,8 +1337,11 @@ async def async_main() -> int:
 
     # Load queries
     query_data = json.loads(args.queries.read_text())
-    queries = query_data["queries"]
-    print(f"Loaded {len(queries)} benchmark queries from {args.queries}")
+    queries = filter_by_split(query_data["queries"], args.split)
+    print(
+        f"Loaded {len(queries)} benchmark queries from {args.queries} "
+        f"(split={args.split})"
+    )
 
     # Run benchmark
     if args.llm_rerank and not os.environ.get("ANTHROPIC_API_KEY"):

--- a/scripts/benchmarks/run_rerank_benchmark.py
+++ b/scripts/benchmarks/run_rerank_benchmark.py
@@ -25,10 +25,11 @@ import math
 import os
 import sys
 import time
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, replace
 from datetime import UTC, datetime
 from pathlib import Path
 
+from scripts.core.config import get_config
 from scripts.core.content_hash import content_hash
 from scripts.core.llm_selector import _parse_timeout
 from scripts.core.reranker import RecallContext, RerankerConfig, rerank
@@ -1073,21 +1074,18 @@ def sweep_rerank(
     cached_results: dict[str, list[dict]],
     queries: list[dict],
     weight_configs: list[dict],
+    base: RerankerConfig,
 ) -> list[dict]:
-    """Run reranker with each weight config on cached results."""
+    """Run reranker with each weight config on cached results.
+
+    Each candidate layers its swept weights onto ``base`` (the live opc.toml
+    config) so non-swept fields are inherited rather than reset to defaults.
+    """
     sweep_results = []
 
     for wc in weight_configs:
         name = wc["name"]
-        config = RerankerConfig(
-            project_weight=wc["project_weight"],
-            recency_weight=wc["recency_weight"],
-            confidence_weight=wc["confidence_weight"],
-            recall_weight=wc["recall_weight"],
-            type_affinity_weight=wc["type_affinity_weight"],
-            tag_overlap_weight=wc["tag_overlap_weight"],
-            pattern_weight=wc["pattern_weight"],
-        )
+        config = build_reranker_config(wc, base)
 
         p_at_k_vals = []
         ndcg_vals = []
@@ -1146,17 +1144,37 @@ def sweep_rerank(
     return sweep_results
 
 
-def build_reranker_config(wc: dict) -> RerankerConfig:
-    """Construct a RerankerConfig from a WEIGHT_SWEEPS entry (name + 7 weights)."""
-    return RerankerConfig(
-        project_weight=wc["project_weight"],
-        recency_weight=wc["recency_weight"],
-        confidence_weight=wc["confidence_weight"],
-        recall_weight=wc["recall_weight"],
-        type_affinity_weight=wc["type_affinity_weight"],
-        tag_overlap_weight=wc["tag_overlap_weight"],
-        pattern_weight=wc["pattern_weight"],
-    )
+# The seven reranker weight fields the sweep perturbs (the only surface a swept
+# config or --apply may touch). Other RerankerConfig fields are inherited from
+# the live base config, never reset.
+SWEEP_WEIGHT_KEYS = (
+    "project_weight",
+    "recency_weight",
+    "confidence_weight",
+    "recall_weight",
+    "type_affinity_weight",
+    "tag_overlap_weight",
+    "pattern_weight",
+)
+
+
+def build_reranker_config(wc: dict, base: RerankerConfig) -> RerankerConfig:
+    """Layer a WEIGHT_SWEEPS entry's weights onto a live ``base`` config.
+
+    Only the swept weight fields present in ``wc`` are overridden; every other
+    field (kg_weight, recency_half_life_days, the RRF params, ...) is inherited
+    from ``base`` — the live opc.toml reranker config. This is required, not
+    optional: constructing a fresh ``RerankerConfig`` from the swept weights
+    alone would silently reset all non-swept fields to dataclass defaults, so a
+    "kept" candidate could be measured with different KG/recency behaviour than
+    the incumbent and would not reproduce after ``--apply`` (which writes only
+    the swept weights). Anchoring to ``base`` makes each candidate a true
+    perturbation of the running config, and ``base``'s live ``kg_weight`` is what
+    lets RerankerConfig.__post_init__ enforce the ``total_signal_weight <= 1.0``
+    invariant on the resulting config.
+    """
+    overrides = {k: wc[k] for k in SWEEP_WEIGHT_KEYS if k in wc}
+    return replace(base, **overrides)
 
 
 def _percentile(values: list[float], pct: float) -> float:
@@ -1417,7 +1435,9 @@ async def async_main() -> int:
             f"Cached {len(cached)} query result sets. "
             f"Running {len(WEIGHT_SWEEPS)} configs..."
         )
-        sweep_results = sweep_rerank(cached, queries, WEIGHT_SWEEPS)
+        sweep_results = sweep_rerank(
+            cached, queries, WEIGHT_SWEEPS, get_config().reranker
+        )
         print_sweep_summary(sweep_results)
 
         # Save sweep results alongside the main report

--- a/scripts/benchmarks/tune_loop.py
+++ b/scripts/benchmarks/tune_loop.py
@@ -1,0 +1,270 @@
+"""Mechanical keep/discard tuning loop around the reranker weight sweep.
+
+This is the autoresearch loop applied to OPC recall: take the frozen harness
+(golden set + metrics + a pinned candidate pool), perturb ONE surface (the
+reranker weights), and for each perturbation apply a mechanical rule —
+
+    holdout NDCG@5 improves AND p95 latency stays within budget  -> keep
+    otherwise                                                     -> discard
+    tiebreak among keeps: simpler is better (fewer signals, then lower latency)
+
+Every run is appended to the journal (journal.py) so dead ends are never
+re-tried, and the keep/discard outcome is recorded back into OPC's own memory
+(store_learning_v2) as WORKING_SOLUTION / FAILED_APPROACH, making the tuning
+history itself recallable.
+
+Decisions are evaluated on the HELD-OUT split only (report §6.1) so the loop
+cannot tune to noise on the queries it optimized against. The winning config is
+printed as a diff; it is written to opc.toml ONLY with --apply (no silent edits).
+
+Usage:
+    uv run python scripts/benchmarks/tune_loop.py
+    uv run python scripts/benchmarks/tune_loop.py --split holdout
+    uv run python scripts/benchmarks/tune_loop.py --latency-budget-ms 5
+    uv run python scripts/benchmarks/tune_loop.py --apply        # write winner
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import re
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+from scripts.benchmarks import journal
+from scripts.benchmarks.run_rerank_benchmark import (
+    WEIGHT_SWEEPS,
+    build_reranker_config,
+    evaluate_config,
+    fetch_full_results,
+    filter_by_split,
+)
+from scripts.core.config import get_config
+
+DEFAULT_QUERIES = Path("scripts/benchmarks/rerank_queries.json")
+OPC_TOML = Path("opc.toml")
+NDCG_EPS = 1e-9  # strict improvement; equal NDCG is not a "win" vs baseline
+
+# Reranker weight keys the sweep perturbs (the only surface --apply may touch).
+WEIGHT_KEYS = [
+    "project_weight",
+    "recency_weight",
+    "confidence_weight",
+    "recall_weight",
+    "type_affinity_weight",
+    "tag_overlap_weight",
+    "pattern_weight",
+]
+
+
+def active_signal_count(config) -> int:
+    """Number of non-zero perturbed weights — the 'simplicity' tiebreak metric."""
+    return sum(1 for k in WEIGHT_KEYS if getattr(config, k) > 0)
+
+
+def decide(candidate: dict, baseline: dict, latency_budget_ms: float) -> str:
+    """keep iff holdout NDCG@5 strictly improves AND p95 within budget."""
+    improved = candidate["ndcg_at_k"] > baseline["ndcg_at_k"] + NDCG_EPS
+    within_budget = candidate["p95_latency_ms"] <= latency_budget_ms
+    return "keep" if (improved and within_budget) else "discard"
+
+
+def latency_budget(baseline_p95: float, override: float | None) -> float:
+    """Co-metric ceiling: explicit override, else 25% over baseline (min +1ms)."""
+    if override is not None:
+        return override
+    return max(baseline_p95 * 1.25, baseline_p95 + 1.0)
+
+
+def apply_weights_to_toml(path: Path, weights: dict[str, float]) -> list[str]:
+    """Rewrite the perturbed weight keys inside [reranker]. Returns changed keys.
+
+    Surgical: only lines matching ``<weight_key> = ...`` within the [reranker]
+    section are touched; everything else (comments, other sections, other keys)
+    is preserved byte-for-byte.
+    """
+    lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+    in_reranker = False
+    changed: list[str] = []
+    for i, line in enumerate(lines):
+        section = re.match(r"\s*\[([^\]]+)\]", line)
+        if section:
+            in_reranker = section.group(1) == "reranker"
+            continue
+        if not in_reranker:
+            continue
+        m = re.match(r"(\s*)([A-Za-z0-9_]+)(\s*=\s*).*", line)
+        if m and m.group(2) in weights:
+            key = m.group(2)
+            newline = f"{m.group(1)}{key}{m.group(3)}{weights[key]}\n"
+            if newline != line:
+                lines[i] = newline
+                changed.append(key)
+    if changed:
+        path.write_text("".join(lines), encoding="utf-8")
+    return changed
+
+
+async def record_outcome(winner: dict | None, baseline: dict, n_queries: int) -> None:
+    """Best-effort: journal the loop outcome into OPC memory as a learning."""
+    try:
+        from scripts.core.store_learning import store_learning_v2
+
+        session = f"recall-tune-{datetime.now(UTC).strftime('%Y%m%d-%H%M%S')}"
+        if winner:
+            ltype = "WORKING_SOLUTION"
+            content = (
+                f"Recall reranker tuning: config '{winner['name']}' "
+                f"({winner['config_hash']}) improved holdout NDCG@5 from "
+                f"{baseline['ndcg_at_k']:.4f} to {winner['ndcg_at_k']:.4f} at "
+                f"p95 {winner['p95_latency_ms']:.3f}ms over {n_queries} held-out "
+                f"queries. Weights: {json.dumps(winner['weights'])}."
+            )
+        else:
+            ltype = "FAILED_APPROACH"
+            content = (
+                f"Recall reranker tuning: no swept config beat baseline holdout "
+                f"NDCG@5 {baseline['ndcg_at_k']:.4f} over {n_queries} held-out "
+                f"queries. The current weights stand; re-running the same sweep is "
+                f"a dead end until the golden set or candidate pool changes."
+            )
+        await store_learning_v2(
+            session_id=session,
+            content=content,
+            learning_type=ltype,
+            context="recall reranker weight tuning loop",
+            tags=["reranker", "tuning"],
+            confidence="medium",
+            project="opc",
+        )
+        print(f"  Recorded {ltype} learning to OPC memory.")
+    except Exception as e:  # noqa: BLE001 — telemetry must never break the loop
+        print(f"  (could not record learning: {e})", file=sys.stderr)
+
+
+async def run(args: argparse.Namespace) -> int:
+    query_data = json.loads(args.queries.read_text())
+    queries = filter_by_split(query_data["queries"], args.split)
+    if not queries:
+        print(f"No queries in split={args.split}; nothing to tune.", file=sys.stderr)
+        return 1
+    print(f"Tuning on {len(queries)} queries (split={args.split}).")
+
+    # Frozen candidate pool: fetch once, rerun every config in-process.
+    cache = await fetch_full_results(queries)
+
+    baseline_config = get_config().reranker
+    baseline = evaluate_config(cache, queries, baseline_config)
+    budget = latency_budget(baseline["p95_latency_ms"], args.latency_budget_ms)
+    ts = datetime.now(UTC).isoformat()
+    journal.append_entry(
+        timestamp=ts,
+        cfg_hash=journal.config_hash(baseline_config),
+        ndcg=baseline["ndcg_at_k"], p_at_k=baseline["precision_at_k"],
+        mrr=baseline["mrr"], p95_latency_ms=baseline["p95_latency_ms"],
+        status="keep",  # baseline is the incumbent
+        description=f"baseline (live opc.toml) split={args.split}",
+        path=args.journal,
+    )
+    print(
+        f"Baseline: NDCG@5={baseline['ndcg_at_k']:.4f} "
+        f"p95={baseline['p95_latency_ms']:.3f}ms  (latency budget {budget:.3f}ms)"
+    )
+
+    evaluated: list[dict] = []
+    for wc in WEIGHT_SWEEPS:
+        config = build_reranker_config(wc)
+        m = evaluate_config(cache, queries, config)
+        status = decide(m, baseline, budget)
+        cand = {
+            "name": wc["name"],
+            "config": config,
+            "config_hash": journal.config_hash(config),
+            "weights": {k: v for k, v in wc.items() if k != "name"},
+            "status": status,
+            **m,
+        }
+        evaluated.append(cand)
+        journal.append_entry(
+            timestamp=ts,
+            cfg_hash=cand["config_hash"],
+            ndcg=m["ndcg_at_k"], p_at_k=m["precision_at_k"],
+            mrr=m["mrr"], p95_latency_ms=m["p95_latency_ms"],
+            status=status,
+            description=f"{wc['name']} split={args.split} vs baseline "
+                        f"{baseline['ndcg_at_k']:.4f}",
+            path=args.journal,
+        )
+        flag = "KEEP " if status == "keep" else "drop "
+        print(
+            f"  {flag} {wc['name']:16s} NDCG@5={m['ndcg_at_k']:.4f} "
+            f"p95={m['p95_latency_ms']:.3f}ms"
+        )
+
+    keeps = [c for c in evaluated if c["status"] == "keep"]
+    # Tiebreak among keeps: highest NDCG, then lower latency, then fewer signals.
+    winner = None
+    if keeps:
+        winner = max(
+            keeps,
+            key=lambda c: (
+                c["ndcg_at_k"],
+                -c["p95_latency_ms"],
+                -active_signal_count(c["config"]),
+            ),
+        )
+
+    print()
+    if winner:
+        print(
+            f"WINNER: {winner['name']} ({winner['config_hash']}) "
+            f"NDCG@5 {baseline['ndcg_at_k']:.4f} -> {winner['ndcg_at_k']:.4f}"
+        )
+        print("Proposed [reranker] weight changes:")
+        for k in WEIGHT_KEYS:
+            base_v = getattr(baseline_config, k)
+            new_v = winner["weights"].get(k, base_v)
+            if base_v != new_v:
+                print(f"  {k}: {base_v} -> {new_v}")
+        if args.apply:
+            changed = apply_weights_to_toml(OPC_TOML, winner["weights"])
+            print(f"  Applied to {OPC_TOML}: {', '.join(changed) or '(no lines changed)'}")
+        else:
+            print("  (re-run with --apply to write these to opc.toml)")
+    else:
+        print("No swept config beat the baseline on the holdout split. Baseline stands.")
+
+    await record_outcome(winner, baseline, len(queries))
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Mechanical keep/discard tuning loop over the reranker sweep"
+    )
+    parser.add_argument("--queries", type=Path, default=DEFAULT_QUERIES)
+    parser.add_argument(
+        "--split", choices=["train", "holdout", "all"], default="holdout",
+        help="Split to decide keep/discard on (default: holdout).",
+    )
+    parser.add_argument(
+        "--latency-budget-ms", type=float, default=None,
+        help="p95 in-process rerank latency ceiling (default: 25%% over baseline).",
+    )
+    parser.add_argument("--journal", type=Path, default=journal.DEFAULT_JOURNAL)
+    parser.add_argument(
+        "--apply", action="store_true",
+        help="Write the winning weights into opc.toml [reranker] (default: off).",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    sys.exit(asyncio.run(run(parse_args())))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmarks/tune_loop.py
+++ b/scripts/benchmarks/tune_loop.py
@@ -6,7 +6,8 @@ reranker weights), and for each perturbation apply a mechanical rule —
 
     holdout NDCG@5 improves AND p95 latency stays within budget  -> keep
     otherwise                                                     -> discard
-    tiebreak among keeps: simpler is better (fewer signals, then lower latency)
+    tiebreak among keeps: highest holdout NDCG@5, then lower p95 latency, then
+    fewer active signals (simpler)
 
 Every run is appended to the journal (journal.py) so dead ends are never
 re-tried, and the keep/discard outcome is recorded back into OPC's own memory
@@ -43,6 +44,7 @@ from scripts.benchmarks.run_rerank_benchmark import (
     filter_by_split,
 )
 from scripts.core.config import get_config
+from scripts.core.config.models import RerankerConfig
 
 DEFAULT_QUERIES = Path("scripts/benchmarks/rerank_queries.json")
 OPC_TOML = Path("opc.toml")
@@ -79,14 +81,31 @@ def latency_budget(baseline_p95: float, override: float | None) -> float:
     return max(baseline_p95 * 1.25, baseline_p95 + 1.0)
 
 
-def apply_weights_to_toml(path: Path, weights: dict[str, float]) -> list[str]:
+def apply_weights_to_toml(
+    path: Path, weights: dict[str, float], base: RerankerConfig
+) -> list[str]:
     """Rewrite the perturbed weight keys inside [reranker]. Returns changed keys.
 
     Surgical: only lines matching ``<weight_key> = ...`` within the [reranker]
     section are touched; everything else (comments, other sections, other keys)
-    is preserved byte-for-byte.
+    is preserved byte-for-byte, and each line keeps its original newline (so a
+    CRLF file stays CRLF rather than gaining mixed endings).
+
+    Before writing, the resulting config (the seven new weights layered onto
+    ``base`` — the live, file-resolved reranker config) is constructed via
+    ``build_reranker_config``, so RerankerConfig.__post_init__ rejects any combo
+    that would push ``total_signal_weight`` past 1.0. That guarantees --apply can
+    never emit an opc.toml that fails to load (e.g. an operator-raised kg_weight
+    plus high swept weights).
     """
-    lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+    # Validate the would-be config first; raises ValueError on an over-budget mix.
+    build_reranker_config({"name": "apply", **weights}, base)
+
+    # newline="" disables universal-newline translation on both read and write,
+    # so each line retains its own terminator (\n or \r\n) and a CRLF file is not
+    # silently rewritten with mixed/normalized endings.
+    with path.open("r", encoding="utf-8", newline="") as f:
+        lines = f.readlines()
     in_reranker = False
     changed: list[str] = []
     for i, line in enumerate(lines):
@@ -99,12 +118,19 @@ def apply_weights_to_toml(path: Path, weights: dict[str, float]) -> list[str]:
         m = re.match(r"(\s*)([A-Za-z0-9_]+)(\s*=\s*).*", line)
         if m and m.group(2) in weights:
             key = m.group(2)
-            newline = f"{m.group(1)}{key}{m.group(3)}{weights[key]}\n"
+            # Preserve this line's original terminator (\r\n / \n / none at EOF).
+            ending = (
+                "\r\n" if line.endswith("\r\n")
+                else "\n" if line.endswith("\n")
+                else ""
+            )
+            newline = f"{m.group(1)}{key}{m.group(3)}{weights[key]}{ending}"
             if newline != line:
                 lines[i] = newline
                 changed.append(key)
     if changed:
-        path.write_text("".join(lines), encoding="utf-8")
+        with path.open("w", encoding="utf-8", newline="") as f:
+            f.writelines(lines)
     return changed
 
 
@@ -146,7 +172,7 @@ async def record_outcome(winner: dict | None, baseline: dict, n_queries: int) ->
 
 
 async def run(args: argparse.Namespace) -> int:
-    query_data = json.loads(args.queries.read_text())
+    query_data = json.loads(args.queries.read_text(encoding="utf-8"))
     queries = filter_by_split(query_data["queries"], args.split)
     if not queries:
         print(f"No queries in split={args.split}; nothing to tune.", file=sys.stderr)
@@ -176,7 +202,10 @@ async def run(args: argparse.Namespace) -> int:
 
     evaluated: list[dict] = []
     for wc in WEIGHT_SWEEPS:
-        config = build_reranker_config(wc)
+        # Perturb from the live incumbent: non-swept fields (kg_weight, recency
+        # half-life, RRF params) inherit baseline_config rather than resetting to
+        # dataclass defaults, so a kept winner reproduces after --apply.
+        config = build_reranker_config(wc, baseline_config)
         m = evaluate_config(cache, queries, config)
         status = decide(m, baseline, budget)
         cand = {
@@ -230,7 +259,9 @@ async def run(args: argparse.Namespace) -> int:
             if base_v != new_v:
                 print(f"  {k}: {base_v} -> {new_v}")
         if args.apply:
-            changed = apply_weights_to_toml(OPC_TOML, winner["weights"])
+            changed = apply_weights_to_toml(
+                OPC_TOML, winner["weights"], baseline_config
+            )
             print(f"  Applied to {OPC_TOML}: {', '.join(changed) or '(no lines changed)'}")
         else:
             print("  (re-run with --apply to write these to opc.toml)")

--- a/scripts/core/config/models.py
+++ b/scripts/core/config/models.py
@@ -173,6 +173,12 @@ class RecallConfig:
     # Follows the DaemonConfig.extraction_model pattern (str field + default).
     # An operator can drop to a cheaper model (e.g. Haiku) to cut per-call cost.
     llm_selector_model: str = "claude-sonnet-4-6"
+    # Recall-tuning feedback loop: when True, recall_log stores the raw query
+    # text (in addition to the always-safe query_hash) so the feedback miner can
+    # materialize human-readable golden queries. DEFAULT FALSE — this reverses
+    # the deliberate "recall_log NEVER stores raw query text" privacy stance
+    # (issue #139/#140); enabling it is an explicit operator decision.
+    log_query_text: bool = False
 
 
 @dataclass(frozen=True)

--- a/scripts/core/content_hash.py
+++ b/scripts/core/content_hash.py
@@ -1,0 +1,21 @@
+"""Canonical content hashing for archival memories.
+
+A memory's ``content_hash`` is the deduplication key for ``archival_memory``
+(unique index ``idx_archival_content_hash``). The golden-set re-anchoring in the
+rerank benchmark matches results by this same hash, so the normalization MUST be
+identical everywhere it is computed. Keeping the definition in one place prevents
+the golden labels from silently drifting away from the stored hashes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+
+def content_hash(content: str) -> str:
+    """Return the canonical SHA-256 hex digest for a memory's content.
+
+    Normalization: strip leading/trailing whitespace, UTF-8 encode, SHA-256.
+    This matches the value stored in ``archival_memory.content_hash``.
+    """
+    return hashlib.sha256(content.strip().encode()).hexdigest()

--- a/scripts/core/recall_learnings.py
+++ b/scripts/core/recall_learnings.py
@@ -95,6 +95,7 @@ load_dotenv()
 project_dir = os.environ.get("CLAUDE_PROJECT_DIR", str(Path(__file__).parent.parent.parent))
 sys.path.insert(0, project_dir)
 
+from scripts.core.content_hash import content_hash  # noqa: E402
 from scripts.core.db.backend_resolution import resolve_backend  # noqa: E402
 
 # Re-export search backends for backward compatibility (tests import these directly)
@@ -480,6 +481,8 @@ async def record_recall(
     source: str | None = None,
     pool_size: int | None = None,
     fetch_k: int | None = None,
+    session_id: str | None = None,
+    query_text: str | None = None,
 ) -> None:
     """Update last_recalled/recall_count and log the recall event (issue #140).
 
@@ -517,6 +520,21 @@ async def record_recall(
 
     source = _sanitize_source(source)
 
+    # Query linkage for the recall-tuning feedback loop. query_hash is always
+    # safe to store (one-way digest, same canonical hash as memory content);
+    # raw query_text is stored ONLY when the operator opts in via
+    # recall.log_query_text, preserving the #139/#140 no-raw-text default.
+    query_hash = content_hash(query_text) if query_text else None
+    stored_query_text = None
+    if query_text:
+        try:
+            from scripts.core.config.handlers import get_config
+
+            if get_config().recall.log_query_text:
+                stored_query_text = query_text
+        except Exception:
+            logger.debug("log_query_text gate check failed; omitting query_text")
+
     try:
         from asyncpg.exceptions import UndefinedColumnError
 
@@ -528,7 +546,8 @@ async def record_recall(
             # over-restrictive scoping (#130) is visible.
             if not result_ids:
                 await _insert_recall_log(
-                    conn, caller_project, [], [], source, pool_size, fetch_k
+                    conn, caller_project, [], [], source, pool_size, fetch_k,
+                    session_id, query_hash, stored_query_text,
                 )
                 return
 
@@ -576,6 +595,9 @@ async def record_recall(
                 source,
                 pool_size,
                 fetch_k,
+                session_id,
+                query_hash,
+                stored_query_text,
             )
     except Exception:
         # Best-effort telemetry must never break recall, but failures (e.g.
@@ -591,19 +613,48 @@ async def _insert_recall_log(
     source: str | None,
     pool_size: int | None = None,
     fetch_k: int | None = None,
+    session_id: str | None = None,
+    query_hash: str | None = None,
+    query_text: str | None = None,
 ) -> None:
-    """Best-effort append one recall_log row (issue #140, #228).
+    """Best-effort append one recall_log row (issue #140, #228, feedback loop).
 
     Runs as a separate autocommitted statement after the counter UPDATE (NOT a
     CTE or transaction) so a pre-migration DB lacking ``recall_log`` fails here
     alone — the failure is swallowed (debug log) and the counter UPDATE stands.
 
-    ``pool_size``/``fetch_k`` (#228) are written via a 7-column INSERT. On a DB
-    where add_recall_log_pool_size.sql hasn't run those columns are absent, so
-    we fall back to the legacy 5-column INSERT — the #140 recall event is still
-    logged (the new telemetry is best-effort and must not regress logging).
+    Column tiers degrade gracefully so each migration is independently optional:
+    the 10-column INSERT adds the query-linkage columns (session_id, query_hash,
+    query_text — add_recall_log_query_link.sql); absent those it falls back to
+    the 7-column pool_size/fetch_k INSERT (#228), then the legacy 5-column INSERT
+    (#140). The recall event is logged at whatever tier the DB supports.
     """
     from asyncpg.exceptions import UndefinedColumnError
+
+    try:
+        await conn.execute(
+            """
+            INSERT INTO recall_log (
+                caller_project, recalled_ids, recalled_projects,
+                result_count, source, pool_size, fetch_k,
+                session_id, query_hash, query_text
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+            """,
+            caller_project,
+            recalled_ids,
+            recalled_projects,
+            len(recalled_ids),
+            source,
+            pool_size,
+            fetch_k,
+            session_id,
+            query_hash,
+            query_text,
+        )
+        return
+    except UndefinedColumnError:
+        logger.debug("recall_log query-link columns absent; pool_size insert")
 
     try:
         await conn.execute(
@@ -1449,6 +1500,8 @@ async def main() -> int:
                 source=args.source,
                 pool_size=pool_size,
                 fetch_k=fetch_k,
+                session_id=args.surfaced_session,
+                query_text=args.query,
             )
         ]
         # Persist prior UNION the ids returned this run (capped, most-recent

--- a/scripts/core/recall_learnings.py
+++ b/scripts/core/recall_learnings.py
@@ -528,7 +528,7 @@ async def record_recall(
     stored_query_text = None
     if query_text:
         try:
-            from scripts.core.config.handlers import get_config
+            from scripts.core.config import get_config
 
             if get_config().recall.log_query_text:
                 stored_query_text = query_text
@@ -623,11 +623,16 @@ async def _insert_recall_log(
     CTE or transaction) so a pre-migration DB lacking ``recall_log`` fails here
     alone — the failure is swallowed (debug log) and the counter UPDATE stands.
 
-    Column tiers degrade gracefully so each migration is independently optional:
-    the 10-column INSERT adds the query-linkage columns (session_id, query_hash,
-    query_text — add_recall_log_query_link.sql); absent those it falls back to
-    the 7-column pool_size/fetch_k INSERT (#228), then the legacy 5-column INSERT
-    (#140). The recall event is logged at whatever tier the DB supports.
+    Column tiers degrade gracefully so each migration is independently optional
+    in either order — 10 -> 8 -> 7 -> 5:
+      * 10-column: query-linkage (session_id, query_hash, query_text —
+        add_recall_log_query_link.sql) AND pool_size/fetch_k (#228) both present.
+      * 8-column: query-linkage present but pool_size/fetch_k absent (query-link
+        migration applied, pool_size migration NOT) — still records the linkage
+        the feedback miner joins on, instead of dropping it to the legacy tier.
+      * 7-column: pool_size/fetch_k present but query-linkage absent (#228 only).
+      * 5-column: legacy, neither newer migration applied (#140).
+    The recall event is logged at the richest tier the DB supports.
     """
     from asyncpg.exceptions import UndefinedColumnError
 
@@ -648,6 +653,32 @@ async def _insert_recall_log(
             source,
             pool_size,
             fetch_k,
+            session_id,
+            query_hash,
+            query_text,
+        )
+        return
+    except UndefinedColumnError:
+        logger.debug("recall_log full-column insert failed; trying query-link tier")
+
+    # 8-column tier: query-linkage columns present but pool_size/fetch_k absent
+    # (the two migrations were applied out of order). Without this tier the
+    # query-link columns would be silently dropped to the legacy 5-column INSERT
+    # below, and the feedback miner could never join on session_id/query_hash.
+    try:
+        await conn.execute(
+            """
+            INSERT INTO recall_log (
+                caller_project, recalled_ids, recalled_projects,
+                result_count, source, session_id, query_hash, query_text
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            """,
+            caller_project,
+            recalled_ids,
+            recalled_projects,
+            len(recalled_ids),
+            source,
             session_id,
             query_hash,
             query_text,
@@ -1453,7 +1484,7 @@ async def main() -> int:
             # (genuine optional-dependency / outage cases, not operator error).
             model = None
             try:
-                from scripts.core.config.handlers import get_config
+                from scripts.core.config import get_config
 
                 model = get_config().recall.llm_selector_model
             except Exception as exc:  # noqa: BLE001 - operator-visible, then fall back

--- a/scripts/core/store_learning.py
+++ b/scripts/core/store_learning.py
@@ -40,7 +40,6 @@ from __future__ import annotations
 import argparse
 import asyncio
 import faulthandler
-import hashlib
 import json
 import logging
 import os
@@ -96,6 +95,7 @@ LEARNING_TYPES = [
 CONFIDENCE_LEVELS = ["high", "medium", "low"]
 
 from scripts.core.config import get_config as _get_config  # noqa: E402
+from scripts.core.content_hash import content_hash as compute_content_hash  # noqa: E402
 from scripts.core.db.backend_resolution import (  # noqa: E402
     get_connection_url,
     resolve_backend,
@@ -760,8 +760,9 @@ async def store_learning_v2(
     try:
         memory = await create_memory_service(backend=backend, session_id=session_id)
 
-        # Compute content hash for deduplication
-        content_hash = hashlib.sha256(content.strip().encode()).hexdigest()
+        # Compute content hash for deduplication. Canonical definition lives in
+        # content_hash.py so the rerank benchmark's golden-set hashes stay in sync.
+        content_hash = compute_content_hash(content)
 
         # Generate embedding
         embed_provider = os.getenv("EMBEDDING_PROVIDER", "local")

--- a/scripts/migrations/add_recall_log_query_link.sql
+++ b/scripts/migrations/add_recall_log_query_link.sql
@@ -1,0 +1,40 @@
+-- Migration: link recall_log events to the originating query (recall-tuning
+-- feedback loop). Adds the columns needed to join a memory_feedback row
+-- (helpful/unhelpful on a recalled learning) back to the query that surfaced it,
+-- so the feedback stream can grow the golden eval set.
+--
+-- Columns:
+--   session_id  TEXT  -- sessions PK / Claude session id; the JOIN key to
+--                        memory_feedback.session_id. Always recorded when the
+--                        caller supplies it (the memory-awareness hook does).
+--   query_hash  TEXT  -- canonical SHA-256 of the query (same digest function as
+--                        archival_memory.content_hash). One-way, so it groups
+--                        identical queries WITHOUT storing prompt text. Always
+--                        safe to record.
+--   query_text  TEXT  -- raw query text. Populated ONLY when the operator sets
+--                        recall.log_query_text = true. DEFAULT is NULL, which
+--                        preserves the deliberate "recall_log NEVER stores raw
+--                        query text" privacy posture of add_recall_log.sql
+--                        (issue #139/#140). Required to materialize a
+--                        human-readable golden query from mined feedback.
+--
+-- Apply with `psql -f` (autocommit). ADD COLUMN IF NOT EXISTS is metadata-only
+-- (no table rewrite, no row locks) and idempotent. The session_id index is a
+-- plain CREATE INDEX IF NOT EXISTS; on an already-populated recall_log consider
+-- CONCURRENTLY to avoid a write lock during the build.
+--
+-- Mining join (see scripts/benchmarks/mine_feedback_labels.py):
+--   SELECT rl.query_text, rl.query_hash, mf.helpful, am.content_hash
+--   FROM memory_feedback mf
+--   JOIN recall_log rl
+--     ON rl.session_id = mf.session_id
+--    AND mf.learning_id = ANY(rl.recalled_ids)
+--    AND rl.created_at <= mf.created_at
+--    AND rl.created_at > mf.created_at - INTERVAL '1 day'
+--   JOIN archival_memory am ON am.id = mf.learning_id;
+
+ALTER TABLE recall_log ADD COLUMN IF NOT EXISTS session_id TEXT;
+ALTER TABLE recall_log ADD COLUMN IF NOT EXISTS query_hash TEXT;
+ALTER TABLE recall_log ADD COLUMN IF NOT EXISTS query_text TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_recall_log_session ON recall_log(session_id);

--- a/tests/test_recall_event_logging.py
+++ b/tests/test_recall_event_logging.py
@@ -54,11 +54,17 @@ class _CapturingConn:
         self._fetch_rows = fetch_rows if fetch_rows is not None else []
         self._fetch_error = fetch_error
         self._execute_error = execute_error
-        # Issue #228: simulate a pre-migration DB where a column is absent.
-        # When set, any execute() whose SQL mentions this column name is
-        # recorded (so the failed attempt is observable) THEN raises
-        # UndefinedColumnError, exercising the legacy-INSERT fallback.
-        self._undefined_column = undefined_column
+        # Issue #228 / feedback loop: simulate a pre-migration DB where one or
+        # more columns are absent. May be a single column name or an iterable of
+        # them. Any execute() whose SQL mentions ANY absent column is recorded
+        # (so the failed attempt is observable) THEN raises UndefinedColumnError,
+        # exercising the INSERT-tier fallback ladder (10 -> 8 -> 7 -> 5).
+        if isinstance(undefined_column, str):
+            self._undefined_columns: tuple[str, ...] = (undefined_column,)
+        elif undefined_column is None:
+            self._undefined_columns = ()
+        else:
+            self._undefined_columns = tuple(undefined_column)
 
     async def fetch(self, sql: str, *args):
         self.fetch_calls.append((sql, args))
@@ -68,12 +74,11 @@ class _CapturingConn:
 
     async def execute(self, sql: str, *args):
         self.execute_calls.append((sql, args))
-        if self._undefined_column is not None and self._undefined_column in sql:
+        missing = next((c for c in self._undefined_columns if c in sql), None)
+        if missing is not None:
             from asyncpg.exceptions import UndefinedColumnError
 
-            raise UndefinedColumnError(
-                f'column "{self._undefined_column}" does not exist'
-            )
+            raise UndefinedColumnError(f'column "{missing}" does not exist')
         if self._execute_error is not None:
             raise self._execute_error
         return "INSERT 0 1"
@@ -239,33 +244,72 @@ class TestRecordRecallLogging:
     async def test_pre_migration_columns_absent_falls_back_to_legacy_insert(
         self, monkeypatch
     ):
-        # A DB missing pool_size/fetch_k also lacks the newer query-link columns,
-        # so both the 10-col (query-link) and 7-col (pool_size) INSERTs raise
-        # UndefinedColumnError; record_recall must walk down to the legacy 5-col
-        # INSERT so the #140 recall event is STILL logged. Must not raise.
+        # A fully legacy DB lacks BOTH the query-link columns AND pool_size/
+        # fetch_k, so the 10-col, 8-col (query-link) and 7-col (pool_size) INSERTs
+        # all raise UndefinedColumnError; record_recall must walk all the way down
+        # to the legacy 5-col INSERT so the #140 recall event is STILL logged.
+        # Must not raise.
         rid = str(uuid.uuid4())
         conn = _CapturingConn(
-            fetch_rows=[_row(rid, "opc")], undefined_column="pool_size"
+            fetch_rows=[_row(rid, "opc")],
+            undefined_column=("pool_size", "session_id"),
         )
         _patch_postgres(monkeypatch)
         _patch_pool(monkeypatch, conn)
 
         await record_recall([rid], caller_project="opc", pool_size=50, fetch_k=50)
 
-        # Three tiers attempted: 10-col query-link, 7-col pool_size, 5-col legacy.
-        assert len(conn.execute_calls) == 3
-        first_sql, _first = conn.execute_calls[0]
-        second_sql, _second = conn.execute_calls[1]
-        legacy_sql, legacy_args = conn.execute_calls[2]
-        # The first two tiers mention pool_size (and failed); the query-link tier
-        # additionally mentions session_id.
-        assert "session_id" in first_sql
-        assert "pool_size" in first_sql
-        assert "pool_size" in second_sql
-        assert "session_id" not in second_sql
+        # Four tiers attempted: 10-col, 8-col query-link, 7-col pool_size, 5-col.
+        assert len(conn.execute_calls) == 4
+        tier10_sql, _a = conn.execute_calls[0]
+        tier8_sql, _b = conn.execute_calls[1]
+        tier7_sql, _c = conn.execute_calls[2]
+        legacy_sql, legacy_args = conn.execute_calls[3]
+        # 10-col has both column families; 8-col has query-link but not pool_size;
+        # 7-col has pool_size but not query-link.
+        assert "session_id" in tier10_sql and "pool_size" in tier10_sql
+        assert "session_id" in tier8_sql and "pool_size" not in tier8_sql
+        assert "pool_size" in tier7_sql and "session_id" not in tier7_sql
         # Fallback is the legacy 5-col INSERT: no pool_size, exactly 5 args.
         assert "pool_size" not in legacy_sql
         assert len(legacy_args) == 5
+
+    async def test_query_link_present_pool_size_absent_uses_8col_tier(
+        self, monkeypatch
+    ):
+        # The fix: a DB with the query-link migration but WITHOUT the pool_size
+        # migration must still record session_id/query_hash/query_text. The 10-col
+        # INSERT fails on the absent pool_size; the new 8-col query-link tier
+        # succeeds instead of degrading to the legacy 5-col INSERT (which would
+        # drop the linkage the feedback miner joins on).
+        from scripts.core.content_hash import content_hash
+
+        rid = str(uuid.uuid4())
+        conn = _CapturingConn(fetch_rows=[_row(rid, "opc")], undefined_column="pool_size")
+        _patch_postgres(monkeypatch)
+        _patch_pool(monkeypatch, conn)
+
+        await record_recall(
+            [rid],
+            caller_project="opc",
+            source="hook",
+            pool_size=50,
+            fetch_k=50,
+            session_id="sess-1",
+            query_text="do X",
+        )
+
+        # Exactly two tiers attempted: 10-col (failed on pool_size) then 8-col.
+        assert len(conn.execute_calls) == 2
+        tier10_sql, _ = conn.execute_calls[0]
+        tier8_sql, args = conn.execute_calls[1]
+        assert "pool_size" in tier10_sql  # the failed full-column tier
+        assert "session_id" in tier8_sql and "pool_size" not in tier8_sql
+        # 8-col bind order: caller_project, recalled_ids, recalled_projects,
+        # result_count, source, session_id, query_hash, query_text.
+        assert len(args) == 8
+        assert args[5] == "sess-1"  # session_id preserved (NOT dropped)
+        assert args[6] == content_hash("do X")  # query_hash always computed
 
     async def test_backward_compatible_pool_size_defaults_none(self, monkeypatch):
         # Issue #228: omitting pool_size/fetch_k binds them as NULL ("rate

--- a/tests/test_recall_event_logging.py
+++ b/tests/test_recall_event_logging.py
@@ -191,10 +191,14 @@ class TestRecordRecallLogging:
         assert args[2] == ["opc", None]  # parallel array preserves NULL element
         assert args[3] == 2
         assert args[4] == "hook"
-        # Issue #228: INSERT is now 7 columns (pool_size/fetch_k appended).
-        assert len(args) == 7
+        # Feedback loop: INSERT is now 10 columns (session_id/query_hash/
+        # query_text appended after pool_size/fetch_k).
+        assert len(args) == 10
         assert args[5] is None  # pool_size unset here -> NULL
         assert args[6] is None  # fetch_k unset here -> NULL
+        assert args[7] is None  # session_id unset here -> NULL
+        assert args[8] is None  # query_hash (no query_text passed) -> NULL
+        assert args[9] is None  # query_text (gated off / unset) -> NULL
 
     async def test_insert_binds_pool_size_and_fetch_k(self, monkeypatch):
         # Issue #228: pool_size/fetch_k are bound as $6/$7 so selection rate
@@ -235,10 +239,10 @@ class TestRecordRecallLogging:
     async def test_pre_migration_columns_absent_falls_back_to_legacy_insert(
         self, monkeypatch
     ):
-        # Issue #228: recall_log exists but add_recall_log_pool_size.sql hasn't
-        # run, so pool_size/fetch_k are absent. The 7-col INSERT raises
-        # UndefinedColumnError; record_recall must fall back to the legacy
-        # 5-col INSERT so the #140 recall event is STILL logged. Must not raise.
+        # A DB missing pool_size/fetch_k also lacks the newer query-link columns,
+        # so both the 10-col (query-link) and 7-col (pool_size) INSERTs raise
+        # UndefinedColumnError; record_recall must walk down to the legacy 5-col
+        # INSERT so the #140 recall event is STILL logged. Must not raise.
         rid = str(uuid.uuid4())
         conn = _CapturingConn(
             fetch_rows=[_row(rid, "opc")], undefined_column="pool_size"
@@ -248,14 +252,20 @@ class TestRecordRecallLogging:
 
         await record_recall([rid], caller_project="opc", pool_size=50, fetch_k=50)
 
-        assert len(conn.execute_calls) == 2
-        first_sql, _first_args = conn.execute_calls[0]
-        second_sql, second_args = conn.execute_calls[1]
-        # First attempt was the 7-col INSERT (mentions pool_size) and failed.
+        # Three tiers attempted: 10-col query-link, 7-col pool_size, 5-col legacy.
+        assert len(conn.execute_calls) == 3
+        first_sql, _first = conn.execute_calls[0]
+        second_sql, _second = conn.execute_calls[1]
+        legacy_sql, legacy_args = conn.execute_calls[2]
+        # The first two tiers mention pool_size (and failed); the query-link tier
+        # additionally mentions session_id.
+        assert "session_id" in first_sql
         assert "pool_size" in first_sql
+        assert "pool_size" in second_sql
+        assert "session_id" not in second_sql
         # Fallback is the legacy 5-col INSERT: no pool_size, exactly 5 args.
-        assert "pool_size" not in second_sql
-        assert len(second_args) == 5
+        assert "pool_size" not in legacy_sql
+        assert len(legacy_args) == 5
 
     async def test_backward_compatible_pool_size_defaults_none(self, monkeypatch):
         # Issue #228: omitting pool_size/fetch_k binds them as NULL ("rate
@@ -546,11 +556,14 @@ class TestMainWiring:
         captured: dict = {}
 
         async def fake_record(
-            ids, *, caller_project=None, source=None, pool_size=None, fetch_k=None
+            ids, *, caller_project=None, source=None, pool_size=None, fetch_k=None,
+            session_id=None, query_text=None
         ):
             captured["ids"] = ids
             captured["caller_project"] = caller_project
             captured["source"] = source
+            captured["session_id"] = session_id
+            captured["query_text"] = query_text
 
         monkeypatch.setattr(rl, "record_recall", fake_record)
 
@@ -558,6 +571,10 @@ class TestMainWiring:
         assert rc == 0
         assert captured["caller_project"] == "foo"  # canonicalized
         assert captured["source"] == "hook"
+        # Query linkage for the feedback loop: raw query is handed to
+        # record_recall, which applies the log_query_text privacy gate itself.
+        assert captured["query_text"] == "x"
+        assert captured["session_id"] is None  # no --surfaced-session in argv
 
     async def test_json_full_skips_record_recall(self, monkeypatch):
         import scripts.core.recall_learnings as rl
@@ -591,7 +608,8 @@ class TestMainWiring:
         called = {"record": False}
 
         async def fake_record(
-            ids, *, caller_project=None, source=None, pool_size=None, fetch_k=None
+            ids, *, caller_project=None, source=None, pool_size=None, fetch_k=None,
+            session_id=None, query_text=None
         ):
             called["record"] = True
 
@@ -637,7 +655,8 @@ class TestMainWiring:
             return ""
 
         async def fake_record(
-            ids, *, caller_project=None, source=None, pool_size=None, fetch_k=None
+            ids, *, caller_project=None, source=None, pool_size=None, fetch_k=None,
+            session_id=None, query_text=None
         ):
             order.append("record")
 
@@ -689,7 +708,8 @@ class TestMainWiring:
         monkeypatch.setattr("builtins.print", lambda *a, **k: printed.append(a[0] if a else ""))
 
         async def slow_record(
-            ids, *, caller_project=None, source=None, pool_size=None, fetch_k=None
+            ids, *, caller_project=None, source=None, pool_size=None, fetch_k=None,
+            session_id=None, query_text=None
         ):
             await asyncio.sleep(5)  # far longer than the injected 0.05 bound
 
@@ -753,7 +773,8 @@ class TestMainWiring:
         captured: dict = {}
 
         async def fake_record(
-            ids, *, caller_project=None, source=None, pool_size=None, fetch_k=None
+            ids, *, caller_project=None, source=None, pool_size=None, fetch_k=None,
+            session_id=None, query_text=None
         ):
             captured["ids"] = ids
             captured["pool_size"] = pool_size
@@ -804,7 +825,8 @@ class TestMainWiring:
         captured: dict = {}
 
         async def fake_record(
-            ids, *, caller_project=None, source=None, pool_size=None, fetch_k=None
+            ids, *, caller_project=None, source=None, pool_size=None, fetch_k=None,
+            session_id=None, query_text=None
         ):
             captured["pool_size"] = pool_size
             captured["fetch_k"] = fetch_k
@@ -892,7 +914,8 @@ class TestExcludeIds:
         captured: dict = {}
 
         async def fake_record(
-            ids, *, caller_project=None, source=None, pool_size=None, fetch_k=None
+            ids, *, caller_project=None, source=None, pool_size=None, fetch_k=None,
+            session_id=None, query_text=None
         ):
             captured["ids"] = list(ids)
 
@@ -932,7 +955,8 @@ class TestExcludeIds:
         captured: dict = {}
 
         async def fake_record(
-            ids_arg, *, caller_project=None, source=None, pool_size=None, fetch_k=None
+            ids_arg, *, caller_project=None, source=None, pool_size=None, fetch_k=None,
+            session_id=None, query_text=None
         ):
             captured["pool_size"] = pool_size
             captured["ids"] = list(ids_arg)
@@ -968,7 +992,8 @@ class TestExcludeIds:
         captured: dict = {}
 
         async def fake_record(
-            ids_arg, *, caller_project=None, source=None, pool_size=None, fetch_k=None
+            ids_arg, *, caller_project=None, source=None, pool_size=None, fetch_k=None,
+            session_id=None, query_text=None
         ):
             captured["fetch_k"] = fetch_k
 
@@ -1001,7 +1026,8 @@ class TestExcludeIds:
         self._wire(monkeypatch, rl, reranker_mod, results)
 
         async def fake_record(
-            ids_arg, *, caller_project=None, source=None, pool_size=None, fetch_k=None
+            ids_arg, *, caller_project=None, source=None, pool_size=None, fetch_k=None,
+            session_id=None, query_text=None
         ):
             return None
 
@@ -1027,7 +1053,8 @@ class TestExcludeIds:
         captured: dict = {}
 
         async def fake_record(
-            ids_arg, *, caller_project=None, source=None, pool_size=None, fetch_k=None
+            ids_arg, *, caller_project=None, source=None, pool_size=None, fetch_k=None,
+            session_id=None, query_text=None
         ):
             captured["ids"] = list(ids_arg)
             captured["pool_size"] = pool_size
@@ -1054,7 +1081,8 @@ class TestExcludeIds:
         self._wire(monkeypatch, rl, reranker_mod, results)
 
         async def fake_record(
-            ids_arg, *, caller_project=None, source=None, pool_size=None, fetch_k=None
+            ids_arg, *, caller_project=None, source=None, pool_size=None, fetch_k=None,
+            session_id=None, query_text=None
         ):
             return None
 
@@ -1089,7 +1117,8 @@ class TestExcludeIds:
         captured: dict = {}
 
         async def fake_record(
-            ids_arg, *, caller_project=None, source=None, pool_size=None, fetch_k=None
+            ids_arg, *, caller_project=None, source=None, pool_size=None, fetch_k=None,
+            session_id=None, query_text=None
         ):
             captured["ids"] = [str(i) for i in ids_arg]
 
@@ -1156,7 +1185,8 @@ class TestSurfacedSession:
             return res
 
         async def fake_record(
-            ids_arg, *, caller_project=None, source=None, pool_size=None, fetch_k=None
+            ids_arg, *, caller_project=None, source=None, pool_size=None, fetch_k=None,
+            session_id=None, query_text=None
         ):
             return None
 
@@ -1297,7 +1327,8 @@ class TestSurfacedSession:
         captured: dict = {}
 
         async def fake_record(
-            ids_arg, *, caller_project=None, source=None, pool_size=None, fetch_k=None
+            ids_arg, *, caller_project=None, source=None, pool_size=None, fetch_k=None,
+            session_id=None, query_text=None
         ):
             captured["fetch_k"] = fetch_k
 

--- a/tests/test_recall_learnings.py
+++ b/tests/test_recall_learnings.py
@@ -1003,7 +1003,9 @@ class TestLLMRerankIntegration:
                 "scripts.core.recall_learnings.record_recall", new_callable=AsyncMock
             ),
             patch(
-                "scripts.core.config.handlers.get_config",
+                # recall_learnings imports get_config from the public scripts.core.config
+                # module; patch that binding so main()'s local import resolves here.
+                "scripts.core.config.get_config",
                 side_effect=RuntimeError("config explosion"),
             ),
             patch(
@@ -1059,7 +1061,9 @@ class TestLLMRerankIntegration:
                 "scripts.core.recall_learnings.record_recall", new_callable=AsyncMock
             ),
             patch(
-                "scripts.core.config.handlers.get_config",
+                # recall_learnings imports get_config from the public scripts.core.config
+                # module; patch that binding so main()'s local import resolves here.
+                "scripts.core.config.get_config",
                 side_effect=ValueError(f"bad config: {secret_value}"),
             ),
             patch(

--- a/tests/test_recall_project_first.py
+++ b/tests/test_recall_project_first.py
@@ -550,7 +550,8 @@ class TestMainDegradesWithWarning:
         monkeypatch.setattr(rl, "get_backend", lambda: "postgres")
 
         async def noop_record(
-            _ids, *, caller_project=None, source=None, pool_size=None, fetch_k=None
+            _ids, *, caller_project=None, source=None, pool_size=None, fetch_k=None,
+            session_id=None, query_text=None
         ):
             return None
 
@@ -855,7 +856,8 @@ class TestProjectFirstThreadsCapture:
                             lambda r: _identity_async(r))
 
         async def noop_record(
-            _ids, *, caller_project=None, source=None, pool_size=None, fetch_k=None
+            _ids, *, caller_project=None, source=None, pool_size=None, fetch_k=None,
+            session_id=None, query_text=None
         ):
             return None
 

--- a/tests/test_recall_tuning_loop.py
+++ b/tests/test_recall_tuning_loop.py
@@ -7,13 +7,16 @@ results, store_learning_v2) are exercised separately against a real Postgres.
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import tempfile
+import uuid
 from pathlib import Path
 
-from scripts.benchmarks import journal, tune_loop
-from scripts.benchmarks.mine_feedback_labels import aggregate_candidates
+from scripts.benchmarks import backfill_golden_hashes, journal, tune_loop
+from scripts.benchmarks.mine_feedback_labels import JOIN_SQL, aggregate_candidates
 from scripts.benchmarks.run_rerank_benchmark import (
+    build_reranker_config,
     compute_mrr,
     compute_ndcg,
     compute_precision_at_k,
@@ -147,6 +150,79 @@ class TestMinerAggregation:
         assert len(cands) == 1 and cands[0]["query"] is None
 
 
+class TestMinerJoinDedup:
+    """The feedback↔recall join must attribute each judgment to ONE recall."""
+
+    def test_join_sql_dedupes_per_feedback_row(self):
+        # A single memory_feedback row can match many recall_log rows in the
+        # window; DISTINCT ON (mf.id) keeps only the nearest preceding recall so
+        # one judgment is not counted N times toward min_judgments (Codex/CodeRabbit).
+        assert "DISTINCT ON (mf.id)" in JOIN_SQL
+        assert "ORDER BY mf.id, rl.created_at DESC" in JOIN_SQL
+
+
+# ---------------------------------------------------------------------------
+# backfill lookup_hashes — defensive UUID parsing
+# ---------------------------------------------------------------------------
+
+
+class _FakeConn:
+    def __init__(self, captured: dict):
+        self._captured = captured
+
+    async def fetch(self, sql, ids):
+        self._captured["ids"] = ids
+        return []
+
+
+class _FakePool:
+    def __init__(self, captured: dict):
+        self._captured = captured
+
+    def acquire(self):
+        captured = self._captured
+
+        class _Acquire:
+            async def __aenter__(self):
+                return _FakeConn(captured)
+
+            async def __aexit__(self, *exc):
+                return False
+
+        return _Acquire()
+
+
+class TestLookupHashes:
+    def test_all_invalid_short_circuits_without_db(self, monkeypatch):
+        # No valid UUID -> returns {} and never touches the pool (Gemini HIGH:
+        # raw strings would otherwise crash asyncpg's uuid[] bind).
+        called = {"pool": False}
+
+        async def boom():
+            called["pool"] = True
+            raise AssertionError("get_pool must not be called")
+
+        monkeypatch.setattr(backfill_golden_hashes, "get_pool", boom)
+        assert asyncio.run(backfill_golden_hashes.lookup_hashes(["not-a-uuid", ""])) == {}
+        assert called["pool"] is False
+
+    def test_parses_valid_uuids_and_skips_invalid(self, monkeypatch):
+        captured: dict = {}
+
+        async def fake_pool():
+            return _FakePool(captured)
+
+        monkeypatch.setattr(backfill_golden_hashes, "get_pool", fake_pool)
+        good = str(uuid.uuid4())
+        asyncio.run(backfill_golden_hashes.lookup_hashes([good, "bogus"]))
+        # Only the valid id is forwarded, parsed to a uuid.UUID object.
+        assert captured["ids"] == [uuid.UUID(good)]
+        assert all(isinstance(u, uuid.UUID) for u in captured["ids"])
+
+    def test_empty_input_returns_empty(self):
+        assert asyncio.run(backfill_golden_hashes.lookup_hashes([])) == {}
+
+
 # ---------------------------------------------------------------------------
 # journal
 # ---------------------------------------------------------------------------
@@ -243,7 +319,7 @@ class TestApplyWeightsToToml:
     def test_updates_only_reranker_weight_lines(self):
         path = self._toml()
         changed = tune_loop.apply_weights_to_toml(
-            path, {"project_weight": 0.30, "recall_weight": 0.05}
+            path, {"project_weight": 0.30, "recall_weight": 0.05}, RerankerConfig()
         )
         after = path.read_text()
         assert set(changed) == {"project_weight", "recall_weight"}
@@ -255,5 +331,74 @@ class TestApplyWeightsToToml:
 
     def test_idempotent_reapply(self):
         path = self._toml()
-        tune_loop.apply_weights_to_toml(path, {"project_weight": 0.30})
-        assert tune_loop.apply_weights_to_toml(path, {"project_weight": 0.30}) == []
+        tune_loop.apply_weights_to_toml(path, {"project_weight": 0.30}, RerankerConfig())
+        assert (
+            tune_loop.apply_weights_to_toml(
+                path, {"project_weight": 0.30}, RerankerConfig()
+            )
+            == []
+        )
+
+    def test_rejects_over_budget_config_before_writing(self):
+        # CodeRabbit: --apply must never emit an unloadable opc.toml. A swept
+        # combo that (with the live kg_weight) pushes total_signal_weight past
+        # 1.0 is rejected by RerankerConfig.__post_init__ BEFORE the file write.
+        path = self._toml()
+        before = path.read_text()
+        over = {k: 0.5 for k in (
+            "project_weight", "recency_weight", "confidence_weight",
+            "recall_weight", "type_affinity_weight", "tag_overlap_weight",
+            "pattern_weight",
+        )}  # 7 * 0.5 + kg 0.05 = 3.55 > 1.0
+        try:
+            tune_loop.apply_weights_to_toml(path, over, RerankerConfig())
+            raise AssertionError("expected ValueError for over-budget config")
+        except ValueError:
+            pass
+        # File is untouched on rejection.
+        assert path.read_text() == before
+
+    def test_preserves_crlf_line_endings(self):
+        # C4: a CRLF opc.toml must stay CRLF after a weight rewrite, not gain
+        # mixed endings.
+        text = "[reranker]\r\nproject_weight = 0.09\r\nrecall_weight = 0.02\r\n"
+        path = Path(tempfile.mkdtemp()) / "crlf.toml"
+        path.write_bytes(text.encode())
+        tune_loop.apply_weights_to_toml(
+            path, {"project_weight": 0.30}, RerankerConfig()
+        )
+        raw = path.read_bytes()
+        assert b"project_weight = 0.3\r\n" in raw
+        assert b"\r\n" in raw and b"\n\n" not in raw  # no LF-only line introduced
+
+
+# ---------------------------------------------------------------------------
+# build_reranker_config — perturb from the live incumbent, not defaults
+# ---------------------------------------------------------------------------
+
+
+class TestBuildRerankerConfig:
+    def test_inherits_non_swept_fields_from_base(self):
+        # A base with operator-tuned non-swept fields: the swept candidate must
+        # keep them, overriding ONLY the seven swept weights (Codex P2).
+        base = RerankerConfig(kg_weight=0.0, recency_half_life_days=90.0)
+        wc = {
+            "name": "heavy-project",
+            "project_weight": 0.30, "recency_weight": 0.05,
+            "confidence_weight": 0.05, "recall_weight": 0.05,
+            "type_affinity_weight": 0.05, "tag_overlap_weight": 0.05,
+            "pattern_weight": 0.05,
+        }
+        cfg = build_reranker_config(wc, base)
+        # Non-swept fields inherited from base, NOT reset to dataclass defaults.
+        assert cfg.kg_weight == 0.0
+        assert cfg.recency_half_life_days == 90.0
+        # Swept weights overridden.
+        assert cfg.project_weight == 0.30
+        assert cfg.recall_weight == 0.05
+
+    def test_partial_weight_dict_inherits_rest(self):
+        base = RerankerConfig()
+        cfg = build_reranker_config({"project_weight": 0.30}, base)
+        assert cfg.project_weight == 0.30
+        assert cfg.recall_weight == base.recall_weight  # untouched -> inherited

--- a/tests/test_recall_tuning_loop.py
+++ b/tests/test_recall_tuning_loop.py
@@ -1,0 +1,259 @@
+"""Unit tests for the recall-tuning loop: re-anchoring, miner, journal, decisions.
+
+Covers the parts that need no live DB — the pure logic that the autoresearch-style
+loop rests on. DB-backed paths (backfill lookup, the feedback join, fetch_full_
+results, store_learning_v2) are exercised separately against a real Postgres.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import tempfile
+from pathlib import Path
+
+from scripts.benchmarks import journal, tune_loop
+from scripts.benchmarks.mine_feedback_labels import aggregate_candidates
+from scripts.benchmarks.run_rerank_benchmark import (
+    compute_mrr,
+    compute_ndcg,
+    compute_precision_at_k,
+    filter_by_split,
+    is_relevant,
+)
+from scripts.core.config.models import RerankerConfig
+from scripts.core.content_hash import content_hash
+
+# ---------------------------------------------------------------------------
+# content_hash — must match the canonical stored hash
+# ---------------------------------------------------------------------------
+
+
+class TestContentHash:
+    def test_matches_legacy_inline_definition(self):
+        for s in ["hello", "  pad  \n", "multi\nline", "", "café ☕"]:
+            assert content_hash(s) == hashlib.sha256(s.strip().encode()).hexdigest()
+
+    def test_normalizes_surrounding_whitespace(self):
+        assert content_hash("  x  ") == content_hash("x")
+
+
+# ---------------------------------------------------------------------------
+# is_relevant / metrics — content-hash re-anchor + hard negatives
+# ---------------------------------------------------------------------------
+
+
+class TestReAnchoredRelevance:
+    def test_hash_match_is_instance_independent(self):
+        h = content_hash("relevant body")
+        # id differs (fresh DB) but content matches -> relevant
+        assert is_relevant("NEW_UUID", "relevant body", [], [], golden_hashes=[h])
+        assert not is_relevant("NEW_UUID", "other", [], [], golden_hashes=[h])
+
+    def test_hash_precedence_over_legacy_ids(self):
+        h = content_hash("body")
+        # content does not match the hash; legacy id would say relevant, hash wins
+        assert not is_relevant("id1", "other", ["id1"], [], golden_hashes=[h])
+
+    def test_hard_negative_overrides_positive(self):
+        hn = content_hash("bad")
+        assert not is_relevant("id1", "bad", ["id1"], [], golden_negatives=[hn])
+
+    def test_legacy_id_and_keyword_paths_still_work(self):
+        assert is_relevant("id1", "x", ["id1"], [])
+        assert is_relevant("z", "has HOOK", [], ["hook"])
+        assert not is_relevant("z", "nope", [], ["hook"])
+
+    def test_metrics_use_hashes(self):
+        h = content_hash("relevant body")
+        ids = ["a", "b", "c"]
+        conts = ["relevant body", "x", "y"]
+        assert compute_precision_at_k(ids, conts, [], [], golden_hashes=[h]) == 1 / 3
+        assert compute_mrr(ids, conts, [], [], golden_hashes=[h]) == 1.0
+        assert round(compute_ndcg(ids, conts, [], [], 3, golden_hashes=[h]), 4) == 1.0
+
+    def test_ndcg_idcg_uses_full_hash_count(self):
+        # Two golden positives but only one retrieved at rank 1: NDCG < 1.
+        h1, h2 = content_hash("one"), content_hash("two")
+        ndcg = compute_ndcg(["a"], ["one"], [], [], 5, golden_hashes=[h1, h2])
+        assert 0.0 < ndcg < 1.0
+
+
+# ---------------------------------------------------------------------------
+# held-out split filtering
+# ---------------------------------------------------------------------------
+
+
+class TestSplitFilter:
+    queries = [
+        {"id": "a", "split": "train"},
+        {"id": "b", "split": "holdout"},
+        {"id": "c", "split": "train"},
+    ]
+
+    def test_all_returns_everything(self):
+        assert len(filter_by_split(self.queries, "all")) == 3
+
+    def test_train_and_holdout(self):
+        assert [q["id"] for q in filter_by_split(self.queries, "train")] == ["a", "c"]
+        assert [q["id"] for q in filter_by_split(self.queries, "holdout")] == ["b"]
+
+    def test_unlabeled_file_is_noop(self):
+        unlabeled = [{"id": "x"}, {"id": "y"}]
+        assert filter_by_split(unlabeled, "holdout") == unlabeled
+
+
+# ---------------------------------------------------------------------------
+# feedback label miner aggregation
+# ---------------------------------------------------------------------------
+
+
+class TestMinerAggregation:
+    def _rows(self):
+        return [
+            {"query_hash": "A", "query_text": "do X", "helpful": True, "content_hash": "hX"},
+            {"query_hash": "A", "query_text": "do X", "helpful": True, "content_hash": "hX"},
+            {"query_hash": "A", "query_text": None, "helpful": True, "content_hash": "hX"},
+            {"query_hash": "A", "query_text": "do X", "helpful": False, "content_hash": "hY"},
+            {"query_hash": "A", "query_text": "do X", "helpful": False, "content_hash": "hY"},
+        ]
+
+    def test_majority_vote_positive_and_negative(self):
+        cands = aggregate_candidates(self._rows(), min_judgments=3)
+        assert len(cands) == 1
+        c = cands[0]
+        assert c["query"] == "do X"  # first non-null query text recovered
+        assert c["golden_hashes"] == ["hX"]
+        assert c["golden_negatives"] == ["hY"]
+        assert c["num_judgments"] == 5
+
+    def test_below_threshold_dropped(self):
+        rows = [{"query_hash": "B", "query_text": "q", "helpful": True, "content_hash": "h"}]
+        assert aggregate_candidates(rows, min_judgments=3) == []
+
+    def test_tie_is_dropped(self):
+        rows = [
+            {"query_hash": "C", "query_text": "q", "helpful": True, "content_hash": "h"},
+            {"query_hash": "C", "query_text": "q", "helpful": False, "content_hash": "h"},
+        ]
+        assert aggregate_candidates(rows, min_judgments=2) == []
+
+    def test_hash_only_candidate_has_null_query(self):
+        rows = [
+            {"query_hash": "D", "query_text": None, "helpful": True, "content_hash": "h1"},
+            {"query_hash": "D", "query_text": None, "helpful": True, "content_hash": "h1"},
+            {"query_hash": "D", "query_text": None, "helpful": True, "content_hash": "h1"},
+        ]
+        cands = aggregate_candidates(rows, min_judgments=3)
+        assert len(cands) == 1 and cands[0]["query"] is None
+
+
+# ---------------------------------------------------------------------------
+# journal
+# ---------------------------------------------------------------------------
+
+
+class TestJournal:
+    def test_config_hash_stable_and_sensitive(self):
+        assert journal.config_hash(RerankerConfig()) == journal.config_hash(RerankerConfig())
+        assert journal.config_hash(RerankerConfig()) != journal.config_hash(
+            RerankerConfig(project_weight=0.30)
+        )
+        assert len(journal.config_hash(RerankerConfig())) == 12
+
+    def test_append_and_read_round_trip(self):
+        path = Path(tempfile.mkdtemp()) / "j.tsv"
+        journal.append_entry(
+            timestamp="2026-06-25T00:00:00Z", cfg_hash="abc",
+            ndcg=0.5, p_at_k=0.4, mrr=0.6, p95_latency_ms=1.234,
+            status="keep", description="line\twith\ttabs\nand newline", path=path,
+        )
+        rows = journal.read_entries(path)
+        assert len(rows) == 1
+        assert rows[0]["config_hash"] == "abc"
+        assert rows[0]["ndcg@5"] == "0.5000"
+        assert rows[0]["status"] == "keep"
+        assert "\t" not in rows[0]["description"]
+
+    def test_invalid_status_rejected(self):
+        path = Path(tempfile.mkdtemp()) / "j.tsv"
+        try:
+            journal.append_entry(
+                timestamp="t", cfg_hash="x", ndcg=0, p_at_k=0, mrr=0,
+                p95_latency_ms=0, status="bogus", description="d", path=path,
+            )
+            raise AssertionError("expected ValueError")
+        except ValueError:
+            pass
+
+    def test_read_missing_file_is_empty(self):
+        assert journal.read_entries(Path(tempfile.mkdtemp()) / "absent.tsv") == []
+
+
+# ---------------------------------------------------------------------------
+# decision rule + opc.toml apply
+# ---------------------------------------------------------------------------
+
+
+class TestDecisionRule:
+    base = {"ndcg_at_k": 0.50, "p95_latency_ms": 1.0}
+
+    def test_keep_on_strict_improvement_within_budget(self):
+        cand = {"ndcg_at_k": 0.55, "p95_latency_ms": 1.0}
+        assert tune_loop.decide(cand, self.base, 1.25) == "keep"
+
+    def test_equal_ndcg_is_not_a_win(self):
+        cand = {"ndcg_at_k": 0.50, "p95_latency_ms": 1.0}
+        assert tune_loop.decide(cand, self.base, 1.25) == "discard"
+
+    def test_over_latency_budget_discards(self):
+        cand = {"ndcg_at_k": 0.99, "p95_latency_ms": 9.0}
+        assert tune_loop.decide(cand, self.base, 1.25) == "discard"
+
+    def test_latency_budget_default_and_override(self):
+        assert tune_loop.latency_budget(4.0, None) == 5.0  # 25% over
+        assert tune_loop.latency_budget(0.1, None) == 1.1  # min +1ms floor
+        assert tune_loop.latency_budget(4.0, 2.0) == 2.0  # explicit override
+
+    def test_active_signal_count(self):
+        zero = RerankerConfig(
+            project_weight=0.0, recency_weight=0.0, confidence_weight=0.0,
+            recall_weight=0.0, type_affinity_weight=0.0, tag_overlap_weight=0.0,
+            pattern_weight=0.0,
+        )
+        assert tune_loop.active_signal_count(zero) == 0
+        assert tune_loop.active_signal_count(RerankerConfig(project_weight=0.1)) >= 1
+
+
+class TestApplyWeightsToToml:
+    def _toml(self) -> Path:
+        text = (
+            "[dedup]\n"
+            "threshold = 0.85\n\n"
+            "[reranker]\n"
+            "project_weight = 0.09\n"
+            "recall_weight = 0.02\n"
+            "rrf_scale_factor = 25\n\n"
+            "[recall]\n"
+            "project_weight = 999  # must NOT be touched (different section)\n"
+        )
+        path = Path(tempfile.mkdtemp()) / "opc.toml"
+        path.write_text(text)
+        return path
+
+    def test_updates_only_reranker_weight_lines(self):
+        path = self._toml()
+        changed = tune_loop.apply_weights_to_toml(
+            path, {"project_weight": 0.30, "recall_weight": 0.05}
+        )
+        after = path.read_text()
+        assert set(changed) == {"project_weight", "recall_weight"}
+        assert "project_weight = 0.3" in after
+        assert "recall_weight = 0.05" in after
+        # other section + non-weight key untouched
+        assert "project_weight = 999" in after
+        assert "rrf_scale_factor = 25" in after
+
+    def test_idempotent_reapply(self):
+        path = self._toml()
+        tune_loop.apply_weights_to_toml(path, {"project_weight": 0.30})
+        assert tune_loop.apply_weights_to_toml(path, {"project_weight": 0.30}) == []


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces a comprehensive recall-tuning loop to automate and improve the optimization of recall performance.

Key changes include:

*   **Golden Set Re-anchoring and Hard Negatives:**
    *   Introduces `golden_hashes` and `golden_negatives` to benchmark queries, allowing relevance judgments to be based on content hashes rather than database-specific UUIDs. This makes golden sets more robust and portable across different database instances.
    *   Adds a new script (`scripts/benchmarks/backfill_golden_hashes.py`) to migrate existing `golden_ids` to `golden_hashes`.
    *   Updates the `bootstrap_golden.py` script to automatically generate `golden_hashes` when creating new golden sets.
    *   Modifies benchmark metrics (`is_relevant`, `compute_precision_at_k`, `compute_ndcg`, `compute_mrr`) to prioritize `golden_negatives` (hard negatives) and `golden_hashes` for more accurate evaluation.
    *   Centralizes content hashing logic in a new `scripts/core/content_hash.py` module to ensure consistency.

*   **Feedback-Driven Golden Label Mining:**
    *   Adds a new script (`scripts/benchmarks/mine_feedback_labels.py`) to mine user `memory_feedback` (helpful/unhelpful judgments) and aggregate them into candidate golden labels.
    *   These candidates are linked back to the original query and content using new `session_id`, `query_hash`, and `query_text` columns in the `recall_log` table.
    *   The mined candidates are output for human review and can be merged into the benchmark query file.

*   **Automated Tuning Loop with Keep/Discard Decisions:**
    *   Introduces a new script (`scripts/benchmarks/tune_loop.py`) that implements a mechanical tuning loop for reranker weights.
    *   It evaluates a sweep of reranker configurations against a held-out set of benchmark queries.
    *   A configuration is "kept" if it strictly improves holdout NDCG@5 and its p95 latency remains within a defined budget.
    *   Tie-breaking prioritizes simpler configurations (fewer active signals) and lower latency.
    *   The winning weights can be automatically applied to `opc.toml` using an `--apply` flag.

*   **Experiment Journaling and Institutional Memory:**
    *   Adds a new `scripts/benchmarks/journal.py` module to log every tuning experiment, including configuration hash, metrics, status (keep/discard/crash), and description, into an untracked TSV file (`scripts/benchmarks/results/journal.tsv`).
    *   The outcome of the tuning loop (winning configuration or no improvement) is recorded as a `WORKING_SOLUTION` or `FAILED_APPROACH` learning in OPC's memory, creating an institutional memory of tuning efforts.

*   **Privacy Controls for Query Logging:**
    *   Adds a new configuration setting `recall.log_query_text` in `opc.toml` and `scripts/core/config/models.py`.
    *   When `true`, the raw query text is stored in `recall_log` (alongside the query hash) to enable human-readable golden queries from mined feedback. This setting is `false` by default to maintain the privacy stance of not storing raw query text.
    *   A new migration script (`scripts/migrations/add_recall_log_query_link.sql`) is provided to add the necessary `session_id`, `query_hash`, and `query_text` columns to the `recall_log` table.

These changes collectively establish a robust, automated system for continuously improving and maintaining recall performance, driven by user feedback and rigorous evaluation.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for content-hash-based benchmark labels and split-aware evaluation.
  * Introduced a tuning loop with journaled keep/discard decisions and optional config updates.
  * Added tools to mine feedback-derived labels and backfill hash-based golden data.

* **Bug Fixes**
  * Improved recall logging so events can be linked back to sessions and queries more reliably.
  * Added safer handling for partial or legacy data during benchmark and logging workflows.

* **Chores**
  * Updated benchmark and query configuration files to reflect train/holdout usage and new label formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->