### PR TITLE
Add FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 environment variable

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,5 +1,8 @@
 name: Claude Code
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true
+
 on:
   issue_comment:
     types: [created]


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request updates the GitHub Actions workflow for Claude Code to set the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` environment variable to `true`.

### Functional impact
- Applies the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` setting at the workflow level in `.github/workflows/claude.yml`
- Ensures the Claude Code workflow runs JavaScript-based GitHub Actions with Node 24

### Purpose
- Adds an explicit workflow configuration to force JavaScript actions in this workflow to use Node 24.
<!-- kody-pr-summary:end -->