### PR TITLE
Add environment variable for Node version

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,7 +1,7 @@
 name: Claude Code Review
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 on:
   pull_request:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,5 +1,8 @@
 name: Claude Code Review
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true
+
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request updates the **Claude Code Review GitHub Actions workflow** to define an environment variable that forces JavaScript-based actions to run with **Node 24**.

### What changed
- Added a workflow-level environment variable:
  - `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'`

### Functional impact
- The **Claude Code Review** workflow will now run JavaScript actions using **Node 24**.
- This change applies across the workflow, ensuring a consistent Node runtime for those actions.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the GitHub Actions runtime configuration to use Node.js 24 for JavaScript-based workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->